### PR TITLE
feat: add streamable-http transport option

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -579,7 +579,7 @@ uv run scripts/run_deephaven_test_server.py --table-group {simple|financial|all}
 A Python script ([`../scripts/mcp_community_test_client.py`](../scripts/mcp_community_test_client.py)) is available for exercising the Community MCP tools and validating server functionality without setting up a full MCP Inspector deployment. The script connects to a running server, lists all available tools, and demonstrates calling each tool with appropriate arguments.
 
 ```sh
-uv run scripts/mcp_community_test_client.py --transport {sse|stdio} [OPTIONS]
+uv run scripts/mcp_community_test_client.py --transport {sse|stdio|streamable-http} [OPTIONS]
 ```
 
 **Key Arguments:**

--- a/src/deephaven_mcp/community/__init__.py
+++ b/src/deephaven_mcp/community/__init__.py
@@ -29,12 +29,12 @@ __all__ = ["mcp_server", "run_server"]
 _LOGGER = logging.getLogger(__name__)
 
 
-def run_server(transport: Literal["stdio", "sse"] = "stdio") -> None:
+def run_server(transport: Literal["stdio", "sse", "streamable-http"] = "stdio") -> None:
     """
     Start the MCP server with the specified transport.
 
     Args:
-        transport (str, optional): The transport type ('stdio' or 'sse'). Defaults to 'stdio'.
+        transport (str, optional): The transport type ('stdio' or 'sse' or 'streamable-http'). Defaults to 'stdio'.
     """
     # Set stream based on transport
     # stdio MCP servers log to stderr so that they don't pollute the communication channel
@@ -65,7 +65,7 @@ def main() -> None:
     Parses CLI arguments using argparse and starts the MCP server with the specified transport.
 
     Arguments:
-        -t, --transport: Transport type for the MCP server ('stdio' or 'sse'). Default: 'stdio'.
+        -t, --transport: Transport type for the MCP server ('stdio', 'sse', or 'streamable-http'). Default: 'stdio'.
     """
     import argparse
 
@@ -75,9 +75,9 @@ def main() -> None:
     parser.add_argument(
         "-t",
         "--transport",
-        choices=["stdio", "sse"],
+        choices=["stdio", "sse", "streamable-http"],
         default="stdio",
-        help="Transport type for the MCP server (stdio or sse). Default: stdio",
+        help="Transport type for the MCP server (stdio, sse, or streamable-http). Default: stdio",
     )
     args = parser.parse_args()
     _LOGGER.info(f"CLI args: {args}")

--- a/src/deephaven_mcp/docs/__init__.py
+++ b/src/deephaven_mcp/docs/__init__.py
@@ -28,12 +28,12 @@ __all__ = ["mcp_server", "run_server"]
 _LOGGER = logging.getLogger(__name__)
 
 
-def run_server(transport: Literal["stdio", "sse"] = "stdio") -> None:
+def run_server(transport: Literal["stdio", "sse", "streamable-http"] = "stdio") -> None:
     """
     Start the MCP server with the specified transport.
 
     Args:
-        transport (str, optional): The transport type ('stdio' or 'sse'). Defaults to 'stdio'.
+        transport (str, optional): The transport type ('stdio' or 'sse' or 'streamable-http'). Defaults to 'stdio'.
     """
     # Set stream based on transport
     # stdio MCP servers log to stderr so that they don't pollute the communication channel
@@ -64,7 +64,7 @@ def main() -> None:
     Parses CLI arguments using argparse and starts the MCP server with the specified transport.
 
     Arguments:
-        -t, --transport: Transport type for the MCP server ('stdio' or 'sse'). Default: 'stdio'.
+        -t, --transport: Transport type for the MCP server ('stdio', 'sse', or 'streamable-http'). Default: 'stdio'.
     """
     import argparse
 
@@ -72,9 +72,9 @@ def main() -> None:
     parser.add_argument(
         "-t",
         "--transport",
-        choices=["stdio", "sse"],
+        choices=["stdio", "sse", "streamable-http"],
         default="stdio",
-        help="Transport type for the MCP server (stdio or sse). Default: stdio",
+        help="Transport type for the MCP server (stdio, sse, or streamable-http). Default: stdio",
     )
     args = parser.parse_args()
     _LOGGER.info(f"CLI args: {args}")


### PR DESCRIPTION
This pull request introduces support for a new transport type, `streamable-http`, in the Deephaven MCP server. The changes ensure that the new transport option is integrated across the codebase and documentation.

### Core Feature Addition: `streamable-http` Transport Support
* Updated the `run_server` function in `src/deephaven_mcp/community/__init__.py` to accept `streamable-http` as a valid transport type.
* Modified the `main` function in `src/deephaven_mcp/community/__init__.py` to include `streamable-http` in the `choices` for the `--transport` CLI argument. Updated the help text accordingly. [[1]](diffhunk://#diff-bee5fb4d424e3bdaff0ef5f4f7c276112611e5e43a273083247435619a967dfeL68-R68) [[2]](diffhunk://#diff-bee5fb4d424e3bdaff0ef5f4f7c276112611e5e43a273083247435619a967dfeL78-R80)
* Applied similar changes to the `run_server` and `main` functions in `src/deephaven_mcp/docs/__init__.py` to ensure consistency for the Docs server. [[1]](diffhunk://#diff-9ce5848c732c9e780b936ed2a224f6c22905e87967541ce71b5f1a4c908e06c3L31-R36) [[2]](diffhunk://#diff-9ce5848c732c9e780b936ed2a224f6c22905e87967541ce71b5f1a4c908e06c3L67-R77)

### Documentation Update
* Updated the Developer Guide (`docs/DEVELOPER_GUIDE.md`) to reflect the addition of `streamable-http` as an option for the `--transport` argument in the `mcp_community_test_client.py` script.