### PR TITLE
feat: Add a SSE to STDIO MCP proxy using mcp-proxy

### DIFF
--- a/mcp-community/src/deephaven_mcp/_version.py
+++ b/mcp-community/src/deephaven_mcp/_version.py
@@ -5,8 +5,10 @@ __all__ = ["__version__", "__version_tuple__", "version", "version_tuple"]
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from typing import Tuple
+    from typing import Union
 
-    VERSION_TUPLE = tuple[int | str, ...]
+    VERSION_TUPLE = Tuple[Union[int, str], ...]
 else:
     VERSION_TUPLE = object
 
@@ -15,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = "0.0.0"
+__version__ = version = '0.0.0'
 __version_tuple__ = version_tuple = (0, 0, 0)

--- a/mcp-community/tests/test__mcp.py
+++ b/mcp-community/tests/test__mcp.py
@@ -264,7 +264,8 @@ async def test_table_schemas_session_error(monkeypatch):
 # === run_script ===
 
 
-def test_app_lifespan_yields_context_and_cleans_up():
+@pytest.mark.asyncio
+async def test_app_lifespan_yields_context_and_cleans_up():
     from deephaven_mcp.community._mcp import app_lifespan
 
     class DummyServer:
@@ -288,16 +289,11 @@ def test_app_lifespan_yields_context_and_cleans_up():
         patch("deephaven_mcp.community._mcp.asyncio.Lock", return_value=refresh_lock),
     ):
         server = DummyServer()
-        import asyncio
-
-        async def run():
-            async with app_lifespan(server) as context:
-                assert context["config_manager"] is config_manager
-                assert context["session_manager"] is session_manager
-                assert context["refresh_lock"] is refresh_lock
-            session_manager.clear_all_sessions.assert_awaited_once()
-
-        asyncio.run(run())
+        async with app_lifespan(server) as context:
+            assert context["config_manager"] is config_manager
+            assert context["session_manager"] is session_manager
+            assert context["refresh_lock"] is refresh_lock
+        session_manager.clear_all_sessions.assert_awaited_once()
 
 
 # Use filterwarnings to suppress ResourceWarning about unclosed sockets, which can be triggered by mocks or library internals in CI

--- a/mcp-community/uv.lock
+++ b/mcp-community/uv.lock
@@ -458,6 +458,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-aiofiles" },
 ]
 test = [
     { name = "pytest" },
@@ -484,6 +485,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "types-aiofiles", marker = "extra == 'dev'" },
 ]
 provides-extras = ["test", "dev"]
 
@@ -1919,6 +1921,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/1a/5f36851f439884bcfe8539f6a20ff7516e7b60f319bbaf69a90dc35cc2eb/typer-0.15.3.tar.gz", hash = "sha256:818873625d0569653438316567861899f7e9972f2e6e0c16dab608345ced713c", size = 101641 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/20/9d953de6f4367163d23ec823200eb3ecb0050a2609691e512c8b95827a9b/typer-0.15.3-py3-none-any.whl", hash = "sha256:c86a65ad77ca531f03de08d1b9cb67cd09ad02ddddf4b34745b5008f43b239bd", size = 45253 },
+]
+
+[[package]]
+name = "types-aiofiles"
+version = "24.1.0.20250516"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/13/41faafda1d85fc8afa744ee67a2d788b3ba63e5f1c7303e5d10c2d784d2d/types_aiofiles-24.1.0.20250516.tar.gz", hash = "sha256:7fd2a7f793bbe180b7b22cd4f59300fe61fdc9940b3bbc9899ffe32849b95188", size = 14304 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/e7/828287ba5d1107db1093a123fe8e481eb5aab55c911f1100f28d0df80d5a/types_aiofiles-24.1.0.20250516-py3-none-any.whl", hash = "sha256:ec265994629146804b656a971c46f393ce860305834b3cacb4b8b6fb7dba7e33", size = 14253 },
 ]
 
 [[package]]

