### PR TITLE
fix: pip tool

### DIFF
--- a/src/deephaven_mcp/community/_mcp.py
+++ b/src/deephaven_mcp/community/_mcp.py
@@ -454,7 +454,7 @@ async def pip_packages(context: Context, worker_name: str) -> dict:
         )
 
         # Convert the Arrow table to a list of dicts
-        packages = []
+        packages: list[dict[str, str]] = []
         if arrow_table is not None:
             # Convert to pandas DataFrame for easy dict conversion
             df = arrow_table.to_pandas()
@@ -470,6 +470,7 @@ async def pip_packages(context: Context, worker_name: str) -> dict:
                     raise ValueError(
                         "Malformed package data: missing 'Package' or 'Version' key"
                     )
+                # Results should have lower case names.  The query had to use Upper case names to avoid invalid column names
                 packages.append({"package": pkg["Package"], "version": pkg["Version"]})
 
         result["success"] = True

--- a/src/deephaven_mcp/community/_mcp.py
+++ b/src/deephaven_mcp/community/_mcp.py
@@ -434,8 +434,8 @@ async def pip_packages(context: Context, worker_name: str) -> dict:
                     names.append(dist.metadata["Name"])
                     versions.append(dist.version)
                 return new_table([
-                    string_col("package", names),
-                    string_col("version", versions),
+                    string_col("Package", names),
+                    string_col("Version", versions),
                 ])
 
             _pip_packages_table = _make_pip_packages_table()
@@ -458,17 +458,19 @@ async def pip_packages(context: Context, worker_name: str) -> dict:
         if arrow_table is not None:
             # Convert to pandas DataFrame for easy dict conversion
             df = arrow_table.to_pandas()
-            packages = df.to_dict(orient="records")
-            # Validate that each package dict has the expected keys
-            for pkg in packages:
+            raw_packages = df.to_dict(orient="records")
+            # Validate and convert keys to lowercase
+            packages = []
+            for pkg in raw_packages:
                 if (
                     not isinstance(pkg, dict)
-                    or "package" not in pkg
-                    or "version" not in pkg
+                    or "Package" not in pkg
+                    or "Version" not in pkg
                 ):
                     raise ValueError(
-                        "Malformed package data: missing 'package' or 'version' key"
+                        "Malformed package data: missing 'Package' or 'Version' key"
                     )
+                packages.append({"package": pkg["Package"], "version": pkg["Version"]})
 
         result["success"] = True
         result["result"] = packages

--- a/src/deephaven_mcp/docs/_mcp.py
+++ b/src/deephaven_mcp/docs/_mcp.py
@@ -112,7 +112,7 @@ async def docs_chat(
                 ]
         pip_packages (list[dict] | None, optional):
             The list of installed pip packages on the relevant worker, as returned by pip_packages()['result'].
-            Each dict should have 'package' and 'version' keys. This provides additional context to the documentation assistant for environment-specific answers.
+            Each dict should have 'package' and 'version' keys. Providing this argument enables the documentation assistant to tailor its answers to your actual environment, resulting in more accurate and relevant responses.
             Example:
                 [
                     {"package": "numpy", "version": "1.25.0"},

--- a/tests/test_community__mcp.py
+++ b/tests/test_community__mcp.py
@@ -593,8 +593,8 @@ async def test_pip_packages_success(monkeypatch):
     # Test successful retrieval of pip packages.
     mock_df = MagicMock()
     mock_df.to_dict.return_value = [
-        {"package": "numpy", "version": "1.25.0"},
-        {"package": "pandas", "version": "2.0.1"},
+        {"Package": "numpy", "Version": "1.25.0"},
+        {"Package": "pandas", "Version": "2.0.1"},
     ]
 
     mock_arrow_table = MagicMock()


### PR DESCRIPTION
This pull request updates the handling of pip package metadata in the `deephaven_mcp` project to improve consistency and clarity. The most notable changes include standardizing key names in package dictionaries to use uppercase (`Package` and `Version`), updating validation logic accordingly, and modifying related test cases and documentation.

### Changes to pip package handling:

* [`src/deephaven_mcp/community/_mcp.py`](diffhunk://#diff-9a2050f2673136ead557592d59eafd6d855fe46204438df53705d4cd99257decL437-R438): Updated `_make_pip_packages_table` to use uppercase column names (`Package` and `Version`) for consistency. Adjusted validation logic to check for these uppercase keys and convert them to lowercase in the final output. [[1]](diffhunk://#diff-9a2050f2673136ead557592d59eafd6d855fe46204438df53705d4cd99257decL437-R438) [[2]](diffhunk://#diff-9a2050f2673136ead557592d59eafd6d855fe46204438df53705d4cd99257decL461-R473)

### Documentation updates:

* [`src/deephaven_mcp/docs/_mcp.py`](diffhunk://#diff-8819912720f7493ef22af67ebe74595c261c742bf056d12af15f7b3dc41f6efaL115-R115): Enhanced the description of the `pip_packages` parameter in the `docs_chat` function to clarify its role in providing environment-specific context for the documentation assistant.

### Test case updates:

* [`tests/test_community__mcp.py`](diffhunk://#diff-8fb7ab7933893868f37ea6ecbbda7900b4626ae39f2c3f56e86362de85ed47b2L596-R597): Updated the `test_pip_packages_success` test case to reflect the new uppercase key format (`Package` and `Version`) in mock data.…e key handling