### PR TITLE
feat: Add programming language as an option for the docs server

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -729,6 +729,7 @@ The Deephaven MCP Docs Server exposes a single MCP-compatible tool:
     ```
   - `deephaven_core_version` (optional): The version of Deephaven Community Core installed for the relevant worker. Providing this enables the documentation assistant to tailor its answers for greater accuracy.
   - `deephaven_enterprise_version` (optional): The version of Deephaven Core+ (Enterprise) installed for the relevant worker. Providing this enables the documentation assistant to tailor its answers for greater accuracy.
+  - `programming_language` (optional): Programming language context for the user's question (e.g., "python", "groovy"). If provided, the assistant tailors its answer for this language.
 - **Returns**: String containing the assistant's response message
 - **Error Handling**: If the underlying LLM API call fails, an `OpenAIClientError` is raised with a descriptive error message. Common errors include:
     - Invalid or missing API keys
@@ -740,6 +741,7 @@ The Deephaven MCP Docs Server exposes a single MCP-compatible tool:
   - This tool is asynchronous and should be awaited when used programmatically
   - For multi-turn conversations, providing conversation history improves contextual understanding
   - Providing Deephaven version arguments for a worker will result in more accurate and context-specific answers.
+  - Providing the `programming_language` argument will tailor the assistant's answer for that language (e.g., "python", "groovy").
   - Powered by Inkeep's LLM API service for retrieving documentation-specific responses
 
 **Example (programmatic use):**
@@ -750,11 +752,12 @@ async def get_docs_answer():
     response = await docs_chat(
         prompt="How do I filter tables in Deephaven?",
         history=[
-            {"role": "user", "content": "Hello"},
-            {"role": "assistant", "content": "Hi! How can I help you with Deephaven today?"}
+            {"role": "user", "content": "How do I create a table?"},
+            {"role": "assistant", "content": "To create a table in Deephaven..."},
         ],
         deephaven_core_version="1.2.3",
-        deephaven_enterprise_version="4.5.6"
+        deephaven_enterprise_version="4.5.6",
+        programming_language="python",
     )
     return response
 ```
@@ -986,7 +989,8 @@ from deephaven_mcp.docs._mcp import docs_chat
 async def get_answer():
     response = await docs_chat(
         prompt="How do I filter tables in Deephaven?",
-        history=[{"role": "user", "content": "Hello"}]
+        history=[{"role": "user", "content": "Hello"}],
+        programming_language="python",
     )
     return response
 

