### PR TITLE
feature: improve docs queries by excluding legacy and providing specific version numbers

### DIFF
--- a/scripts/mcp_community_test_client.py
+++ b/scripts/mcp_community_test_client.py
@@ -182,6 +182,29 @@ async def main():
         except Exception as e:
             print(f"Error calling run_script: {e}")
 
+    # 6. worker_statuses
+    print("\nCalling tool: worker_statuses")
+    if "worker_statuses" in tool_map:
+        try:
+            result = await tool_map["worker_statuses"].run_json(
+                {}, cancellation_token=CancellationToken(),
+            )
+            print(f"Result for worker_statuses: {result}")
+        except Exception as e:
+            print(f"Error calling worker_statuses: {e}")
+
+    # 7. pip_packages (requires worker_name)
+    print("\nCalling tool: pip_packages (sample args)")
+    if "pip_packages" in tool_map:
+        try:
+            result = await tool_map["pip_packages"].run_json(
+                {"worker_name": "worker1"},
+                cancellation_token=CancellationToken(),
+            )
+            print(f"Result for pip_packages: {result}")
+        except Exception as e:
+            print(f"Error calling pip_packages: {e}")
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/src/deephaven_mcp/docs/_mcp.py
+++ b/src/deephaven_mcp/docs/_mcp.py
@@ -48,14 +48,12 @@ inkeep_client = OpenAIClient(
     api_key=_INKEEP_API_KEY,
     base_url="https://api.inkeep.com/v1",
     model="inkeep-context-expert",
-    system_prompt="You are a helpful assistant that answers questions about Deephaven Data Labs documentation. Answer with reference to the docs when possible.",
 )
 """
 OpenAIClient: Configured for Inkeep-powered Deephaven documentation Q&A.
 - api_key: Pulled from _INKEEP_API_KEY env var.
 - base_url: https://api.inkeep.com/v1
 - model: inkeep-context-expert
-- system_prompt: Custom prompt for documentation assistance.
 
 This client is injected into tools for agentic and programmatic use. It should not be instantiated directly by users.
 """
@@ -92,7 +90,11 @@ async def health_check(request: Request) -> JSONResponse:
 
 
 @mcp_server.tool()
-async def docs_chat(prompt: str, history: list[dict[str, str]] | None = None) -> str:
+async def docs_chat(
+    prompt: str,
+    history: list[dict[str, str]] | None = None,
+    pip_packages: list[dict] | None = None,
+) -> str:
     """
     docs_chat - Asynchronous Documentation Q&A Tool (MCP Tool)
 
@@ -108,6 +110,14 @@ async def docs_chat(prompt: str, history: list[dict[str, str]] | None = None) ->
                     {"role": "user", "content": "How do I install Deephaven?"},
                     {"role": "assistant", "content": "To install Deephaven, ..."}
                 ]
+        pip_packages (list[dict] | None, optional):
+            The list of installed pip packages on the relevant worker, as returned by pip_packages()['result'].
+            Each dict should have 'package' and 'version' keys. This provides additional context to the documentation assistant for environment-specific answers.
+            Example:
+                [
+                    {"package": "numpy", "version": "1.25.0"},
+                    {"package": "pandas", "version": "2.1.0"}
+                ]
 
     Returns:
         str: The assistant's response message answering the user's documentation question. The response is a natural language string, suitable for direct display or further agentic processing.
@@ -119,17 +129,49 @@ async def docs_chat(prompt: str, history: list[dict[str, str]] | None = None) ->
         - This tool is asynchronous and should be awaited in agentic or orchestration frameworks.
         - The tool is discoverable via MCP server tool registries and can be invoked by name ('docs_chat').
         - For best results, provide relevant chat history for multi-turn conversations.
+        - For environment-specific questions, provide pip_packages for more accurate answers.
         - Designed for integration with LLM agents, RAG pipelines, chatbots, and automation scripts.
 
     Example (agentic call):
         >>> response = await docs_chat(
         ...     prompt="How do I install Deephaven?",
-        ...     history=[{"role": "user", "content": "Hi"}]
+        ...     history=[{"role": "user", "content": "Hi"}],
+        ...     pip_packages=[{"package": "numpy", "version": "1.25.0"}]
         ... )
         >>> print(response)
         To install Deephaven, ...
     """
