### PR TITLE
fix: getting deephaven core version

### DIFF
--- a/src/deephaven_mcp/community/_mcp.py
+++ b/src/deephaven_mcp/community/_mcp.py
@@ -255,6 +255,9 @@ async def describe_workers(context: Context) -> dict:
                     core_version, enterprise_version = await sessions.get_dh_versions(
                         session
                     )
+                    _LOGGER.debug(
+                        f"[describe_workers] Worker '{name}' versions: core={core_version}, enterprise={enterprise_version}"
+                    )
                     if core_version is not None:
                         result_dict["deephaven_core_version"] = core_version
                     if enterprise_version is not None:

--- a/src/deephaven_mcp/community/_sessions.py
+++ b/src/deephaven_mcp/community/_sessions.py
@@ -571,13 +571,13 @@ async def get_pip_packages_table(session: Session) -> pyarrow.Table:
     return arrow_table
 
 
-async def get_dh_versions(session: Any) -> tuple[str | None, str | None]:
+async def get_dh_versions(session: Session) -> tuple[str | None, str | None]:
     """
     Retrieve the Deephaven Core and Core+ versions installed in a given Deephaven session.
     These versions are retrieved by running a script in the session that queries the installed pip packages.
 
     Args:
-        session (Any): An active Deephaven session object.
+        session (Session): An active Deephaven session object.
 
     Returns:
         Tuple[Optional[str], Optional[str]]: A tuple containing:
@@ -605,12 +605,13 @@ async def get_dh_versions(session: Any) -> tuple[str | None, str | None]:
         raw_packages = df.to_dict(orient="records")
         for pkg in raw_packages:
             pkg_name = pkg.get("Package", "").lower()
-            if pkg_name == "deephaven" and dh_core_version is None:
-                dh_core_version = pkg.get("Version")
+            version = pkg.get("Version", "")
+            if pkg_name == "deephaven-core" and dh_core_version is None:
+                dh_core_version = version
             elif (
                 pkg_name == "deephaven_coreplus_worker" and dh_coreplus_version is None
             ):
-                dh_coreplus_version = pkg.get("Version")
+                dh_coreplus_version = version
             if dh_core_version and dh_coreplus_version:
                 break
 

--- a/tests/test_community__sessions.py
+++ b/tests/test_community__sessions.py
@@ -453,7 +453,7 @@ async def test_get_dh_versions_both_versions(monkeypatch):
     session = MagicMock()
     df = MagicMock()
     df.to_dict.return_value = [
-        {"Package": "deephaven", "Version": "1.2.3"},
+        {"Package": "deephaven-core", "Version": "1.2.3"},
         {"Package": "deephaven_coreplus_worker", "Version": "4.5.6"},
     ]
     arrow_table = MagicMock()
@@ -472,7 +472,7 @@ async def test_get_dh_versions_only_core(monkeypatch):
     session = MagicMock()
     df = MagicMock()
     df.to_dict.return_value = [
-        {"Package": "deephaven", "Version": "1.2.3"},
+        {"Package": "deephaven-core", "Version": "1.2.3"},
         {"Package": "numpy", "Version": "2.0.0"},
     ]
     arrow_table = MagicMock()


### PR DESCRIPTION
This pull request includes updates to improve logging, enhance type annotations, and fix a version detection issue in the Deephaven MCP codebase. Additionally, corresponding test cases have been updated to reflect these changes.

### Logging Improvements:
* Added a debug log statement in `describe_workers` to log the core and enterprise versions of each worker. (`src/deephaven_mcp/community/_mcp.py`)

### Type Annotation Enhancements:
* Updated the `get_dh_versions` function to use the specific `Session` type instead of the generic `Any` type for the `session` parameter, improving type safety and clarity. (`src/deephaven_mcp/community/_sessions.py`)

### Bug Fixes:
* Corrected the package name used for detecting the Deephaven Core version from `"deephaven"` to `"deephaven-core"` to align with the actual package naming convention. (`src/deephaven_mcp/community/_sessions.py`)

### Test Updates:
* Updated test cases `test_get_dh_versions_both_versions` and `test_get_dh_versions_only_core` to use the corrected package name `"deephaven-core"` in mock data. (`tests/test_community__sessions.py`) [[1]](diffhunk://#diff-6915af41b300744f05d20aaa210a545a2ff779e4454f540ce9d3fb4cf2666fe1L456-R456) [[2]](diffhunk://#diff-6915af41b300744f05d20aaa210a545a2ff779e4454f540ce9d3fb4cf2666fe1L475-R475)