### PR TITLE
Add config file and update MCP tools documentation in README

### DIFF
--- a/mcp-community/README.md
+++ b/mcp-community/README.md
@@ -43,7 +43,11 @@ This repository provides an implementation of a Deephaven Community Core MCP ser
 ## Architecture
 - **Server:** Built on [FastMCP](https://github.com/jlowin/fastmcp) and [autogen-ext](https://github.com/jlowin/autogen-ext).
 - **Workers:** Each worker is a Deephaven Community Core server defined in a config file.
-- **Tools:** Exposed as MCP tools (refresh, worker_names, table_schemas, run_script).
+- **Tools:** Exposed as MCP tools:
+  - `refresh`: Reload configuration and clear all active worker sessions atomically.
+  - `worker_statuses`: List all configured workers and their availability status.
+  - `table_schemas`: Retrieve schemas for one or more tables from a worker (requires `worker_name`).
+  - `run_script`: Execute a script on a specified Deephaven worker (requires `worker_name` and a script or script path).
 - **Transport:** Selectable via CLI (`--transport sse` or `--transport stdio`).
 
 ```


### PR DESCRIPTION
This pull request updates the `README.md` file to provide a more detailed explanation of the tools exposed by the MCP system.

Key changes:

* Expanded the description of the **Tools** section under the Architecture heading in `mcp-community/README.md`. Each tool now includes a brief explanation of its functionality:
  - `refresh`: Reloads configuration and clears all active worker sessions atomically.
  - `worker_statuses`: Lists all configured workers and their availability status.
  - `table_schemas`: Retrieves schemas for one or more tables from a worker (requires `worker_name`).
  - [`run_script`](diffhunk://#diff-6bcb375e2f41a04f051d8c38b983f27c070483e9f4fb7d0a2074a14d0ede1d5dL46-R50): Executes a script on a specified Deephaven worker (requires `worker_name` and a script or script path).