-    return await inkeep_client.chat(prompt, history)
+
+    system_prompts=[
+        """
+        You are a helpful assistant that answers questions about Deephaven Data Labs documentation. 
+        Never return answers about Legacy Deephaven.
+        """,
+    ]
+
+    # Extract Deephaven Core version from pip_packages if available
+    deephaven_core_version = None
+    if pip_packages:
+        for pkg in pip_packages:
+            if pkg.get("package", "").lower() == "deephaven":
+                deephaven_core_version = pkg.get("version")
+                break
+
+    if deephaven_core_version:
+        system_prompts.append(f"Answer questions about Deephaven Core version: {deephaven_core_version}.")
+
+    # Extract Deephaven Core+ version from pip_packages if available
+    deephaven_coreplus_version = None
+    if pip_packages:
+        for pkg in pip_packages:
+            if pkg.get("package", "").lower() == "deephaven_coreplus_worker":
+                deephaven_coreplus_version = pkg.get("version")
+                break
+
+    if deephaven_coreplus_version:
+        system_prompts.append(f"Answer questions about Deephaven Core+ (Enterprise) version: {deephaven_coreplus_version}.")
+
+    return await inkeep_client.chat(prompt=prompt, history=history, system_prompts=system_prompts)
 
 
 __all__ = ["mcp_server"]

--- a/tests/test_docs_mcp.py
+++ b/tests/test_docs_mcp.py
@@ -4,6 +4,11 @@ import sys
 import types
 
 import pytest
+import pytest
+import asyncio
+from starlette.requests import Request
+
+
 
 
 def test_env_var_required(monkeypatch):
@@ -37,8 +42,10 @@ class DummyOpenAIClient:
     def __init__(self, response=None, exc=None):
         self.response = response
         self.exc = exc
+        self.last_system_prompts = None
 
-    async def chat(self, prompt, history=None):
+    async def chat(self, prompt, history=None, system_prompts=None, **kwargs):
+        self.last_system_prompts = system_prompts
         if self.exc:
             raise self.exc
         return self.response
@@ -55,6 +62,86 @@ def test_docs_chat_success(monkeypatch):
     result = asyncio.run(coro)
     assert result == "Hello from docs!"
 
+
+def test_docs_chat_with_pip_packages(monkeypatch):
+    monkeypatch.setenv("INKEEP_API_KEY", "dummy-key")
+    sys.modules.pop("deephaven_mcp.docs._mcp", None)
+    import deephaven_mcp.docs._mcp as mcp_mod
+
+    dummy_client = DummyOpenAIClient(response="Pip-aware!")
+    mcp_mod.inkeep_client = dummy_client
+    pip_pkgs = [
+        {"package": "numpy", "version": "1.25.0"},
+        {"package": "pandas", "version": "2.1.0"},
+    ]
+    coro = mcp_mod.docs_chat("Which version of pandas?", None, pip_packages=pip_pkgs)
+    result = asyncio.run(coro)
+    assert result == "Pip-aware!"
+    # Should only include the base system prompt
+    assert len(dummy_client.last_system_prompts) == 1
+    assert "helpful assistant" in dummy_client.last_system_prompts[0]
+
+
+def test_docs_chat_with_deephaven_core(monkeypatch):
+    monkeypatch.setenv("INKEEP_API_KEY", "dummy-key")
+    sys.modules.pop("deephaven_mcp.docs._mcp", None)
+    import deephaven_mcp.docs._mcp as mcp_mod
+    dummy_client = DummyOpenAIClient(response="core!")
+    mcp_mod.inkeep_client = dummy_client
+    pip_pkgs = [
+        {"package": "deephaven", "version": "0.39.0"}
+    ]
+    coro = mcp_mod.docs_chat("core version?", None, pip_packages=pip_pkgs)
+    result = asyncio.run(coro)
+    assert result == "core!"
+    assert any("Core version: 0.39.0" in p for p in dummy_client.last_system_prompts)
+
+
+def test_docs_chat_with_coreplus(monkeypatch):
+    monkeypatch.setenv("INKEEP_API_KEY", "dummy-key")
+    sys.modules.pop("deephaven_mcp.docs._mcp", None)
+    import deephaven_mcp.docs._mcp as mcp_mod
+    dummy_client = DummyOpenAIClient(response="coreplus!")
+    mcp_mod.inkeep_client = dummy_client
+    pip_pkgs = [
+        {"package": "deephaven_coreplus_worker", "version": "1.2.3"}
+    ]
+    coro = mcp_mod.docs_chat("coreplus version?", None, pip_packages=pip_pkgs)
+    result = asyncio.run(coro)
+    assert result == "coreplus!"
+    assert any("Core+ (Enterprise) version: 1.2.3" in p for p in dummy_client.last_system_prompts)
+
+
+def test_docs_chat_with_both_versions(monkeypatch):
+    monkeypatch.setenv("INKEEP_API_KEY", "dummy-key")
+    sys.modules.pop("deephaven_mcp.docs._mcp", None)
+    import deephaven_mcp.docs._mcp as mcp_mod
+    dummy_client = DummyOpenAIClient(response="both!")
+    mcp_mod.inkeep_client = dummy_client
+    pip_pkgs = [
+        {"package": "deephaven", "version": "0.39.0"},
+        {"package": "deephaven_coreplus_worker", "version": "1.2.3"}
+    ]
+    coro = mcp_mod.docs_chat("both?", None, pip_packages=pip_pkgs)
+    result = asyncio.run(coro)
+    assert result == "both!"
+    prompts = dummy_client.last_system_prompts
+    assert any("Core version: 0.39.0" in p for p in prompts)
+    assert any("Core+ (Enterprise) version: 1.2.3" in p for p in prompts)
+
+
+@pytest.mark.asyncio
+async def test_health_check_direct():
+    import sys
+    import importlib
+    sys.modules.pop("deephaven_mcp.docs._mcp", None)
+    mod = importlib.import_module("deephaven_mcp.docs._mcp")
+    # Minimal ASGI scope for Request
+    scope = {"type": "http", "method": "GET", "path": "/health"}
+    req = Request(scope)
+    resp = await mod.health_check(req)
+    assert resp.status_code == 200
+    assert resp.body == b'{"status":"ok"}'
 
 def test_docs_chat_error(monkeypatch):
     from deephaven_mcp.openai import OpenAIClientError


