### PR TITLE
ci: Fix whl publishing

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -8,37 +8,7 @@ on:
     branches: ["main"]
 
 jobs:
-  build-wheels:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Upgrade pip and install build tools
-        run: |
-          python -m pip install --upgrade pip
-          pip install build wheel
-
-      - name: Build wheel
-        run: |
-          python -m build --wheel
-
-      - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheel
-          path: dist/*.whl
-
-      - name: Publish to PyPI
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: pypa/gh-action-pypi-publish@release/v1
+  build:
+    uses: ./.github/workflows/reusable-build-wheel.yml
+    with:
+      python-version: "3.10"

--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -1,0 +1,26 @@
+name: Publish Wheels
+
+on:
+  push:
+    tags:
+      - 'v*'  # Triggers on tags like v1.0.0, v2.1.3, etc. Adjust as needed.
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-build-wheel.yml
+    with:
+      python-version: "3.10"
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wheel
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -1,0 +1,47 @@
+# This is a reusable GitHub Actions workflow for building Python wheels.
+# Usage:
+#   Call this workflow from another workflow using the 'uses:' syntax and provide the 'python-version' input.
+#   This workflow checks out the code, sets up Python, installs build tools, builds the wheel, and uploads it as an artifact named 'wheel'.
+# Example call:
+#   jobs:
+#     build:
+#       uses: ./.github/workflows/reusable-build-wheel.yml
+#       with:
+#         python-version: "3.10"
+#
+# This workflow does NOT publish to PyPI. Use a separate publish workflow for that purpose.
+
+name: Reusable Build Wheel
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: true
+        type: string
+
+jobs:
+  build-wheel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Upgrade pip and install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build wheel
+
+      - name: Build wheel
+        run: python -m build --wheel
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel
+          path: dist/*.whl

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,57 +7,57 @@ on:
     branches: [ "main" ]
 
 jobs:
-  test-mcp-community:
-    name: Test MCP Community
+  test-python:
+    name: Test Python
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-        - name: Set up Python ${{ matrix.python-version }}
-          uses: actions/setup-python@v5
-          with:
-            python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
-        - name: Cache pip dependencies
-          uses: actions/cache@v3
-          with:
-            path: ~/.cache/pip
-            key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-            restore-keys: |
-              ${{ runner.os }}-pip-
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
-        - name: Install dependencies
-          run: |
-            python -m pip install --upgrade pip
-            pip install pytest pytest-cov coverage
-            pip install .[test]
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov coverage
+          pip install .[test]
 
-        - name: Run tests with coverage
-          run: pytest -W error --cov=deephaven_mcp --cov-report=term --cov-report=xml
+      - name: Run tests with coverage
+        run: pytest -W error --cov=deephaven_mcp --cov-report=term --cov-report=xml
 
-        - name: Upload coverage report
-          uses: actions/upload-artifact@v4
-          with:
-            name: coverage-xml-${{ matrix.python-version }}
-            path: coverage.xml
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml-${{ matrix.python-version }}
+          path: coverage.xml
 
-        - name: Fail if any file has <90% coverage (except _version.py)
-          run: |
-            coverage report -m | tee coverage.txt
-            awk '
-              NR > 2 && $1 !~ /_version\.py/ && $1 ~ /\.py/ {
-                cov = $4
-                gsub("%","",cov)
-                if (cov+0 < 90) {
-                  print $1 " has coverage " cov "% which is below the required 90%."
-                  fail=1
-                }
+      - name: Fail if any file has <90% coverage (except _version.py)
+        run: |
+          coverage report -m | tee coverage.txt
+          awk '
+            NR > 2 && $1 !~ /_version\.py/ && $1 ~ /\.py/ {
+              cov = $4
+              gsub("%","",cov)
+              if (cov+0 < 90) {
+                print $1 " has coverage " cov "% which is below the required 90%."
+                fail=1
               }
-              END { exit fail }
-            ' coverage.txt
+            }
+            END { exit fail }
+          ' coverage.txt
 


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflows by introducing a reusable workflow for building Python wheels and splitting responsibilities into distinct workflows for building and publishing. Additionally, it includes minor updates to the naming conventions in the unit test workflow for clarity.

### Workflow Refactoring:

* [`.github/workflows/build-wheels.yml`](diffhunk://#diff-14b51e9e6321caf5d23b2253f2415daf475fdaa417c0aa8fe896c3a460f2d023L11-R14): Replaced the inline build process with a call to the new reusable workflow `reusable-build-wheel.yml`, simplifying the workflow definition.
* [`.github/workflows/reusable-build-wheel.yml`](diffhunk://#diff-3826dffee70012c1e07ee3d63a4cf5ba7ed82c17bbac68145432a97e71dbade7R1-R47): Added a reusable workflow for building Python wheels. This workflow handles code checkout, Python setup, dependency installation, wheel building, and artifact uploading.

### Workflow Separation:

* [`.github/workflows/publish-wheels.yml`](diffhunk://#diff-0ab4ad989c0acc68ae228e9906bb5539f391de6f0b54d06df7b98b289bbfc4f5R1-R26): Introduced a new workflow for publishing Python wheels to PyPI. This workflow triggers on version tags, uses the reusable build workflow, and handles artifact downloading and publishing.

### Naming Updates:

* [`.github/workflows/unit-tests.yml`](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3L10-R11): Renamed the job from `test-mcp-community` to `test-python` for better clarity and alignment with its purpose.