--- a/mcp-docs/README.md
+++ b/mcp-docs/README.md
@@ -15,6 +15,7 @@ A Model Context Protocol (MCP) server for learning about Deephaven Data Labs doc
 - [Usage](#usage)
   - [Test Client](#test-client)
   - [MCP Inspector](#mcp-inspector)
+  - [Using mcp-proxy](#using-mcp-proxy)
 - [Configuration](#configuration)
   - [Environment Variables](#environment-variables)
 - [Architecture](#architecture)
@@ -149,6 +150,34 @@ The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) is a web-
     - Enter a prompt/question and submit. The response will be shown in the Inspector UI.
 
 > **Tip:** By running the Inspector locally, you ensure compatibility with local MCP servers and can experiment with all features interactively. The default Inspector URL is [http://localhost:6274](http://localhost:6274).
+
+### Using mcp-proxy
+
+[`mcp-proxy`](https://github.com/modelcontextprotocol/mcp-proxy) is a utility for bridging Model Context Protocol (MCP) servers that use SSE/Streamable-HTTP to clients that expect standard input/output (stdio) or HTTP endpoints, such as Claude Desktop. This is especially useful if you want to connect Claude Desktop or other tools that do not natively support SSE to your MCP server.
+
+#### When to use
+- You want to use Claude Desktop (or another tool) with this MCP server, but it does not support SSE/Streamable-HTTP directly.
+- You need to proxy between the MCP server's SSE endpoint and a local client.
+
+#### How to use
+1. **Install dependencies** (already handled if you installed from `pyproject.toml`):
+    ```sh
+    pip install mcp-proxy
+    # or, if using uv/other modern tools:
+    uv pip install mcp-proxy
+    ```
+2. **Run mcp-proxy** to connect to your running MCP server:
+    ```sh
+    mcp-proxy --server-url http://localhost:8000/sse --stdio
+    ```
+    - Replace `http://localhost:8000/sse` with your MCP server's SSE endpoint URL as needed.
+    - The `--stdio` flag tells the proxy to communicate using standard input/output, which is compatible with Claude Desktop.
+    - For more options, run `mcp-proxy --help`.
+3. **Configure Claude Desktop** to connect to the local proxy (typically via stdio or a local HTTP endpoint, depending on your setup).
+
+#### Additional notes
+- `mcp-proxy` is included as a dependency in this project, so you do not need to install it separately.
+- For advanced configuration or troubleshooting, see the [mcp-proxy documentation](https://pypi.org/project/mcp-proxy/) or run `mcp-proxy --help`.
 
 ---
 

--- a/mcp-docs/pyproject.toml
+++ b/mcp-docs/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
     "python-dotenv>=1.0.0",   # Load .env files
     "mcp[cli]>=1.6.0",  # Enable import of mcp.server.fastmcp for docs
     "aiohttp>=3.9.0",  # For stress testing /sse endpoint
+    "mcp-proxy",  # MCP proxy for using SSE/Streamable-HTTP as stdio
+
     "aiolimiter>=1.1.0",  # For global async rate limiting
     "autogen-core",  # For test client CancellationToken
     "autogen-ext"  # For test client SseServerParams, etc.

--- a/mcp-docs/uv.lock
+++ b/mcp-docs/uv.lock
@@ -333,6 +333,7 @@ dependencies = [
     { name = "autogen-ext" },
     { name = "fastapi" },
     { name = "mcp", extra = ["cli"] },
+    { name = "mcp-proxy" },
     { name = "openai" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -369,6 +370,7 @@ requires-dist = [
     { name = "httpx", extras = ["cli"], marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.6.0" },
+    { name = "mcp-proxy" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.6.0" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.4.0" },
@@ -786,6 +788,19 @@ wheels = [
 cli = [
     { name = "python-dotenv" },
     { name = "typer" },
+]
+
+[[package]]
+name = "mcp-proxy"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mcp" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/34/4e1cf8b6eb93bed8d9f3442408d6d6f266fde522fc2201c39bce49477976/mcp_proxy-0.6.0.tar.gz", hash = "sha256:e4f41dbd6c978cfe359dcbcc66cd14a4735606f9ff856e9b6888ef310038edd0", size = 20322 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/03/ab61421d76fb81ca71125d815b25950c879514c4d665a69bc43cb6242b48/mcp_proxy-0.6.0-py3-none-any.whl", hash = "sha256:befbbd1ce7700b66bf16684971b753f78a1417e2ef360dfb536413a2c6ad6b3a", size = 13637 },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request includes updates to improve type annotations, enhance documentation, and add a new dependency for proxying MCP servers. Below is a summary of the most important changes:

### Type Annotation Improvements:
* Updated `VERSION_TUPLE` type definition in `mcp-community/src/deephaven_mcp/_version.py` to use `Tuple` and `Union` from `typing` for better type clarity and compatibility.
* Changed string literals for `__version__` and `version` from double quotes to single quotes for consistency.

### Documentation Enhancements:
* Added a new section, "Using mcp-proxy," to the `README.md` file, explaining the purpose, usage scenarios, and setup instructions for the `mcp-proxy` utility.
* Updated the table of contents in `README.md` to include a link to the new "Using mcp-proxy" section.

### Dependency Management:
* Added `mcp-proxy` as a dependency in `pyproject.toml` to support bridging MCP servers with tools like Claude Desktop.