### PR TITLE
fix: add missing dist path in publish workflow

### DIFF
--- a/.github/workflows/publish-wheels.yml
+++ b/.github/workflows/publish-wheels.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wheel
+          path: dist
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/publish-wheels.yml` file. The change specifies a `path` (`dist`) for the downloaded artifact in the `actions/download-artifact` step.