### PR TITLE
chore: add python 3.13 to toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: System :: Distributed Computing"


### PR DESCRIPTION
This pull request updates the supported Python versions in the `pyproject.toml` file.

* Added support for Python 3.13 by including it in the `classifiers` list. (`pyproject.toml`, [pyproject.tomlR21](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R21))