### PR DESCRIPTION
This pull request introduces enhancements to the `deephaven_mcp` module, focusing on improving the system prompt handling for OpenAI-based chat completions, adding support for pip package context in documentation Q&A, and expanding test coverage. Key changes include the removal of the default system prompt, dynamic system prompt construction based on pip packages, and updates to the `OpenAIClient` class to support multiple system prompts.

### Enhancements to Documentation Q&A (`docs_chat`):

* Added a `pip_packages` parameter to the `docs_chat` function, allowing it to dynamically include pip package information (e.g., `numpy`, `pandas`, `deephaven`) for environment-specific answers. The system prompts are adjusted to reflect the versions of relevant packages. (`[[1]](diffhunk://#diff-8819912720f7493ef22af67ebe74595c261c742bf056d12af15f7b3dc41f6efaL95-R97)`, `[[2]](diffhunk://#diff-8819912720f7493ef22af67ebe74595c261c742bf056d12af15f7b3dc41f6efaR113-R120)`, `[[3]](diffhunk://#diff-8819912720f7493ef22af67ebe74595c261c742bf056d12af15f7b3dc41f6efaR132-R174)`)

### Refactoring of `OpenAIClient`:

* Removed the default `system_prompt` attribute from the `OpenAIClient` class, replacing it with support for multiple system prompts passed dynamically during chat requests. (`[[1]](diffhunk://#diff-5514786116f9654d73c7b71f59cd80742a521650824fee8d78cc96b46a9748d6L32-L40)`, `[[2]](diffhunk://#diff-5514786116f9654d73c7b71f59cd80742a521650824fee8d78cc96b46a9748d6L56)`, `[[3]](diffhunk://#diff-5514786116f9654d73c7b71f59cd80742a521650824fee8d78cc96b46a9748d6L66)`, `[[4]](diffhunk://#diff-5514786116f9654d73c7b71f59cd80742a521650824fee8d78cc96b46a9748d6L84)`)
* Added a `_validate_system_prompts` method to ensure all system prompts are valid strings. (`[src/deephaven_mcp/openai.pyR118-R196](diffhunk://#diff-5514786116f9654d73c7b71f59cd80742a521650824fee8d78cc96b46a9748d6R118-R196)`)
* Updated the `_build_messages`, `chat`, and `stream_chat` methods to handle multiple system prompts. (`[[1]](diffhunk://#diff-5514786116f9654d73c7b71f59cd80742a521650824fee8d78cc96b46a9748d6L176-R212)`, `[[2]](diffhunk://#diff-5514786116f9654d73c7b71f59cd80742a521650824fee8d78cc96b46a9748d6R253-R264)`, `[[3]](diffhunk://#diff-5514786116f9654d73c7b71f59cd80742a521650824fee8d78cc96b46a9748d6L243-R280)`)

### Tooling and Testing:

* Added new tools (`worker_statuses` and `pip_packages`) to the `mcp_community_test_client.py` script for testing specific functionalities. (`[scripts/mcp_community_test_client.pyR185-R207](diffhunk://#diff-188b84f2c151cd44728ee4b2b387efd1bc6e02dbaf5d0e9e127827eb08faf500R185-R207)`)
* Expanded test coverage in `tests/test_docs_mcp.py` to validate the behavior of `docs_chat` with various pip package configurations and both `deephaven` and `deephaven_coreplus_worker` versions. (`[[1]](diffhunk://#diff-208ebe904dd890b3d92d46b7548a8ef3ffea15f2f8259c7ca9c61571436c27c3R45-R48)`, `[[2]](diffhunk://#diff-208ebe904dd890b3d92d46b7548a8ef3ffea15f2f8259c7ca9c61571436c27c3R66-R145)`)
* Added tests for the `health_check` endpoint to ensure it responds correctly. (`[tests/test_docs_mcp.pyR66-R145](diffhunk://#diff-208ebe904dd890b3d92d46b7548a8ef3ffea15f2f8259c7ca9c61571436c27c3R66-R145)`)

These changes enhance the flexibility and accuracy of the `deephaven_mcp` module, particularly in its handling of context-specific documentation queries and dynamic system prompts.