### PR TITLE
Remove default worker, replace worker_names with worker_statuses.

### DIFF
--- a/mcp-community/README.md
+++ b/mcp-community/README.md
@@ -43,7 +43,7 @@ This repository provides an implementation of a Deephaven Community Core MCP ser
 ## Architecture
 - **Server:** Built on [FastMCP](https://github.com/jlowin/fastmcp) and [autogen-ext](https://github.com/jlowin/autogen-ext).
 - **Workers:** Each worker is a Deephaven Community Core server defined in a config file.
-- **Tools:** Exposed as MCP tools (refresh, default_worker, worker_names, table_schemas, run_script).
+- **Tools:** Exposed as MCP tools (refresh, , worker_names, table_schemas, run_script).
 - **Transport:** Selectable via CLI (`--transport sse` or `--transport stdio`).
 
 ```
@@ -88,7 +88,7 @@ uv pip install ".[dev]"
 
 ### 2. Prepare Worker Configuration
 
-The MCP server requires a JSON configuration file describing the available Deephaven Community Core workers. This file must be an object with a `workers` mapping and a `default_worker` key.
+The MCP server requires a JSON configuration file describing the available Deephaven Community Core workers. This file must be an object with a `workers` mapping. 
 
 See the section on [Worker Configuration File Specification](#worker-configuration-file-specification) below for a complete list of fields and options.
 
@@ -105,7 +105,6 @@ See the section on [Worker Configuration File Specification](#worker-configurati
       "port": 10001
     }
   },
-  "default_worker": "worker1"
 }
 ```
 
@@ -288,8 +287,7 @@ The worker configuration file is a JSON object that defines all available Deepha
       "host": "localhost",
       "port": 10001
     }
-  },
-  "default_worker": "worker1"
+  }
 }
 ```
 
@@ -299,7 +297,6 @@ The worker configuration file is a JSON object that defines all available Deepha
 | Field                | Type      | Required | Default      | Description                                                      |
 |----------------------|-----------|----------|--------------|------------------------------------------------------------------|
 | `workers`            | object    | Yes      | —            | Map of worker names to worker configuration objects               |
-| `default_worker`     | string    | Yes      | —            | Name of the default worker (must match a key in `workers`)       |
 | `host`               | string    | No       | "localhost"  | Hostname or IP address of the Deephaven server (optional; only required for direct TCP connections) |
 | `port`               | integer   | No       | 10000        | Port number for the Deephaven server (optional; only required for direct TCP connections)           |
 | `auth_type`          | string    | No       | "Anonymous"  | Authentication type (`Anonymous`, `Basic`, `Bearer`, etc.)       |
@@ -312,7 +309,6 @@ The worker configuration file is a JSON object that defines all available Deepha
 | `client_private_key` | string    | No       | null          | Path to client private key for mutual TLS                        |
 
 ### Notes
-- The `default_worker` must be the name of one of the keys in `workers`.
 - The config file must be valid JSON (no comments allowed in actual file).
 - Unknown fields are not allowed.
 - This schema may be extended in future releases; consult the documentation for updates.

--- a/mcp-community/README.md
+++ b/mcp-community/README.md
@@ -43,7 +43,7 @@ This repository provides an implementation of a Deephaven Community Core MCP ser
 ## Architecture
 - **Server:** Built on [FastMCP](https://github.com/jlowin/fastmcp) and [autogen-ext](https://github.com/jlowin/autogen-ext).
 - **Workers:** Each worker is a Deephaven Community Core server defined in a config file.
-- **Tools:** Exposed as MCP tools (refresh, , worker_names, table_schemas, run_script).
+- **Tools:** Exposed as MCP tools (refresh, worker_names, table_schemas, run_script).
 - **Transport:** Selectable via CLI (`--transport sse` or `--transport stdio`).
 
 ```