--- a/src/deephaven_mcp/docs/_mcp.py
+++ b/src/deephaven_mcp/docs/_mcp.py
@@ -95,6 +95,7 @@ async def docs_chat(
     history: list[dict[str, str]] | None = None,
     deephaven_core_version: str | None = None,
     deephaven_enterprise_version: str | None = None,
+    programming_language: str | None = None,
 ) -> str:
     """
     docs_chat - Asynchronous Documentation Q&A Tool (MCP Tool)
@@ -115,6 +116,8 @@ async def docs_chat(
             The version of Deephaven Community Core installed for the relevant worker. Providing this enables the documentation assistant to tailor its answers for greater accuracy.
         deephaven_enterprise_version (str | None, optional):
             The version of Deephaven Core+ (Enterprise) installed for the relevant worker. Providing this enables the documentation assistant to tailor its answers for greater accuracy.
+        programming_language (str | None, optional):
+            The programming language context for the user's question (e.g., "python", "groovy"). If provided, the assistant will tailor its answer to this language.
 
     Returns:
         str: The assistant's response message answering the user's documentation question. The response is a natural language string, suitable for direct display or further agentic processing.
@@ -135,7 +138,8 @@ async def docs_chat(
         ...     prompt="How do I install Deephaven?",
         ...     history=[{"role": "user", "content": "Hi"}],
         ...     deephaven_core_version="1.2.3",
-        ...     deephaven_enterprise_version="4.5.6"
+        ...     deephaven_enterprise_version="4.5.6",
+        ...     programming_language="python",
         ... )
         >>> print(response)
         To install Deephaven, ...
@@ -156,6 +160,11 @@ async def docs_chat(
     if deephaven_enterprise_version:
         system_prompts.append(
             f"Worker environment: Deephaven Core+ (Enterprise) version: {deephaven_enterprise_version}"
+        )
+
+    if programming_language:
+        system_prompts.append(
+            f"Worker environment: Programming language: {programming_language}"
         )
 
     return await inkeep_client.chat(

--- a/tests/test_docs_mcp.py
+++ b/tests/test_docs_mcp.py
@@ -10,6 +10,7 @@ from starlette.requests import Request
 
 def test_all_exports():
     import deephaven_mcp.docs._mcp as mcp_mod
+
     assert hasattr(mcp_mod, "mcp_server")
     assert "mcp_server" in mcp_mod.__all__
 
@@ -58,6 +59,7 @@ def test_docs_chat_programming_language(monkeypatch):
     monkeypatch.setenv("INKEEP_API_KEY", "dummy-key")
     sys.modules.pop("deephaven_mcp.docs._mcp", None)
     import deephaven_mcp.docs._mcp as mcp_mod
+
     dummy_client = DummyOpenAIClient(response="lang!")
     mcp_mod.inkeep_client = dummy_client
     coro = mcp_mod.docs_chat("language?", None, programming_language="groovy")
@@ -74,7 +76,9 @@ def test_docs_chat_success(monkeypatch):
 
     # Patch inkeep_client with dummy
     mcp_mod.inkeep_client = DummyOpenAIClient(response="Hello from docs!")
-    coro = mcp_mod.docs_chat("hi", [{"role": "user", "content": "hi"}], programming_language=None)
+    coro = mcp_mod.docs_chat(
+        "hi", [{"role": "user", "content": "hi"}], programming_language=None
+    )
     result = asyncio.run(coro)
     assert result == "Hello from docs!"
 
@@ -86,7 +90,12 @@ def test_docs_chat_with_core_version(monkeypatch):
 
     dummy_client = DummyOpenAIClient(response="core!")
     mcp_mod.inkeep_client = dummy_client
-    coro = mcp_mod.docs_chat("core version?", None, deephaven_core_version="0.39.0", programming_language=None)
+    coro = mcp_mod.docs_chat(
+        "core version?",
+        None,
+        deephaven_core_version="0.39.0",
+        programming_language=None,
+    )
     result = asyncio.run(coro)
     assert result == "core!"
     prompts = dummy_client.last_system_prompts
@@ -102,7 +111,10 @@ def test_docs_chat_with_enterprise_version(monkeypatch):
     dummy_client = DummyOpenAIClient(response="coreplus!")
     mcp_mod.inkeep_client = dummy_client
     coro = mcp_mod.docs_chat(
-        "coreplus version?", None, deephaven_enterprise_version="1.2.3", programming_language=None
+        "coreplus version?",
+        None,
+        deephaven_enterprise_version="1.2.3",
+        programming_language=None,
     )
     result = asyncio.run(coro)
     assert result == "coreplus!"


### PR DESCRIPTION
This pull request introduces support for a new `programming_language` parameter in the Deephaven MCP documentation assistant, allowing responses to be tailored to a specific programming language. It also includes updates to the documentation, implementation, and test cases to reflect this new functionality.

### Documentation Updates:
* Updated `docs/DEVELOPER_GUIDE.md` to include the new `programming_language` parameter in the function signature, usage examples, and explanatory notes. [[1]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092R732) [[2]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092R744) [[3]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092L753-R760) [[4]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092L989-R993)

### Implementation Changes:
* Added the `programming_language` parameter to the `docs_chat` function in `src/deephaven_mcp/docs/_mcp.py`, including its handling in system prompts and the function's docstring. [[1]](diffhunk://#diff-8819912720f7493ef22af67ebe74595c261c742bf056d12af15f7b3dc41f6efaR98) [[2]](diffhunk://#diff-8819912720f7493ef22af67ebe74595c261c742bf056d12af15f7b3dc41f6efaR119-R120) [[3]](diffhunk://#diff-8819912720f7493ef22af67ebe74595c261c742bf056d12af15f7b3dc41f6efaL138-R142) [[4]](diffhunk://#diff-8819912720f7493ef22af67ebe74595c261c742bf056d12af15f7b3dc41f6efaR165-R169)

### Testing Enhancements:
* Added a new test case `test_docs_chat_programming_language` in `tests/test_docs_mcp.py` to validate the behavior of the `programming_language` parameter.
* Updated existing test cases to include the `programming_language` parameter, ensuring compatibility and correctness. [[1]](diffhunk://#diff-208ebe904dd890b3d92d46b7548a8ef3ffea15f2f8259c7ca9c61571436c27c3R11-R17) [[2]](diffhunk://#diff-208ebe904dd890b3d92d46b7548a8ef3ffea15f2f8259c7ca9c61571436c27c3R58-R81) [[3]](diffhunk://#diff-208ebe904dd890b3d92d46b7548a8ef3ffea15f2f8259c7ca9c61571436c27c3L70-R98) [[4]](diffhunk://#diff-208ebe904dd890b3d92d46b7548a8ef3ffea15f2f8259c7ca9c61571436c27c3L86-R117) [[5]](diffhunk://#diff-208ebe904dd890b3d92d46b7548a8ef3ffea15f2f8259c7ca9c61571436c27c3R138) [[6]](diffhunk://#diff-208ebe904dd890b3d92d46b7548a8ef3ffea15f2f8259c7ca9c61571436c27c3L123-R155) [[7]](diffhunk://#diff-208ebe904dd890b3d92d46b7548a8ef3ffea15f2f8259c7ca9c61571436c27c3L158-R190)