### PR TITLE
feat: remove pytest.ini

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,10 @@ addopts = "--cov=deephaven_mcp --cov-report=term-missing"  # Enable code coverag
 python_files = ["test_*.py"]  # Test file naming pattern
 python_classes = ["Test"]  # Test class naming pattern
 python_functions = ["test_"]  # Test function naming pattern
+filterwarnings = [
+    "ignore:The NumPy module was reloaded (imported a second time):UserWarning"
+]
+asyncio_default_fixture_loop_scope = "function"
 
 # Mypy configuration for type checking
 [tool.mypy]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore:The NumPy module was reloaded \(imported a second time\):UserWarning
-
-asyncio_default_fixture_loop_scope = function

--- a/tests/test_docs_mcp.py
+++ b/tests/test_docs_mcp.py
@@ -6,6 +6,8 @@ import types
 
 import pytest
 from starlette.requests import Request
+import importlib
+import sys
 
 
 def test_env_var_required(monkeypatch):
@@ -133,9 +135,6 @@ def test_docs_chat_with_neither_version(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_health_check_direct(monkeypatch):
-    import importlib
-    import sys
-
     monkeypatch.setenv("INKEEP_API_KEY", "dummy-key")
     sys.modules.pop("deephaven_mcp.docs._mcp", None)
     mod = importlib.import_module("deephaven_mcp.docs._mcp")

--- a/tests/test_docs_mcp.py
+++ b/tests/test_docs_mcp.py
@@ -6,8 +6,6 @@ import types
 
 import pytest
 from starlette.requests import Request
-import importlib
-import sys
 
 
 def test_env_var_required(monkeypatch):

--- a/tests/test_docs_mcp.py
+++ b/tests/test_docs_mcp.py
@@ -132,10 +132,11 @@ def test_docs_chat_with_neither_version(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_health_check_direct():
+async def test_health_check_direct(monkeypatch):
     import importlib
     import sys
 
+    monkeypatch.setenv("INKEEP_API_KEY", "dummy-key")
     sys.modules.pop("deephaven_mcp.docs._mcp", None)
     mod = importlib.import_module("deephaven_mcp.docs._mcp")
     # Minimal ASGI scope for Request


### PR DESCRIPTION
This pull request includes changes to streamline configuration management and enhance test reliability. The most important updates involve moving pytest configurations from `pytest.ini` to `pyproject.toml` and improving the `test_health_check_direct` test by adding environment variable mocking.

### Configuration Management Updates:
* Moved pytest configurations (`filterwarnings` and `asyncio_default_fixture_loop_scope`) from `pytest.ini` to `pyproject.toml` to consolidate settings into a single configuration file. (`pyproject.toml`: [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R124-R127) `pytest.ini`: [[2]](diffhunk://#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1L1-L5)

### Test Enhancements:
* Updated the `test_health_check_direct` test in `tests/test_docs_mcp.py` to use `monkeypatch` for setting the `INKEEP_API_KEY` environment variable, improving test isolation and reliability. (`tests/test_docs_mcp.py`: [tests/test_docs_mcp.pyL135-R139](diffhunk://#diff-208ebe904dd890b3d92d46b7548a8ef3ffea15f2f8259c7ca9c61571436c27c3L135-R139))