--- a/mcp-community/src/deephaven_mcp/community/_mcp.py
+++ b/mcp-community/src/deephaven_mcp/community/_mcp.py
@@ -47,7 +47,7 @@ mcp_server = FastMCP("deephaven-mcp-community")
 """
 FastMCP Server Instance for Deephaven MCP Community Tools
 
-This object is the singleton FastMCP server for the Deephaven MCP community toolset. It is responsible for registering and exposing all MCP tool functions defined in this module (such as refresh, default_worker, worker_names, table_schemas, and run_script) to the MCP runtime environment.
+This object is the singleton FastMCP server for the Deephaven MCP community toolset. It is responsible for registering and exposing all MCP tool functions defined in this module (such as refresh, worker_names, table_schemas, and run_script) to the MCP runtime environment.
 
 Key Details:
     - The server is instantiated with the name 'deephaven-mcp-community', which uniquely identifies this toolset in the MCP ecosystem.

--- a/mcp-community/src/deephaven_mcp/community/_sessions.py
+++ b/mcp-community/src/deephaven_mcp/community/_sessions.py
@@ -251,8 +251,8 @@ class SessionManager:
         try:
             session = await asyncio.to_thread(Session, **kwargs)
         except Exception as e:
-            _LOGGER.error(f"Failed to create Deephaven Session: {e}", exc_info=True)
-            raise SessionCreationError(f"Failed to create Deephaven Session: {e}") from e
+            _LOGGER.error(f"Failed to create Deephaven Session with config: {log_kwargs}: {e}", exc_info=True)
+            raise SessionCreationError(f"Failed to create Deephaven Session with config: {log_kwargs}: {e}") from e
 
         _LOGGER.info(f"Successfully created Deephaven Session: {session}")
         return session

--- a/mcp-community/src/deephaven_mcp/config.py
+++ b/mcp-community/src/deephaven_mcp/config.py
@@ -36,7 +36,7 @@ The configuration file must be a JSON object with exactly two top-level keys:
         - client_private_key (str): Path to a PEM file containing the client private key for mutual TLS.
 
       Notes:
-        - All fields are optional; if a field is omitted, a default may be used by the consuming code, or the feature may be disabled.
+        - All fields are optional; if a field is omitted, the consuming code may use an internal default value for that field, or the feature may be disabled. There is no default or fallback worker—every worker must be explicitly configured and selected by name.
         - All file paths should be absolute, or relative to the process working directory.
         - If use_tls is True and any of the optional TLS fields are provided, they must point to valid PEM files.
         - Sensitive fields (auth_token, client_private_key) are redacted from logs for security.

--- a/mcp-community/tests/test__mcp.py
+++ b/mcp-community/tests/test__mcp.py
@@ -26,23 +26,6 @@ async def test_refresh_failure(monkeypatch):
     assert result["isError"] is True
     assert "fail" in result["error"]
 
-# === default_worker ===
-@pytest.mark.asyncio
-async def test_default_worker_success(monkeypatch):
-    monkeypatch.setattr(mcp_mod, "_CONFIG_MANAGER", MagicMock())
-    mcp_mod._CONFIG_MANAGER.get_worker_name_default = AsyncMock(return_value="worker1")
-    result = await mcp_mod.default_worker()
-    assert result == {"success": True, "result": "worker1"}
-
-@pytest.mark.asyncio
-async def test_default_worker_error(monkeypatch):
-    monkeypatch.setattr(mcp_mod, "_CONFIG_MANAGER", MagicMock())
-    mcp_mod._CONFIG_MANAGER.get_worker_name_default = AsyncMock(side_effect=Exception("fail"))
-    result = await mcp_mod.default_worker()
-    assert result["success"] is False
-    assert result["isError"] is True
-    assert "fail" in result["error"]
-
 # === worker_names ===
 @pytest.mark.asyncio
 async def test_worker_names_success(monkeypatch):
@@ -78,7 +61,7 @@ async def test_table_schemas_success(monkeypatch):
             return Table()
     mcp_mod._SESSION_MANAGER.get_or_create_session = AsyncMock(return_value=DummySession())
     mcp_mod._CONFIG_MANAGER.get_worker_config = AsyncMock(return_value=MagicMock())
-    res = await mcp_mod.table_schemas("worker", ["t1"])
+    res = await mcp_mod.table_schemas(worker_name="worker", table_names=["t1"])
     assert isinstance(res, list)
     assert res[0]["success"] is True
     assert res[0]["table"] == "t1"
@@ -102,7 +85,7 @@ async def test_table_schemas_all_tables(monkeypatch):
             return Table()
     mcp_mod._SESSION_MANAGER.get_or_create_session = AsyncMock(return_value=DummySession())
     mcp_mod._CONFIG_MANAGER.get_worker_config = AsyncMock(return_value=MagicMock())
-    res = await mcp_mod.table_schemas("worker", None)
+    res = await mcp_mod.table_schemas(worker_name="worker", table_names=None)
     assert isinstance(res, list)
     assert len(res) == 2
     for i, tname in enumerate(["t1", "t2"]):
@@ -128,7 +111,7 @@ async def test_table_schemas_schema_key_error(monkeypatch):
             return Table()
     mcp_mod._SESSION_MANAGER.get_or_create_session = AsyncMock(return_value=DummySession())
     mcp_mod._CONFIG_MANAGER.get_worker_config = AsyncMock(return_value=MagicMock())
-    res = await mcp_mod.table_schemas("worker", ["t1"])
+    res = await mcp_mod.table_schemas(worker_name="worker", table_names=["t1"])
     assert isinstance(res, list)
     assert res[0]["success"] is False
     assert res[0]["isError"] is True
@@ -140,7 +123,7 @@ async def test_table_schemas_session_error(monkeypatch):
     monkeypatch.setattr(mcp_mod, "_CONFIG_MANAGER", MagicMock())
     mcp_mod._SESSION_MANAGER.get_or_create_session = AsyncMock(side_effect=Exception("fail"))
     mcp_mod._CONFIG_MANAGER.get_worker_config = AsyncMock(return_value=MagicMock())
-    res = await mcp_mod.table_schemas("worker", ["t1"])
+    res = await mcp_mod.table_schemas(worker_name="worker", table_names=["t1"])
     assert isinstance(res, list)
     assert res[0]["success"] is False
     assert res[0]["isError"] is True
@@ -156,16 +139,16 @@ async def test_run_script_success(monkeypatch):
             DummySession.called = script
     mcp_mod._SESSION_MANAGER.get_or_create_session = AsyncMock(return_value=DummySession())
     mcp_mod._CONFIG_MANAGER.get_worker_config = AsyncMock(return_value=MagicMock())
-    res = await mcp_mod.run_script("worker", script="print(1)")
+    res = await mcp_mod.run_script(worker_name="worker", script="print(1)")
     assert res["success"] is True
     assert DummySession.called == "print(1)"
 
 @pytest.mark.asyncio
 async def test_run_script_no_script(monkeypatch):
-    res = await mcp_mod.run_script("worker")
+    res = await mcp_mod.run_script(worker_name="worker")
     assert res["success"] is False
     assert res["isError"] is True
-    assert "Must provide" in res["error"]
+    assert "Must provide either script or script_path." in res["error"]
 
 @pytest.mark.asyncio
 async def test_run_script_session_error(monkeypatch):
@@ -173,7 +156,7 @@ async def test_run_script_session_error(monkeypatch):
     monkeypatch.setattr(mcp_mod, "_CONFIG_MANAGER", MagicMock())
     mcp_mod._SESSION_MANAGER.get_or_create_session = AsyncMock(side_effect=Exception("fail"))
     mcp_mod._CONFIG_MANAGER.get_worker_config = AsyncMock(return_value=MagicMock())
-    res = await mcp_mod.run_script("worker", script="print(1)")
+    res = await mcp_mod.run_script(worker_name="worker", script="print(1)")
     assert res["success"] is False
     assert res["isError"] is True
     assert "fail" in res["error"]
@@ -190,7 +173,7 @@ async def test_run_script_script_path(monkeypatch):
     with patch("aiofiles.open", new_callable=MagicMock) as aio_open:
         mock_file = aio_open.return_value.__aenter__.return_value
         mock_file.read = AsyncMock(return_value="print(123)")
-        res = await mcp_mod.run_script("worker", script_path="myscript.py")
+        res = await mcp_mod.run_script(worker_name="worker", script_path="/tmp/foo.py")
     assert res["success"] is True
     assert DummySession.called == "print(123)"
 
@@ -203,7 +186,7 @@ async def test_run_script_script_path_error(monkeypatch):
     with patch("aiofiles.open", new_callable=MagicMock) as aio_open:
         mock_file = aio_open.return_value.__aenter__.return_value
         mock_file.read = AsyncMock(side_effect=FileNotFoundError("fail"))
-        res = await mcp_mod.run_script("worker", script_path="notfound.py")
+        res = await mcp_mod.run_script(worker_name="worker", script_path="/tmp/foo.py")
     assert res["success"] is False
     assert res["isError"] is True
     assert "fail" in res["error"]

--- a/mcp-community/tests/test_config.py
+++ b/mcp-community/tests/test_config.py
@@ -24,13 +24,12 @@ VALID_CONFIG = {
             "use_tls": False,
         }
     },
-    "default_worker": "local",
+
 }
 
 
 MINIMAL_CONFIG = {
-    "workers": {"local": {}},
-    "default_worker": "local",
+    "workers": {"local": {}}
 }
 
 # --- Fixtures ---
@@ -45,39 +44,26 @@ async def cleanup_config_cache():
 # --- Validation tests ---
 def test_validate_config_unknown_top_level_key():
     from deephaven_mcp import config
-    bad_config = {"workers": {}, "default_worker": "local", "extra": 1}
+    bad_config = {"workers": {}, "extra": 1}
     with pytest.raises(ValueError, match="Unknown top-level keys in Deephaven worker config: {'extra'}"):
         config.ConfigManager.validate_config(bad_config)
 
 def test_validate_config_missing_required_worker_field(monkeypatch):
     from deephaven_mcp import config
     monkeypatch.setattr(config, '_REQUIRED_FIELDS', ['host'])
-    bad_config = {"workers": {"local": {}}, "default_worker": "local"}
+    bad_config = {"workers": {"local": {}}}
     with pytest.raises(ValueError, match=r"Missing required fields in worker config for local: \['host'\]"):
         config.ConfigManager.validate_config(bad_config)
     monkeypatch.setattr(config, '_REQUIRED_FIELDS', [])
 
 def test_validate_config_invalid_schema():
     from deephaven_mcp import config
-    # Case 1: Remove 'default_worker' from a minimal config
-    bad_config = MINIMAL_CONFIG.copy()
-    bad_config.pop("default_worker")
+    # Case: Minimal config is valid
+    valid_config = MINIMAL_CONFIG.copy()
+    assert config.ConfigManager.validate_config(valid_config) == valid_config
+    # Case: Missing workers key
+    bad_config = {}
     with pytest.raises(ValueError):
-        config.ConfigManager.validate_config(bad_config)
-    # Case 2: Construct a config missing 'default_worker' explicitly
-    bad_config2 = {
-        "workers": {
-            "local": {"host": "localhost", "port": 10000}
-        }
-        # Missing default_worker
-    }
-    with pytest.raises(ValueError):
-        config.ConfigManager.validate_config(bad_config2)
-
-def test_validate_config_missing_default_worker():
-    from deephaven_mcp import config
-    bad_config = {"workers": {}}
-    with pytest.raises(ValueError, match="Missing required top-level keys in Deephaven worker config: {'default_worker'}"):
         config.ConfigManager.validate_config(bad_config)
 
 # --- Config loading tests ---
@@ -86,8 +72,48 @@ async def test_get_config_valid():
     from deephaven_mcp import config
     await config.DEFAULT_CONFIG_MANAGER.set_config_cache(VALID_CONFIG)
     cfg = await config.DEFAULT_CONFIG_MANAGER.get_config()
-    assert cfg["default_worker"] == "local"
+    assert "workers" in cfg
     assert "local" in cfg["workers"]
+
+@pytest.mark.asyncio
+async def test_get_config_sets_cache_and_logs(monkeypatch, caplog):
+    from deephaven_mcp import config
+    import importlib
+    import json
+    from unittest import mock
+
+    # Prepare a valid config JSON string
+    valid_config = {
+        "workers": {
+            "local": {
+                "host": "localhost",
+                "port": 10000,
+                "auth_type": "token",
+                "auth_token": "tokenval",
+                "never_timeout": True,
+                "session_type": "single",
+                "use_tls": False,
+            }
+        }
+    }
+    config_json = json.dumps(valid_config)
+
+    # Patch environment variable
+    monkeypatch.setenv("DH_MCP_CONFIG_FILE", "/fake/path/config.json")
+    # Patch aiofiles.open to return our config JSON
+    aiofiles_mock = mock.Mock()
+    aiofiles_open_ctx = mock.AsyncMock()
+    aiofiles_open_ctx.__aenter__.return_value.read = mock.AsyncMock(return_value=config_json)
+    aiofiles_mock.open = mock.Mock(return_value=aiofiles_open_ctx)
+    monkeypatch.setitem(importlib.import_module('aiofiles').__dict__, 'open', aiofiles_mock.open)
+
+    # Clear cache
+    await config.DEFAULT_CONFIG_MANAGER.clear_config_cache()
+    with caplog.at_level("INFO"):
+        cfg = await config.DEFAULT_CONFIG_MANAGER.get_config()
+    assert cfg == valid_config
+    assert config.DEFAULT_CONFIG_MANAGER._cache == valid_config
+    assert any("Deephaven worker configuration loaded and validated successfully" in r for r in caplog.text.splitlines())
 
 @pytest.mark.asyncio
 async def test_get_config_missing_env(monkeypatch):
@@ -114,11 +140,11 @@ async def test_get_config_invalid_json(monkeypatch):
 @pytest.mark.asyncio
 async def test_clear_config_cache():
     from deephaven_mcp import config
-    await config.DEFAULT_CONFIG_MANAGER.set_config_cache({"workers": {"a": {}}, "default_worker": "a"})
+    await config.DEFAULT_CONFIG_MANAGER.set_config_cache({"workers": {"a": {}}})
     cfg1 = await config.DEFAULT_CONFIG_MANAGER.get_config()
     assert "a" in cfg1["workers"]
     await config.DEFAULT_CONFIG_MANAGER.clear_config_cache()
-    await config.DEFAULT_CONFIG_MANAGER.set_config_cache({"workers": {"b": {}}, "default_worker": "b"})
+    await config.DEFAULT_CONFIG_MANAGER.set_config_cache({"workers": {"b": {}}})
     cfg2 = await config.DEFAULT_CONFIG_MANAGER.get_config()
     assert "b" in cfg2["workers"]
     assert "a" not in cfg2["workers"]
@@ -139,33 +165,11 @@ async def test_get_worker_names():
     names = await config.DEFAULT_CONFIG_MANAGER.get_worker_names()
     assert "local" in names
 
-@pytest.mark.asyncio
-async def test_get_worker_name_default():
-    from deephaven_mcp import config
-    await config.DEFAULT_CONFIG_MANAGER.set_config_cache(VALID_CONFIG)
-    name = await config.DEFAULT_CONFIG_MANAGER.get_worker_name_default()
-    assert name == "local"
-
-@pytest.mark.asyncio
-async def test_resolve_worker_name():
-    from deephaven_mcp import config
-    await config.DEFAULT_CONFIG_MANAGER.set_config_cache(VALID_CONFIG)
-    name = await config.DEFAULT_CONFIG_MANAGER.resolve_worker_name("local")
-    assert name == "local"
-    name = await config.DEFAULT_CONFIG_MANAGER.resolve_worker_name(None)
-    assert name == "local"
-
-@pytest.mark.asyncio
-async def test_resolve_worker_name_no_default():
-    from deephaven_mcp import config
-    bad_config = {"workers": {"local": {}}}
-    with pytest.raises(ValueError, match="Missing required top-level keys in Deephaven worker config: {'default_worker'}"):
-        await config.DEFAULT_CONFIG_MANAGER.set_config_cache(bad_config)
 
 @pytest.mark.asyncio
 async def test_get_worker_config_no_workers_key():
     from deephaven_mcp import config
-    bad_config = {"default_worker": "local"}
+    bad_config = {}
     with pytest.raises(ValueError, match="Missing required top-level keys in Deephaven worker config: {'workers'}"):
         await config.DEFAULT_CONFIG_MANAGER.set_config_cache(bad_config)
 
@@ -180,74 +184,42 @@ async def test_get_config_missing_env(monkeypatch):
 
 def test_validate_config_workers_not_dict():
     from deephaven_mcp import config
-    bad_config = {"workers": ["not", "a", "dict"], "default_worker": "local"}
+    bad_config = {"workers": ["not", "a", "dict"]}
     with pytest.raises(ValueError, match="'workers' must be a dictionary in Deephaven worker config"):
         config.ConfigManager.validate_config(bad_config)
 
 def test_validate_config_workers_empty():
     from deephaven_mcp import config
-    bad_config = {"workers": {}, "default_worker": "local"}
+    bad_config = {"workers": {}}
     with pytest.raises(ValueError, match="No workers defined in Deephaven worker config"):
         config.ConfigManager.validate_config(bad_config)
 
 def test_validate_config_worker_config_not_dict():
     from deephaven_mcp import config
-    bad_config = {"workers": {"local": "not_a_dict"}, "default_worker": "local"}
+    bad_config = {"workers": {"local": "not_a_dict"}}
     with pytest.raises(ValueError, match="Worker config for local must be a dictionary"):
         config.ConfigManager.validate_config(bad_config)
 
 def test_validate_config_unknown_worker_field():
     from deephaven_mcp import config
-    bad_config = {"workers": {"local": {"host": "localhost", "foo": 1}}, "default_worker": "local"}
+    bad_config = {"workers": {"local": {"foo": 1}}}
     with pytest.raises(ValueError, match="Unknown field 'foo' in worker config for local"):
         config.ConfigManager.validate_config(bad_config)
 
 def test_validate_config_worker_field_wrong_type():
     from deephaven_mcp import config
-    bad_config = {"workers": {"local": {"host": 123}}, "default_worker": "local"}
+    bad_config = {"workers": {"local": {"host": 123}}}
     with pytest.raises(ValueError, match="Field 'host' in worker config for local must be of type"):
         config.ConfigManager.validate_config(bad_config)
-
-def test_validate_config_default_worker_not_in_workers():
-    from deephaven_mcp import config
-    bad_config = {"workers": {"remote": {}}, "default_worker": "local"}
-    with pytest.raises(ValueError, match="Default worker 'local' is not defined in workers"):
-        config.ConfigManager.validate_config(bad_config)
-
-@pytest.mark.asyncio
-async def test_resolve_worker_name_missing_default(monkeypatch):
-    from deephaven_mcp import config
-    # Patch get_config to return a config without default_worker
-    async def fake_get_config():
-        return {"workers": {"local": {}}}
-    monkeypatch.setattr(config.DEFAULT_CONFIG_MANAGER, "get_config", fake_get_config)
-    with pytest.raises(RuntimeError, match="No worker name specified and no default_worker in config"):
-        await config.DEFAULT_CONFIG_MANAGER.resolve_worker_name(None)
-
-@pytest.mark.asyncio
-async def test_get_config_loads_and_validates(monkeypatch):
-    from deephaven_mcp import config
-    # Set up environment variable
-    monkeypatch.setenv("DH_MCP_CONFIG_FILE", "/fake/path/config.json")
-    # Mock aiofiles.open to return valid JSON config
-    aiofiles_mock = mock.Mock()
-    aiofiles_open_ctx = mock.AsyncMock()
-    aiofiles_open_ctx.__aenter__.return_value.read = mock.AsyncMock(return_value=json.dumps(VALID_CONFIG))
-    aiofiles_mock.open = mock.Mock(return_value=aiofiles_open_ctx)
-    monkeypatch.setitem(importlib.import_module('aiofiles').__dict__, 'open', aiofiles_mock.open)
-    # Should load and validate config
-    result = await config.DEFAULT_CONFIG_MANAGER.get_config()
-    assert result["default_worker"] == VALID_CONFIG["default_worker"]
-    assert "local" in result["workers"]
 
 @pytest.mark.asyncio
 async def test_clear_config_cache():
     from deephaven_mcp import config
-    await config.DEFAULT_CONFIG_MANAGER.set_config_cache({"workers": {"a": {}}, "default_worker": "a"})
+    await config.DEFAULT_CONFIG_MANAGER.set_config_cache({"workers": {"a": {}}})
     cfg1 = await config.DEFAULT_CONFIG_MANAGER.get_config()
     assert "a" in cfg1["workers"]
     await config.DEFAULT_CONFIG_MANAGER.clear_config_cache()
-    await config.DEFAULT_CONFIG_MANAGER.set_config_cache({"workers": {"b": {}}, "default_worker": "b"})
+    await config.DEFAULT_CONFIG_MANAGER.set_config_cache({"workers": {"b": {}}})
     cfg2 = await config.DEFAULT_CONFIG_MANAGER.get_config()
     assert "b" in cfg2["workers"]
     assert "a" not in cfg2["workers"]
@@ -267,25 +239,3 @@ async def test_get_worker_names():
     await config.DEFAULT_CONFIG_MANAGER.set_config_cache(VALID_CONFIG)
     names = await config.DEFAULT_CONFIG_MANAGER.get_worker_names()
     assert "local" in names
-
-@pytest.mark.asyncio
-async def test_get_worker_name_default():
-    from deephaven_mcp import config
-    await config.DEFAULT_CONFIG_MANAGER.set_config_cache(VALID_CONFIG)
-    name = await config.DEFAULT_CONFIG_MANAGER.get_worker_name_default()
-    assert name == "local"
-
-@pytest.mark.asyncio
-async def test_resolve_worker_name():
-    from deephaven_mcp import config
-    await config.DEFAULT_CONFIG_MANAGER.set_config_cache(VALID_CONFIG)
-    name = await config.DEFAULT_CONFIG_MANAGER.resolve_worker_name("local")
-    assert name == "local"
-    name = await config.DEFAULT_CONFIG_MANAGER.resolve_worker_name(None)
-    assert name == "local"
-
-def test_validate_config_missing_default_worker():
-    from deephaven_mcp import config
-    bad_config = {"workers": {}}
-    with pytest.raises(ValueError, match="Missing required top-level keys in Deephaven worker config: {'default_worker'}"):
-        config.ConfigManager.validate_config(bad_config)

--- a/mcp-community/tests/test_sessions.py
+++ b/mcp-community/tests/test_sessions.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../s
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 from pydeephaven import Session
-from deephaven_mcp.community._sessions import SessionManager, _load_bytes
+from deephaven_mcp.community._sessions import SessionManager, _load_bytes, SessionCreationError
 
 # --- Fixtures and helpers ---
 @pytest.fixture
@@ -149,8 +149,9 @@ async def test_create_session_error(monkeypatch):
     mgr = SessionManager()
     # Patch Session to raise
     monkeypatch.setattr("deephaven_mcp.community._sessions.Session", MagicMock(side_effect=RuntimeError("fail")))
-    with pytest.raises(RuntimeError):
+    with pytest.raises(SessionCreationError) as exc_info:
         await mgr._create_session(host='localhost')
+    assert "fail" in str(exc_info.value)
 
 @pytest.mark.asyncio
 async def test_get_or_create_session_liveness_exception(monkeypatch, session_manager, caplog):

--- a/mcp-community/tests/test_sessions.py
+++ b/mcp-community/tests/test_sessions.py
@@ -158,7 +158,6 @@ async def test_get_or_create_session_liveness_exception(monkeypatch, session_man
     bad_session = MagicMock(spec=Session)
     type(bad_session).is_alive = property(lambda self: (_ for _ in ()).throw(Exception("fail")))
     session_manager._cache['foo'] = bad_session
-    monkeypatch.setattr("deephaven_mcp.config.DEFAULT_CONFIG_MANAGER.resolve_worker_name", AsyncMock(return_value="foo"))
     monkeypatch.setattr("deephaven_mcp.config.DEFAULT_CONFIG_MANAGER.get_worker_config", AsyncMock(return_value={"host": "localhost"}))
     monkeypatch.setattr("deephaven_mcp.community._sessions.Session", MagicMock())
     await session_manager.get_or_create_session("foo")
@@ -173,7 +172,6 @@ async def test_get_or_create_session_reuses_alive(monkeypatch, session_manager):
     session.host = "localhost"
     session.port = 10000
     session_manager._cache["foo"] = session
-    monkeypatch.setattr("deephaven_mcp.config.DEFAULT_CONFIG_MANAGER.resolve_worker_name", AsyncMock(return_value="foo"))
     monkeypatch.setattr("deephaven_mcp.config.DEFAULT_CONFIG_MANAGER.get_worker_config", AsyncMock(return_value={"host": "localhost"}))
     monkeypatch.setattr("deephaven_mcp.community._sessions.Session", MagicMock())
     result = await session_manager.get_or_create_session("foo")
@@ -183,7 +181,6 @@ async def test_get_or_create_session_reuses_alive(monkeypatch, session_manager):
 async def test_get_or_create_session_creates_new(monkeypatch, session_manager):
     session_manager._cache.clear()
     fake_config = {"host": "localhost"}
-    monkeypatch.setattr("deephaven_mcp.config.DEFAULT_CONFIG_MANAGER.resolve_worker_name", AsyncMock(return_value="foo"))
     monkeypatch.setattr("deephaven_mcp.config.DEFAULT_CONFIG_MANAGER.get_worker_config", AsyncMock(return_value=fake_config))
     monkeypatch.setattr(SessionManager, "_get_session_parameters", AsyncMock(return_value={"host": "localhost"}))
     monkeypatch.setattr(SessionManager, "_create_session", AsyncMock(return_value="SESSION"))
@@ -197,7 +194,6 @@ async def test_get_or_create_session_handles_dead(monkeypatch, session_manager):
     session.is_alive = False
     session_manager._cache["foo"] = session
     fake_config = {"host": "localhost"}
-    monkeypatch.setattr("deephaven_mcp.config.DEFAULT_CONFIG_MANAGER.resolve_worker_name", AsyncMock(return_value="foo"))
     monkeypatch.setattr("deephaven_mcp.config.DEFAULT_CONFIG_MANAGER.get_worker_config", AsyncMock(return_value=fake_config))
     monkeypatch.setattr(SessionManager, "_get_session_parameters", AsyncMock(return_value={"host": "localhost"}))
     monkeypatch.setattr(SessionManager, "_create_session", AsyncMock(return_value="SESSION"))


### PR DESCRIPTION
This pull request removes the concept of a "default worker" from the Deephaven MCP Community Core project and introduces related updates to the documentation, tools, and session management. Key changes include the removal of the `default_worker` field from configuration, updates to tools to require explicit worker names, and improvements to session management error handling.

### Removal of "default worker" concept:
- The `default_worker` field has been removed from the JSON configuration file and its documentation (`README.md`) to simplify configuration and enforce explicit worker selection. [[1]](diffhunk://#diff-6bcb375e2f41a04f051d8c38b983f27c070483e9f4fb7d0a2074a14d0ede1d5dL91-R91) [[2]](diffhunk://#diff-6bcb375e2f41a04f051d8c38b983f27c070483e9f4fb7d0a2074a14d0ede1d5dL108) [[3]](diffhunk://#diff-6bcb375e2f41a04f051d8c38b983f27c070483e9f4fb7d0a2074a14d0ede1d5dL291-R290) [[4]](diffhunk://#diff-6bcb375e2f41a04f051d8c38b983f27c070483e9f4fb7d0a2074a14d0ede1d5dL302) [[5]](diffhunk://#diff-6bcb375e2f41a04f051d8c38b983f27c070483e9f4fb7d0a2074a14d0ede1d5dL315)
- References to the `default_worker` tool have been removed from the codebase, and tools like `table_schemas` and `run_script` now require explicit `worker_name` arguments. [[1]](diffhunk://#diff-c930b4fafb0c2cb44663fc216473393d0f9ed469307696d6acc9c0433fe11d79L14-R16) [[2]](diffhunk://#diff-c930b4fafb0c2cb44663fc216473393d0f9ed469307696d6acc9c0433fe11d79L276-R246) [[3]](diffhunk://#diff-c930b4fafb0c2cb44663fc216473393d0f9ed469307696d6acc9c0433fe11d79L286-R256)

### Updates to tools:
- The `worker_names` tool has been replaced with a new `worker_statuses` tool, which lists all workers and their availability. This tool provides more detailed information about worker states.
- The `table_schemas` and `run_script` tools now require a `worker_name` argument, ensuring explicit worker targeting. [[1]](diffhunk://#diff-c930b4fafb0c2cb44663fc216473393d0f9ed469307696d6acc9c0433fe11d79L276-R246) [[2]](diffhunk://#diff-c930b4fafb0c2cb44663fc216473393d0f9ed469307696d6acc9c0433fe11d79L286-R256)

### Session management improvements:
- Removed fallback behavior for "default worker" in session management. The `get_or_create_session` method now requires a `worker_name` argument. [[1]](diffhunk://#diff-e0d8e46716a52c580e546fc8854c720c0bc5358d5e899a27c5ab38ff861a8dfaL336-R374) [[2]](diffhunk://#diff-e0d8e46716a52c580e546fc8854c720c0bc5358d5e899a27c5ab38ff861a8dfaL361-R420)
- Introduced a `SessionCreationError` exception to provide clearer error handling when session creation fails. [[1]](diffhunk://#diff-e0d8e46716a52c580e546fc8854c720c0bc5358d5e899a27c5ab38ff861a8dfaR40-R44) [[2]](diffhunk://#diff-e0d8e46716a52c580e546fc8854c720c0bc5358d5e899a27c5ab38ff861a8dfaL235-R256)

These changes improve clarity, enforce explicit worker selection, and enhance error handling across the project.