### PR TITLE
ci: add PyPI publishing workflow

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -36,3 +36,10 @@ jobs:
         with:
           name: wheel
           path: dist/*.whl
+
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -1,4 +1,4 @@
-name: Build Wheels
+name: Build and Publish Wheels
 
 on:
   workflow_dispatch:
@@ -10,6 +10,8 @@ on:
 jobs:
   build-wheels:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -40,6 +42,3 @@ jobs:
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/build-wheels.yml` file to include a new step for publishing Python wheels to PyPI when a tag is pushed.

Enhancements to CI/CD workflow:

* Added a new job step named "Publish to PyPI" that uses the `pypa/gh-action-pypi-publish` action to publish built wheels to PyPI. This step is conditionally executed when the GitHub reference starts with `refs/tags/`, ensuring it only runs for tagged commits. (`[.github/workflows/build-wheels.ymlR39-R45](diffhunk://#diff-14b51e9e6321caf5d23b2253f2415daf475fdaa417c0aa8fe896c3a460f2d023R39-R45)`)