### PR TITLE
feat: Improve configuration module

### DIFF
--- a/src/deephaven_mcp/community/_mcp.py
+++ b/src/deephaven_mcp/community/_mcp.py
@@ -218,7 +218,7 @@ async def describe_workers(context: Context) -> dict:
     try:
         config_manager = context.request_context.lifespan_context["config_manager"]
         session_manager = context.request_context.lifespan_context["session_manager"]
-        names = await config_manager.get_community_session_names()
+        names = await config.get_all_config_names(config_manager, "community_sessions")
         results = []
         for name in names:
             try:

--- a/src/deephaven_mcp/community/_sessions.py
+++ b/src/deephaven_mcp/community/_sessions.py
@@ -456,9 +456,7 @@ class SessionManager:
 
             # At this point, we need to create a new session and update the cache
             _LOGGER.info(f"Creating new session for worker: {worker_name}")
-            worker_cfg = await self._config_manager.get_community_session_config(
-                worker_name
-            )
+            worker_cfg = await config.get_named_config(self._config_manager, "community_sessions", worker_name)
             session_params = await self._get_session_parameters(worker_cfg)
 
             # Redact sensitive info for logging

--- a/src/deephaven_mcp/community/_sessions.py
+++ b/src/deephaven_mcp/community/_sessions.py
@@ -456,7 +456,9 @@ class SessionManager:
 
             # At this point, we need to create a new session and update the cache
             _LOGGER.info(f"Creating new session for worker: {worker_name}")
-            worker_cfg = await config.get_named_config(self._config_manager, "community_sessions", worker_name)
+            worker_cfg = await config.get_named_config(
+                self._config_manager, "community_sessions", worker_name
+            )
             session_params = await self._get_session_parameters(worker_cfg)
 
             # Redact sensitive info for logging

--- a/src/deephaven_mcp/config/__init__.py
+++ b/src/deephaven_mcp/config/__init__.py
@@ -194,7 +194,7 @@ import json
 import logging
 import os
 from time import perf_counter
-from typing import Any, cast
+from typing import Any, cast, Callable
 
 import aiofiles
 
@@ -219,12 +219,13 @@ CONFIG_ENV_VAR = "DH_MCP_CONFIG_FILE"
 str: Name of the environment variable specifying the path to the Deephaven MCP config file.
 """
 
+_REQUIRED_TOP_LEVEL_KEYS: set[str] = set()
+"""Set of top-level keys that MUST be present in the configuration file."""
+_ALLOWED_TOP_LEVEL_KEYS: set[str] = {"community_sessions", "enterprise_systems"}
+"""Set of all allowed top-level keys in the configuration file."""
+
 
 class ConfigManager:
-    _REQUIRED_TOP_LEVEL_KEYS: set[str] = set()
-    """Set of top-level keys that MUST be present in the configuration file."""
-    _ALLOWED_TOP_LEVEL_KEYS: set[str] = {"community_sessions", "enterprise_systems"}
-    """Set of all allowed top-level keys in the configuration file."""
 
     """
     Async configuration manager for Deephaven MCP configuration.
@@ -265,32 +266,46 @@ class ConfigManager:
         """
         Set the in-memory configuration cache (coroutine-safe, for testing only).
 
+        This method allows tests or advanced users to inject a configuration dictionary directly
+        into the manager's cache, bypassing file I/O. The configuration will be validated before
+        being cached. This is useful for unit tests or scenarios where you want to avoid
+        reading from disk.
+
         Args:
             config (dict[str, Any]): The configuration dictionary to set as the cache. This will be validated before caching.
 
         Returns:
             None
 
+        Raises:
+            McpConfigurationError: If the provided configuration is invalid.
+
         Example:
             >>> # Assuming config_manager is an instance of ConfigManager
             >>> await config_manager.set_config_cache({'community_sessions': {'example_session': {}}})
         """
         async with self._lock:
-            self._cache = self.validate_config(config)
+            self._cache = validate_config(config)
 
     async def get_config(self) -> dict[str, Any]:
         """
         Load and validate the Deephaven MCP application configuration from disk (coroutine-safe).
 
-        Uses `aiofiles` for async file I/O and caches the result. If the cache is present,
-        returns it; otherwise, loads from disk and validates.
+        This method loads the configuration from the file path specified by the DH_MCP_CONFIG_FILE
+        environment variable, validates its structure and contents, and caches the result for
+        subsequent calls. If the cache is already populated, it returns the cached configuration.
+        All file I/O is performed asynchronously using aiofiles, and the method is coroutine-safe.
+        If the configuration file or its contents are invalid, detailed errors are logged and
+        exceptions are raised.
 
         Returns:
-            dict[str, Any]: The loaded and validated configuration dictionary. Returns an empty dictionary if the config file path is not set or the file is empty (but valid JSON like {}). Raises McpConfigurationError or its subclasses on loading, parsing, or validation failures.
+            dict[str, Any]: The loaded and validated configuration dictionary. Returns an empty
+                dictionary if the config file path is not set or the file is empty (but valid JSON like {}).
 
         Raises:
-            RuntimeError: If the `DH_MCP_CONFIG_FILE` environment variable is not set, or the file cannot be read.
-            ValueError: If the config file is invalid (e.g., not JSON, missing required keys, incorrect types).
+            RuntimeError: If the DH_MCP_CONFIG_FILE environment variable is not set.
+            McpConfigurationError: If the config file is invalid (e.g., not JSON, missing required keys,
+                incorrect types, or fails validation).
 
         Example:
             >>> # Assuming config_manager is an instance of ConfigManager
@@ -307,280 +322,280 @@ class ConfigManager:
                 _LOGGER.debug("Using cached Deephaven MCP application configuration.")
                 return self._cache
 
-            _LOGGER.info("Loading Deephaven MCP application configuration from disk...")
-            start_time = perf_counter()
+            config_path = _get_config_path()
+            validated = await _load_and_validate_config(config_path)
+            self._cache = validated
+            _log_config_summary(validated)
+            return validated
 
-            if CONFIG_ENV_VAR not in os.environ:
-                _LOGGER.error(f"Environment variable {CONFIG_ENV_VAR} is not set.")
-                raise RuntimeError(f"Environment variable {CONFIG_ENV_VAR} is not set.")
 
-            config_path = os.environ[CONFIG_ENV_VAR]
-            _LOGGER.info(
-                f"Environment variable {CONFIG_ENV_VAR} is set to: {config_path}"
-            )
+async def get_named_config(
+    config_manager: "ConfigManager",
+    section: str,
+    name: str,
+) -> dict[str, Any]:
+    """
+    Retrieve a named config dict from a section, with logging and error handling.
 
-            data = await self._load_config_from_file(config_path)
+    Args:
+        config_manager (ConfigManager): The ConfigManager instance to use for config retrieval.
+        section (str): The top-level config section (e.g., 'community_sessions', 'enterprise_systems').
+        name (str): The specific item name to retrieve.
+        redact_fn (Callable): Function to redact sensitive fields for logging.
 
-            try:
-                validated_data = self.validate_config(data)
-            except (
-                CommunitySessionConfigurationError,
-                EnterpriseSystemConfigurationError,
-            ) as specific_e:
-                _LOGGER.error(
-                    f"Configuration validation failed for {config_path}: {specific_e}"
-                )
-                raise McpConfigurationError(
-                    f"Configuration validation failed: {specific_e}"
-                ) from specific_e
-            except ValueError as ve:
-                _LOGGER.error(
-                    f"General configuration validation error for {config_path}: {ve}"
-                )
-                raise McpConfigurationError(
-                    f"General configuration validation error: {ve}"
-                ) from ve
+    Returns:
+        dict[str, Any]: The configuration dictionary for the specified item.
 
-            self._cache = validated_data
-            end_time = perf_counter()
-            duration_ms = (end_time - start_time) * 1000
-            _LOGGER.info(
-                f"Successfully loaded and validated Deephaven MCP application configuration from {config_path} in {duration_ms:.2f}ms."
-            )
+    Raises:
+        ValueError: If the named item is not found in the config section.
+    """
+    _LOGGER.debug(f"Getting config for '{section}:{name}'")
+    config = await config_manager.get_config()
+    section_map = config.get(section, {})
 
-            # Log configured sessions after successful load and validation
-            community_sessions = self._cache.get("community_sessions", {})
-            if community_sessions:
-                _LOGGER.info("Configured Community Sessions:")
-                for name, details in community_sessions.items():
-                    _LOGGER.info(
-                        f"  Session '{name}': {redact_community_session_config(details)}"
-                    )
-            else:
-                _LOGGER.info("No Community Sessions configured.")
+    # get redact fn
+    if section == "community_sessions":
+        redact_fn = redact_community_session_config
+    elif section == "enterprise_systems":
+        redact_fn = redact_enterprise_system_config
+    else:
+        raise ValueError(f"Invalid section: {section}")
 
-            enterprise_systems = self._cache.get("enterprise_systems", {})
-            if enterprise_systems:
-                _LOGGER.info("Configured Enterprise Systems:")
-                for name, details in enterprise_systems.items():
-                    _LOGGER.info(
-                        f"  System '{name}': {redact_enterprise_system_config(details)}"
-                    )
-            else:
-                _LOGGER.info("No Enterprise Systems configured.")
+    if name not in section_map:
+        _LOGGER.error(f"Config for '{section}:{name}' not found in configuration")
+        raise ValueError(f"Config for '{section}:{name}' not found in configuration")
+    _LOGGER.debug(
+        f"Retrieved configuration for '{section}:{name}': {redact_fn(section_map[name])}"
+    )
+    return section_map[name]
 
-            return self._cache
 
-    async def _load_config_from_file(self, config_path: str) -> dict[str, Any]:
-        """Load and parse configuration from a JSON file."""
-        try:
-            async with aiofiles.open(config_path) as f:
-                content = await f.read()
-            # Ensure the result is a dictionary for type checking
-            return cast(dict[str, Any], json.loads(content))
-        except FileNotFoundError:
-            _LOGGER.error(f"Configuration file not found: {config_path}")
-            raise McpConfigurationError(
-                f"Configuration file not found: {config_path}"
-            ) from None
-        except PermissionError:
-            _LOGGER.error(
-                f"Permission denied when trying to read configuration file: {config_path}"
-            )
-            raise McpConfigurationError(
-                f"Permission denied when trying to read configuration file: {config_path}"
-            ) from None
-        except json.JSONDecodeError as e:
-            _LOGGER.error(f"Invalid JSON in configuration file {config_path}: {e}")
-            raise McpConfigurationError(
-                f"Invalid JSON in configuration file {config_path}: {e}"
-            ) from e
-        except Exception as e:  # Catch other potential IOErrors or unexpected issues
-            _LOGGER.error(
-                f"Unexpected error loading or parsing config file {config_path}: {e}"
-            )
-            raise McpConfigurationError(
-                f"Unexpected error loading or parsing config file {config_path}: {e}"
-            ) from e
+async def get_all_config_names(
+    config_manager: "ConfigManager",
+    section: str,
+) -> list[str]:
+    """
+    Retrieve all names from a given config section.
 
-    async def get_community_session_config(self, session_name: str) -> dict[str, Any]:
-        """
-        Retrieves the configuration for a specific community session by its name.
+    Args:
+        config_manager (ConfigManager): The ConfigManager instance to use for config retrieval.
+        section (str): The top-level config section to extract names from (e.g., 'community_sessions', 'enterprise_systems').
 
-        Args:
-            session_name (str): The name of the community session to retrieve. This argument is required.
+    Returns:
+        list[str]: List of keys (names) in the specified config section, or empty list if not found or not a dict.
+    """
+    _LOGGER.debug(f"Getting list of all names from config section '{section}'")
+    config = await config_manager.get_config()
+    section_map = config.get(section, {})
+    if not isinstance(section_map, dict):
+        _LOGGER.warning(f"'{section}' is not a dictionary, returning empty list of names.")
+        return []
+    names = list(section_map.keys())
+    _LOGGER.debug(f"Found {len(names)} {section} item(s): {names}")
+    return names
 
-        Returns:
-            dict[str, Any]: The configuration dictionary for the specified community session.
 
-        Raises:
-            CommunitySessionConfigurationError: If the community session is not found or config is invalid.
+async def _load_config_from_file(config_path: str) -> dict[str, Any]:
+    """
+    Load and parse the Deephaven MCP configuration from a JSON file asynchronously.
 
-        Example:
-            >>> # Assuming config_manager is an instance of ConfigManager
-            >>> local_session_config = await config_manager.get_community_session_config('local_session_name')
-        """
-        _LOGGER.debug(f"Getting community session config for session: {session_name!r}")
-        config = await self.get_config()
-        community_sessions_map = config.get("community_sessions", {})
+    Args:
+        config_path (str): The file path to the configuration JSON file.
 
-        if session_name not in community_sessions_map:
-            _LOGGER.error(
-                f"Community session {session_name} not found in configuration"
-            )
-            raise CommunitySessionConfigurationError(
-                f"Community session {session_name} not found in configuration"
-            )
+    Returns:
+        dict[str, Any]: The parsed configuration as a dictionary.
 
-        _LOGGER.debug(
-            f"Retrieved configuration for community session '{session_name}': {redact_community_session_config(community_sessions_map[session_name])}"
-        )
-        return cast(dict[str, Any], community_sessions_map[session_name])
+    Raises:
+        McpConfigurationError: If the file is not found, cannot be read, is not valid JSON, or any other I/O error occurs.
 
-    async def get_community_session_names(self) -> list[str]:
-        """
-        Retrieves a list of all configured community session names.
+    Example:
+        >>> config = await _load_config_from_file('/path/to/config.json')
+        >>> print(config['community_sessions'])
+    """
+    try:
+        async with aiofiles.open(config_path) as f:
+            content = await f.read()
+        return cast(dict[str, Any], json.loads(content))
+    except FileNotFoundError:
+        _LOGGER.error(f"Configuration file not found: {config_path}")
+        raise McpConfigurationError(f"Configuration file not found: {config_path}") from None
+    except PermissionError:
+        _LOGGER.error(f"Permission denied when trying to read configuration file: {config_path}")
+        raise McpConfigurationError(f"Permission denied when trying to read configuration file: {config_path}") from None
+    except json.JSONDecodeError as e:
+        _LOGGER.error(f"Invalid JSON in configuration file {config_path}: {e}")
+        raise McpConfigurationError(f"Invalid JSON in configuration file {config_path}: {e}") from e
+    except Exception as e:
+        _LOGGER.error(f"Unexpected error loading or parsing config file {config_path}: {e}")
+        raise McpConfigurationError(f"Unexpected error loading or parsing config file {config_path}: {e}") from e
 
-        Returns:
-            list[str]: A list of community session names.
 
-        Example:
-            >>> # Assuming config_manager is an instance of ConfigManager
-            >>> session_names = await config_manager.get_community_session_names()
-            >>> for session_name in session_names:
-            ...     print(f"Available community session: {session_name}")
-        """
-        _LOGGER.debug("Getting list of all community session names")
-        config = await self.get_config()
-        community_sessions_map = config.get("community_sessions", {})
-        session_names = list(community_sessions_map.keys())
+def _get_config_path() -> str:
+    """
+    Retrieve the configuration file path from the environment variable.
 
-        _LOGGER.debug(
-            f"Found {len(session_names)} community session(s): {session_names}"
-        )
-        return session_names
+    This function retrieves the path to the Deephaven MCP configuration JSON file from the environment variable specified by CONFIG_ENV_VAR.
 
-    async def get_enterprise_system_config(self, system_name: str) -> dict[str, Any]:
-        """
-        Retrieves the configuration for a specific enterprise system by its name.
+    Returns:
+        str: The path to the Deephaven MCP configuration JSON file as specified by the CONFIG_ENV_VAR environment variable.
 
-        Args:
-            system_name (str): The name of the enterprise system configuration to retrieve. Required.
+    Raises:
+        RuntimeError: If the CONFIG_ENV_VAR environment variable is not set.
 
-        Returns:
-            dict[str, Any]: The configuration dictionary for the specified enterprise system.
+    Example:
+        >>> os.environ['DH_MCP_CONFIG_FILE'] = '/path/to/config.json'
+        >>> path = _get_config_path()
+        >>> print(path)
+        '/path/to/config.json'
+    """
+    if CONFIG_ENV_VAR not in os.environ:
+        _LOGGER.error(f"Environment variable {CONFIG_ENV_VAR} is not set.")
+        raise RuntimeError(f"Environment variable {CONFIG_ENV_VAR} is not set.")
+    config_path = os.environ[CONFIG_ENV_VAR]
+    _LOGGER.info(f"Environment variable {CONFIG_ENV_VAR} is set to: {config_path}")
+    return config_path
 
-        Raises:
-            EnterpriseSystemConfigurationError: If the enterprise system configuration is not found.
 
-        Example:
-            >>> # Assuming config_manager is an instance of ConfigManager
-            >>> enterprise_system_config = await config_manager.get_enterprise_system_config('prod_cluster')
-        """
-        _LOGGER.debug(f"Getting enterprise system config for system: {system_name!r}")
-        config = await self.get_config()
-        enterprise_systems_map = config.get("enterprise_systems", {})
+async def _load_and_validate_config(config_path: str) -> dict[str, Any]:
+    """
+    Load and validate the Deephaven MCP configuration from a JSON file.
 
-        if (
-            not isinstance(enterprise_systems_map, dict)
-            or system_name not in enterprise_systems_map
-        ):
-            _LOGGER.error(
-                f"Enterprise system '{system_name}' not found in configuration or 'enterprise_systems' is not a dict."
-            )
-            raise EnterpriseSystemConfigurationError(
-                f"Enterprise system '{system_name}' not found in configuration."
-            )
+    This function loads the configuration from the specified file path, parses it as JSON,
+    and validates it according to the expected schema. All exceptions are logged and
+    re-raised as McpConfigurationError for unified error handling.
 
-        # TODO: Implement redaction for enterprise systems if needed, similar to community sessions.
-        # For now, returning the raw config.
-        _LOGGER.debug(
-            f"Retrieved configuration for enterprise system '{system_name}': {enterprise_systems_map[system_name]}"  # Add redaction if sensitive
-        )
-        return cast(dict[str, Any], enterprise_systems_map[system_name])
+    Args:
+        config_path (str): The path to the configuration JSON file.
 
-    async def get_all_enterprise_system_names(self) -> list[str]:
-        """
-        Retrieves a list of all configured enterprise system names.
+    Returns:
+        dict[str, Any]: The loaded and validated configuration dictionary.
 
-        Returns:
-            list[str]: A list of enterprise system configuration names.
+    Raises:
+        McpConfigurationError: If the file cannot be read, is not valid JSON, or fails validation.
 
-        Example:
-            >>> # Assuming config_manager is an instance of ConfigManager
-            >>> system_names = await config_manager.get_all_enterprise_system_names()
-            >>> for system_name in system_names:
-            ...     print(f"Available enterprise system: {system_name}")
-        """
-        _LOGGER.debug("Getting list of all enterprise system names")
-        config = await self.get_config()
-        enterprise_systems_map = config.get("enterprise_systems", {})
+    Example:
+        >>> config = await _load_and_validate_config('/path/to/config.json')
+        >>> print(config['enterprise_systems'])
+    """
+    try:
+        data = await _load_config_from_file(config_path)
+        return validate_config(data)
+    except (CommunitySessionConfigurationError, EnterpriseSystemConfigurationError) as specific_e:
+        _LOGGER.error(f"Configuration validation failed for {config_path}: {specific_e}")
+        raise McpConfigurationError(f"Configuration validation failed: {specific_e}") from specific_e
+    except ValueError as ve:
+        _LOGGER.error(f"General configuration validation error for {config_path}: {ve}")
+        raise McpConfigurationError(f"General configuration validation error: {ve}") from ve
+    except Exception as e:
+        _LOGGER.error(f"Error loading configuration file {config_path}: {e}")
+        raise McpConfigurationError(f"Error loading configuration file: {e}") from e
 
-        if not isinstance(enterprise_systems_map, dict):
-            _LOGGER.warning(
-                "'enterprise_systems' is not a dictionary, returning empty list of names."
-            )
-            return []
 
-        system_names = list(enterprise_systems_map.keys())
+def _log_config_summary(config: dict[str, Any]) -> None:
+    """
+    Log a summary of the loaded Deephaven MCP configuration.
 
-        _LOGGER.debug(f"Found {len(system_names)} enterprise system(s): {system_names}")
-        return system_names
+    This function logs the names and (redacted) details of all configured community sessions and
+    enterprise systems. If no sessions or systems are configured, it logs that information as well.
 
-    @staticmethod
-    def validate_config(config: dict[str, Any]) -> dict[str, Any]:
-        """
-        Validate the Deephaven MCP application configuration dictionary.
+    Args:
+        config (dict[str, Any]): The loaded and validated configuration dictionary.
 
-        Ensures that the configuration has the correct top-level structure.
-        The 'community_sessions' and 'enterprise_systems' keys are optional. If present, they delegate to
-        their respective validation functions (`validate_community_sessions_config` and
-        `validate_enterprise_systems_config`) for detailed validation of their content.
-        Only known top-level keys are allowed.
+    Example:
+        >>> config = {'community_sessions': {'local': {...}}, 'enterprise_systems': {}}
+        >>> _log_config_summary(config)
+    """
+    community_sessions = config.get("community_sessions", {})
+    if community_sessions:
+        _LOGGER.info("Configured Community Sessions:")
+        for name, details in community_sessions.items():
+            _LOGGER.info(f"  Session '{name}': {redact_community_session_config(details)}")
+    else:
+        _LOGGER.info("No Community Sessions configured.")
+    enterprise_systems = config.get("enterprise_systems", {})
+    if enterprise_systems:
+        _LOGGER.info("Configured Enterprise Systems:")
+        for name, details in enterprise_systems.items():
+            _LOGGER.info(f"  System '{name}': {redact_enterprise_system_config(details)}")
+    else:
+        _LOGGER.info("No Enterprise Systems configured.")
 
-        Args:
-            config (dict[str, Any]): The configuration dictionary to validate.
-                                     May optionally include a 'community_sessions' dictionary as a top-level key.
 
-        Returns:
-            dict[str, Any]: The validated configuration dictionary.
+def validate_config(config: dict[str, Any]) -> dict[str, Any]:
+    """
+    Validate the Deephaven MCP application configuration dictionary.
 
-        Raises:
-            ValueError: If the config has unknown top-level keys and validating specific sections like 'community_sessions' and 'enterprise_systems' if they are present.
+    This function ensures that the configuration dictionary conforms to the expected schema for Deephaven MCP.
+    The configuration may contain the following top-level keys:
+      - 'community_sessions' (dict, optional):
+            A dictionary mapping community session names (str) to session configuration dicts.
+            Each session configuration dict may contain any of the following fields (all optional):
+                - 'host' (str): Hostname or IP address.
+                - 'port' (int): Port number.
+                - 'auth_type' (str): Authentication type ('token', 'basic', 'anonymous').
+                - 'auth_token' (str, optional): Direct authentication token or password.
+                - 'auth_token_env_var' (str, optional): Environment variable for authentication token.
+                - 'never_timeout' (bool): If True, session never times out.
+                - 'session_type' (str): Programming language for the session ('python', 'groovy', etc.).
+                - 'use_tls' (bool): Whether to use TLS/SSL.
+                - 'tls_root_certs' (str, optional): Path to PEM file with root certificates.
+                - 'client_cert_chain' (str, optional): Path to client certificate chain PEM file.
+                - 'client_private_key' (str, optional): Path to client private key PEM file.
+            All fields are optional; unknown fields are not allowed and will cause validation to fail.
+      - 'enterprise_systems' (dict, optional):
+            A dictionary mapping enterprise system names (str) to enterprise system configuration dicts.
+            Each enterprise system configuration dict must include:
+                - 'connection_json_url' (str, required): URL to the server's connection.json file.
+                - 'auth_type' (str, required): One of:
+                    * 'password':
+                        - 'username' (str, required): The username.
+                        - 'password' (str, optional): The password.
+                        - 'password_env_var' (str, optional): Environment variable for the password.
+                          (Exactly one of 'password' or 'password_env_var' must be provided, but not both.)
+                    * 'private_key':
+                        - 'private_key' (str, required): The private key.
+            All fields not listed above are disallowed and will cause validation to fail.
 
-        Example:
-            >>> validated_config = ConfigManager.validate_config({'community_sessions': {'local_session': {}}, 'enterprise_systems': {'prod_cluster': {}}})
-            >>> validated_config_empty = ConfigManager.validate_config({}) # Also valid
-        """
-        top_level_keys = set(config.keys())
+    Validation Rules:
+        - Only known top-level keys are allowed ('community_sessions', 'enterprise_systems').
+        - All present sections are validated according to their schema.
+        - Missing required top-level keys (if any) will cause validation to fail.
+        - Unknown or misspelled keys will cause validation to fail.
+        - All field types must be correct if present.
+        - Sensitive fields are redacted from logs.
 
-        # Check for missing required keys
-        missing_keys = ConfigManager._REQUIRED_TOP_LEVEL_KEYS - top_level_keys
-        if missing_keys:
-            _LOGGER.error(
-                f"Missing required top-level keys in Deephaven MCP config: {missing_keys}"
-            )
-            raise McpConfigurationError(
-                f"Missing required top-level keys in Deephaven MCP config: {missing_keys}"
-            )
+    Args:
+        config (dict[str, Any]): The configuration dictionary to validate.
 
-        # Check for unknown keys (keys present that are not in allowed_top_level)
-        unknown_keys = top_level_keys - ConfigManager._ALLOWED_TOP_LEVEL_KEYS
-        if unknown_keys:
-            _LOGGER.error(
-                f"Unknown top-level keys in Deephaven MCP config: {unknown_keys}"
-            )
-            raise McpConfigurationError(
-                f"Unknown top-level keys in Deephaven MCP config: {unknown_keys}"
-            )
+    Returns:
+        dict[str, Any]: The validated configuration dictionary.
 
-        # Validate 'community_sessions' if present
-        if "community_sessions" in top_level_keys:
-            validate_community_sessions_config(config["community_sessions"])
+    Raises:
+        McpConfigurationError: If required top-level keys are missing or unknown keys are present.
+        CommunitySessionConfigurationError: If a community session config is invalid.
+        EnterpriseSystemConfigurationError: If an enterprise system config is invalid.
 
-        # Validate 'enterprise_systems' if present
-        if "enterprise_systems" in top_level_keys:
-            validate_enterprise_systems_config(config["enterprise_systems"])
+    Example:
+        >>> validated_config = validate_config({'community_sessions': {'local_session': {}}, 'enterprise_systems': {'prod_cluster': {}}})
+        >>> validated_config_empty = validate_config({})  # Also valid
+    """
+    top_level_keys = set(config.keys())
 
-        _LOGGER.info("Configuration validation passed.")
-        return config
+    # Check for missing required keys
+    missing_keys = _REQUIRED_TOP_LEVEL_KEYS - top_level_keys
+    if missing_keys:
+        _LOGGER.error(f"Missing required top-level keys in Deephaven MCP config: {missing_keys}")
+        raise McpConfigurationError(f"Missing required top-level keys in Deephaven MCP config: {missing_keys}")
+    unknown_keys = top_level_keys - _ALLOWED_TOP_LEVEL_KEYS
+    if unknown_keys:
+        _LOGGER.error(f"Unknown top-level keys in Deephaven MCP config: {unknown_keys}")
+        raise McpConfigurationError(f"Unknown top-level keys in Deephaven MCP config: {unknown_keys}")
+    if "community_sessions" in top_level_keys:
+        validate_community_sessions_config(config["community_sessions"])
+
+    # Validate 'enterprise_systems' if present
+    if "enterprise_systems" in top_level_keys:
+        validate_enterprise_systems_config(config["enterprise_systems"])
+
+    _LOGGER.info("Configuration validation passed.")
+    return config

--- a/src/deephaven_mcp/config/community_session.py
+++ b/src/deephaven_mcp/config/community_session.py
@@ -8,6 +8,12 @@ This module includes:
 - Custom exceptions related to community session configuration errors.
 """
 
+__all__ = [
+    "validate_community_sessions_config",
+    "validate_single_community_session_config",
+    "redact_community_session_config",
+]
+
 import logging
 import types
 from typing import Any

--- a/src/deephaven_mcp/config/enterprise_system.py
+++ b/src/deephaven_mcp/config/enterprise_system.py
@@ -2,6 +2,13 @@
 Validation logic for the 'enterprise_systems' section of the Deephaven MCP configuration.
 """
 
+__all__ = [
+    "validate_enterprise_systems_config",
+    "validate_single_enterprise_system",
+    "redact_enterprise_system_config",
+    "redact_enterprise_systems_map",
+]
+
 import logging
 from typing import Any
 
@@ -117,14 +124,14 @@ def validate_enterprise_systems_config(enterprise_systems_map: Any | None) -> No
             msg = f"Enterprise system name must be a string, but got {type(system_name).__name__}: {system_name!r}."
             _LOGGER.error(msg)
             raise EnterpriseSystemConfigurationError(msg)
-        _validate_single_enterprise_system(system_name, system_config)
+        validate_single_enterprise_system(system_name, system_config)
 
     _LOGGER.info(
         f"Validation for 'enterprise_systems' passed. Found {len(enterprise_systems_map)} enterprise system(s)."
     )
 
 
-def _validate_single_enterprise_system(system_name: str, config: Any) -> None:
+def validate_single_enterprise_system(system_name: str, config: Any) -> None:
     """
     Validate a single enterprise system's configuration dictionary.
 

--- a/tests/test_community__mcp.py
+++ b/tests/test_community__mcp.py
@@ -148,6 +148,7 @@ async def test_describe_workers_all_available_with_versions(monkeypatch):
     config_manager = MagicMock()
     session_manager = MagicMock()
     config_manager.get_community_session_names = AsyncMock(return_value=["w1", "w2"])
+    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "python"}, "w2": {"session_type": "python"}}})
     alive_session = MagicMock(is_alive=True)
     session_manager.get_or_create_session = AsyncMock(return_value=alive_session)
     config_manager.get_community_session_config = AsyncMock(
@@ -189,6 +190,7 @@ async def test_describe_workers_all_available_no_versions(monkeypatch):
     config_manager = MagicMock()
     session_manager = MagicMock()
     config_manager.get_community_session_names = AsyncMock(return_value=["w1", "w2"])
+    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "python"}, "w2": {"session_type": "python"}}})
     alive_session = MagicMock(is_alive=True)
     session_manager.get_or_create_session = AsyncMock(return_value=alive_session)
     config_manager.get_community_session_config = AsyncMock(
@@ -221,6 +223,7 @@ async def test_describe_workers_some_unavailable(monkeypatch):
     config_manager.get_community_session_names = AsyncMock(
         return_value=["w1", "w2", "w3"]
     )
+    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "python"}, "w2": {"session_type": "python"}, "w3": {"session_type": "python"}}})
     alive_session = MagicMock(is_alive=True)
     dead_session = MagicMock(is_alive=False)
 
@@ -268,6 +271,7 @@ async def test_describe_workers_non_python(monkeypatch):
     config_manager = MagicMock()
     session_manager = MagicMock()
     config_manager.get_community_session_names = AsyncMock(return_value=["w1"])
+    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "groovy"}}})
     alive_session = MagicMock(is_alive=True)
     session_manager.get_or_create_session = AsyncMock(return_value=alive_session)
     config_manager.get_community_session_config = AsyncMock(
@@ -299,6 +303,7 @@ async def test_describe_workers_versions_error(monkeypatch):
     config_manager = MagicMock()
     session_manager = MagicMock()
     config_manager.get_community_session_names = AsyncMock(return_value=["w1"])
+    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "python"}}})
     alive_session = MagicMock(is_alive=True)
     session_manager.get_or_create_session = AsyncMock(return_value=alive_session)
     config_manager.get_community_session_config = AsyncMock(
@@ -333,6 +338,7 @@ async def test_describe_workers_some_unavailable_with_versions(monkeypatch):
     config_manager.get_community_session_names = AsyncMock(
         return_value=["w1", "w2", "w3"]
     )
+    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "python"}, "w2": {"session_type": "python"}, "w3": {"session_type": "python"}}})
     alive_session = MagicMock(is_alive=True)
     dead_session = MagicMock(is_alive=False)
 
@@ -350,7 +356,7 @@ async def test_describe_workers_some_unavailable_with_versions(monkeypatch):
     )
     # Only w1 is alive, w2 fails, w3 is dead
     monkeypatch.setattr(
-        mcp_mod.sessions, "get_dh_versions", AsyncMock(return_value=("1.2.3", None))
+        mcp_mod.sessions, "get_dh_versions", AsyncMock(return_value=("1.2.3", "4.5.6"))
     )
     context = MockContext(
         {
@@ -367,18 +373,19 @@ async def test_describe_workers_some_unavailable_with_versions(monkeypatch):
                 "available": True,
                 "programming_language": "python",
                 "deephaven_core_version": "1.2.3",
+                "deephaven_enterprise_version": "4.5.6",
             },
             {"worker": "w2", "available": False, "programming_language": "python"},
             {"worker": "w3", "available": False, "programming_language": "python"},
         ],
     }
 
-
 @pytest.mark.asyncio
 async def test_describe_workers_worker_config_error(monkeypatch):
     config_manager = MagicMock()
     session_manager = MagicMock()
     config_manager.get_community_session_names = AsyncMock(return_value=["w1"])
+    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "python"}}})
     # Simulate get_worker_config raising an exception
     config_manager.get_community_session_config = AsyncMock(
         side_effect=config.CommunitySessionConfigurationError("config-fail")
@@ -402,9 +409,7 @@ async def test_describe_workers_worker_config_error(monkeypatch):
 async def test_describe_workers_config_error(monkeypatch):
     config_manager = MagicMock()
     session_manager = MagicMock()
-    config_manager.get_community_session_names = AsyncMock(
-        side_effect=Exception("fail-cfg")
-    )
+    config_manager.get_config = AsyncMock(side_effect=Exception("fail-cfg"))
     context = MockContext(
         {
             "config_manager": config_manager,

--- a/tests/test_community__mcp.py
+++ b/tests/test_community__mcp.py
@@ -148,7 +148,14 @@ async def test_describe_workers_all_available_with_versions(monkeypatch):
     config_manager = MagicMock()
     session_manager = MagicMock()
     config_manager.get_community_session_names = AsyncMock(return_value=["w1", "w2"])
-    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "python"}, "w2": {"session_type": "python"}}})
+    config_manager.get_config = AsyncMock(
+        return_value={
+            "community_sessions": {
+                "w1": {"session_type": "python"},
+                "w2": {"session_type": "python"},
+            }
+        }
+    )
     alive_session = MagicMock(is_alive=True)
     session_manager.get_or_create_session = AsyncMock(return_value=alive_session)
     config_manager.get_community_session_config = AsyncMock(
@@ -190,7 +197,14 @@ async def test_describe_workers_all_available_no_versions(monkeypatch):
     config_manager = MagicMock()
     session_manager = MagicMock()
     config_manager.get_community_session_names = AsyncMock(return_value=["w1", "w2"])
-    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "python"}, "w2": {"session_type": "python"}}})
+    config_manager.get_config = AsyncMock(
+        return_value={
+            "community_sessions": {
+                "w1": {"session_type": "python"},
+                "w2": {"session_type": "python"},
+            }
+        }
+    )
     alive_session = MagicMock(is_alive=True)
     session_manager.get_or_create_session = AsyncMock(return_value=alive_session)
     config_manager.get_community_session_config = AsyncMock(
@@ -223,7 +237,15 @@ async def test_describe_workers_some_unavailable(monkeypatch):
     config_manager.get_community_session_names = AsyncMock(
         return_value=["w1", "w2", "w3"]
     )
-    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "python"}, "w2": {"session_type": "python"}, "w3": {"session_type": "python"}}})
+    config_manager.get_config = AsyncMock(
+        return_value={
+            "community_sessions": {
+                "w1": {"session_type": "python"},
+                "w2": {"session_type": "python"},
+                "w3": {"session_type": "python"},
+            }
+        }
+    )
     alive_session = MagicMock(is_alive=True)
     dead_session = MagicMock(is_alive=False)
 
@@ -271,7 +293,9 @@ async def test_describe_workers_non_python(monkeypatch):
     config_manager = MagicMock()
     session_manager = MagicMock()
     config_manager.get_community_session_names = AsyncMock(return_value=["w1"])
-    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "groovy"}}})
+    config_manager.get_config = AsyncMock(
+        return_value={"community_sessions": {"w1": {"session_type": "groovy"}}}
+    )
     alive_session = MagicMock(is_alive=True)
     session_manager.get_or_create_session = AsyncMock(return_value=alive_session)
     config_manager.get_community_session_config = AsyncMock(
@@ -303,7 +327,9 @@ async def test_describe_workers_versions_error(monkeypatch):
     config_manager = MagicMock()
     session_manager = MagicMock()
     config_manager.get_community_session_names = AsyncMock(return_value=["w1"])
-    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "python"}}})
+    config_manager.get_config = AsyncMock(
+        return_value={"community_sessions": {"w1": {"session_type": "python"}}}
+    )
     alive_session = MagicMock(is_alive=True)
     session_manager.get_or_create_session = AsyncMock(return_value=alive_session)
     config_manager.get_community_session_config = AsyncMock(
@@ -338,7 +364,15 @@ async def test_describe_workers_some_unavailable_with_versions(monkeypatch):
     config_manager.get_community_session_names = AsyncMock(
         return_value=["w1", "w2", "w3"]
     )
-    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "python"}, "w2": {"session_type": "python"}, "w3": {"session_type": "python"}}})
+    config_manager.get_config = AsyncMock(
+        return_value={
+            "community_sessions": {
+                "w1": {"session_type": "python"},
+                "w2": {"session_type": "python"},
+                "w3": {"session_type": "python"},
+            }
+        }
+    )
     alive_session = MagicMock(is_alive=True)
     dead_session = MagicMock(is_alive=False)
 
@@ -380,12 +414,15 @@ async def test_describe_workers_some_unavailable_with_versions(monkeypatch):
         ],
     }
 
+
 @pytest.mark.asyncio
 async def test_describe_workers_worker_config_error(monkeypatch):
     config_manager = MagicMock()
     session_manager = MagicMock()
     config_manager.get_community_session_names = AsyncMock(return_value=["w1"])
-    config_manager.get_config = AsyncMock(return_value={"community_sessions": {"w1": {"session_type": "python"}}})
+    config_manager.get_config = AsyncMock(
+        return_value={"community_sessions": {"w1": {"session_type": "python"}}}
+    )
     # Simulate get_worker_config raising an exception
     config_manager.get_community_session_config = AsyncMock(
         side_effect=config.CommunitySessionConfigurationError("config-fail")

--- a/tests/test_community_sessions.py
+++ b/tests/test_community_sessions.py
@@ -277,6 +277,9 @@ async def test_get_or_create_session_liveness_exception(
     session_manager._config_manager.get_worker_config = AsyncMock(
         return_value={"host": "localhost"}
     )
+    session_manager._config_manager.get_config = AsyncMock(
+        return_value={"community_sessions": {"foo": {"host": "localhost"}}}
+    )
     monkeypatch.setattr("deephaven_mcp.community._sessions.Session", MagicMock())
     await session_manager.get_or_create_session("foo")
     assert any("Error checking session liveness" in r for r in caplog.text.splitlines())
@@ -454,6 +457,9 @@ async def test_get_or_create_session_reuses_alive(monkeypatch, session_manager):
     session_manager._config_manager.get_worker_config = AsyncMock(
         return_value={"host": "localhost"}
     )
+    session_manager._config_manager.get_config = AsyncMock(
+        return_value={"community_sessions": {"foo": {"host": "localhost"}}}
+    )
     monkeypatch.setattr("deephaven_mcp.community._sessions.Session", MagicMock())
     result = await session_manager.get_or_create_session("foo")
     assert result is session
@@ -465,6 +471,9 @@ async def test_get_or_create_session_creates_new(monkeypatch, session_manager):
     fake_config = {"host": "localhost"}
     session_manager._config_manager.get_worker_config = AsyncMock(
         return_value=fake_config
+    )
+    session_manager._config_manager.get_config = AsyncMock(
+        return_value={"community_sessions": {"foo": {"host": "localhost"}}}
     )
     monkeypatch.setattr(
         SessionManager,
@@ -487,6 +496,10 @@ async def test_get_or_create_session_handles_dead(monkeypatch, session_manager):
     fake_config = {"host": "localhost"}
     session_manager._config_manager.get_worker_config = AsyncMock(
         return_value=fake_config
+    )
+    # Patch get_config to include 'community_sessions: {"foo": ...}'
+    session_manager._config_manager.get_config = AsyncMock(
+        return_value={"community_sessions": {"foo": {"host": "localhost"}}}
     )
     monkeypatch.setattr(
         SessionManager,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,29 +1,32 @@
 """
 Comprehensive test suite for deephaven_mcp.config (public/private functions, 100% coverage, up-to-date with latest refactor).
 """
-import os
-import json
-import pytest
+
 import asyncio
-from unittest import mock
+import json
 import logging
+import os
 import re
+from unittest import mock
 
 import aiofiles
+import pytest
+
 from deephaven_mcp.config import (
-    ConfigManager,
-    get_named_config,
-    get_all_config_names,
-    validate_config,
-    _load_config_from_file,
-    _load_and_validate_config,
-    _get_config_path,
-    _log_config_summary,
-    McpConfigurationError,
-    CommunitySessionConfigurationError,
-    EnterpriseSystemConfigurationError,
     CONFIG_ENV_VAR,
+    CommunitySessionConfigurationError,
+    ConfigManager,
+    EnterpriseSystemConfigurationError,
+    McpConfigurationError,
+    _get_config_path,
+    _load_and_validate_config,
+    _load_config_from_file,
+    _log_config_summary,
+    get_all_config_names,
+    get_named_config,
+    validate_config,
 )
+
 
 # --- Fixtures and helpers ---
 @pytest.fixture
@@ -41,6 +44,7 @@ def valid_community_config():
             }
         }
     }
+
 
 @pytest.fixture
 def valid_enterprise_config():
@@ -60,9 +64,11 @@ def valid_enterprise_config():
         }
     }
 
+
 @pytest.fixture
 def valid_full_config(valid_community_config, valid_enterprise_config):
     return {**valid_community_config, **valid_enterprise_config}
+
 
 @pytest.fixture(autouse=True)
 def clear_env():
@@ -73,52 +79,67 @@ def clear_env():
     if old is not None:
         os.environ[CONFIG_ENV_VAR] = old
 
+
 # --- Top-level config validation ---
 def test_validate_config_accepts_empty():
     assert validate_config({}) == {}
 
+
 def test_validate_config_accepts_community_only(valid_community_config):
     assert validate_config(valid_community_config) == valid_community_config
+
 
 def test_validate_config_accepts_enterprise_only(valid_enterprise_config):
     assert validate_config(valid_enterprise_config) == valid_enterprise_config
 
+
 def test_validate_config_accepts_full(valid_full_config):
     assert validate_config(valid_full_config) == valid_full_config
+
 
 def test_validate_config_rejects_unknown_top_level():
     with pytest.raises(McpConfigurationError):
         validate_config({"foo": {}})
 
+
 # --- Community session validation ---
 from deephaven_mcp.config.community_session import (
+    redact_community_session_config,
     validate_community_sessions_config,
     validate_single_community_session_config,
-    redact_community_session_config,
 )
+
 
 def test_community_sessions_accepts_empty():
     validate_community_sessions_config({})
+
 
 def test_community_sessions_rejects_non_dict():
     with pytest.raises(CommunitySessionConfigurationError):
         validate_community_sessions_config([])
 
+
 def test_community_sessions_rejects_non_dict_item():
     with pytest.raises(CommunitySessionConfigurationError):
         validate_community_sessions_config({"foo": []})
+
 
 def test_community_sessions_unknown_field():
     with pytest.raises(CommunitySessionConfigurationError):
         validate_single_community_session_config("foo", {"host": "localhost", "bad": 1})
 
+
 def test_community_sessions_wrong_type():
     with pytest.raises(CommunitySessionConfigurationError):
         validate_single_community_session_config("foo", {"host": 1})
 
+
 def test_community_sessions_mutual_exclusive_auth_token():
     with pytest.raises(CommunitySessionConfigurationError):
-        validate_single_community_session_config("foo", {"auth_token": "a", "auth_token_env_var": "b"})
+        validate_single_community_session_config(
+            "foo", {"auth_token": "a", "auth_token_env_var": "b"}
+        )
+
 
 def test_community_sessions_redact():
     d = {"auth_token": "secret", "host": "localhost"}
@@ -126,84 +147,167 @@ def test_community_sessions_redact():
     assert redacted["auth_token"] == "[REDACTED]"
     assert redacted["host"] == "localhost"
 
+
 # --- Enterprise system validation ---
 from deephaven_mcp.config.enterprise_system import (
-    validate_enterprise_systems_config,
-    redact_enterprise_system_config,
-    _validate_single_enterprise_system,
     _validate_and_get_auth_type,
+    _validate_single_enterprise_system,
+    redact_enterprise_system_config,
+    validate_enterprise_systems_config,
 )
+
 
 def test_enterprise_systems_accepts_empty():
     validate_enterprise_systems_config({})
+
 
 def test_enterprise_systems_rejects_non_dict():
     with pytest.raises(EnterpriseSystemConfigurationError):
         validate_enterprise_systems_config([])
 
+
 def test_enterprise_systems_rejects_non_dict_item():
     with pytest.raises(EnterpriseSystemConfigurationError):
         validate_enterprise_systems_config({"foo": []})
+
 
 def test_enterprise_systems_invalid_system_name_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
         validate_enterprise_systems_config({1: {}})
 
+
 def test_enterprise_systems_missing_connection_json_url():
     with pytest.raises(EnterpriseSystemConfigurationError):
         _validate_single_enterprise_system("foo", {"auth_type": "password"})
 
+
 def test_enterprise_systems_invalid_connection_json_url_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system("foo", {"connection_json_url": 1, "auth_type": "password"})
+        _validate_single_enterprise_system(
+            "foo", {"connection_json_url": 1, "auth_type": "password"}
+        )
+
 
 def test_enterprise_systems_missing_auth_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
         _validate_single_enterprise_system("foo", {"connection_json_url": "url"})
 
+
 def test_enterprise_systems_invalid_auth_type_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system("foo", {"connection_json_url": "url", "auth_type": 1})
+        _validate_single_enterprise_system(
+            "foo", {"connection_json_url": "url", "auth_type": 1}
+        )
+
 
 def test_enterprise_systems_unknown_auth_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system("foo", {"connection_json_url": "url", "auth_type": "badtype"})
+        _validate_single_enterprise_system(
+            "foo", {"connection_json_url": "url", "auth_type": "badtype"}
+        )
+
 
 def test_enterprise_systems_unknown_key():
     # Should log a warning but not raise
-    _validate_single_enterprise_system("foo", {"connection_json_url": "url", "auth_type": "password", "username": "u", "password": "p", "bad": 1})
+    _validate_single_enterprise_system(
+        "foo",
+        {
+            "connection_json_url": "url",
+            "auth_type": "password",
+            "username": "u",
+            "password": "p",
+            "bad": 1,
+        },
+    )
+
 
 def test_enterprise_systems_password_auth_missing_username():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system("foo", {"connection_json_url": "url", "auth_type": "password", "password": "p"})
+        _validate_single_enterprise_system(
+            "foo",
+            {"connection_json_url": "url", "auth_type": "password", "password": "p"},
+        )
+
 
 def test_enterprise_systems_password_auth_invalid_username_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system("foo", {"connection_json_url": "url", "auth_type": "password", "username": 1, "password": "p"})
+        _validate_single_enterprise_system(
+            "foo",
+            {
+                "connection_json_url": "url",
+                "auth_type": "password",
+                "username": 1,
+                "password": "p",
+            },
+        )
+
 
 def test_enterprise_systems_password_auth_missing_password_keys():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system("foo", {"connection_json_url": "url", "auth_type": "password", "username": "u"})
+        _validate_single_enterprise_system(
+            "foo",
+            {"connection_json_url": "url", "auth_type": "password", "username": "u"},
+        )
+
 
 def test_enterprise_systems_password_auth_invalid_password_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system("foo", {"connection_json_url": "url", "auth_type": "password", "username": "u", "password": 1})
+        _validate_single_enterprise_system(
+            "foo",
+            {
+                "connection_json_url": "url",
+                "auth_type": "password",
+                "username": "u",
+                "password": 1,
+            },
+        )
+
 
 def test_enterprise_systems_password_auth_invalid_password_env_var_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system("foo", {"connection_json_url": "url", "auth_type": "password", "username": "u", "password_env_var": 1})
+        _validate_single_enterprise_system(
+            "foo",
+            {
+                "connection_json_url": "url",
+                "auth_type": "password",
+                "username": "u",
+                "password_env_var": 1,
+            },
+        )
+
 
 def test_enterprise_systems_password_auth_both_passwords_present():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system("foo", {"connection_json_url": "url", "auth_type": "password", "username": "u", "password": "p", "password_env_var": "env"})
+        _validate_single_enterprise_system(
+            "foo",
+            {
+                "connection_json_url": "url",
+                "auth_type": "password",
+                "username": "u",
+                "password": "p",
+                "password_env_var": "env",
+            },
+        )
+
 
 def test_enterprise_systems_private_key_auth_missing_key():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system("foo", {"connection_json_url": "url", "auth_type": "private_key"})
+        _validate_single_enterprise_system(
+            "foo", {"connection_json_url": "url", "auth_type": "private_key"}
+        )
+
 
 def test_enterprise_systems_private_key_auth_invalid_key_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system("foo", {"connection_json_url": "url", "auth_type": "private_key", "private_key": 1})
+        _validate_single_enterprise_system(
+            "foo",
+            {
+                "connection_json_url": "url",
+                "auth_type": "private_key",
+                "private_key": 1,
+            },
+        )
+
 
 def test_enterprise_systems_redact():
     d = {"password": "secret", "connection_json_url": "url"}
@@ -211,9 +315,13 @@ def test_enterprise_systems_redact():
     assert redacted["password"] == "[REDACTED]"
     assert redacted["connection_json_url"] == "url"
 
+
 def test_validate_and_get_auth_type_invalid():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_and_get_auth_type("foo", {"connection_json_url": "url", "auth_type": "badtype"})
+        _validate_and_get_auth_type(
+            "foo", {"connection_json_url": "url", "auth_type": "badtype"}
+        )
+
 
 # --- ConfigManager cache/async/IO ---
 
@@ -1540,10 +1648,7 @@ async def test_get_config_no_community_sessions_key_from_file(monkeypatch, caplo
     assert cm._cache == {}
     # Check for the new log messages for empty config
     log_text = caplog.text
-    assert (
-        "Configuration validation passed."
-        in log_text
-    )
+    assert "Configuration validation passed." in log_text
     assert "No Community Sessions configured." in log_text
     assert "No Enterprise Systems configured." in log_text
 
@@ -1561,6 +1666,7 @@ async def test_get_config_no_community_sessions_key_from_file(monkeypatch, caplo
 
 import pytest
 
+
 @pytest.mark.asyncio
 async def test_get_named_config_invalid_section():
     cm = ConfigManager()
@@ -1568,16 +1674,30 @@ async def test_get_named_config_invalid_section():
     with pytest.raises(ValueError, match="Invalid section: not_a_section"):
         await get_named_config(cm, "not_a_section", "foo")
 
+
 @pytest.mark.asyncio
 async def test_get_named_config_invalid_name_enterprise_systems():
     cm = ConfigManager()
-    cm._cache = {"enterprise_systems": {"foo": {"connection_json_url": "url", "auth_type": "api_key", "api_key": "SECRET"}}}
-    with pytest.raises(ValueError, match="Config for 'enterprise_systems:bar' not found in configuration"):
+    cm._cache = {
+        "enterprise_systems": {
+            "foo": {
+                "connection_json_url": "url",
+                "auth_type": "api_key",
+                "api_key": "SECRET",
+            }
+        }
+    }
+    with pytest.raises(
+        ValueError,
+        match="Config for 'enterprise_systems:bar' not found in configuration",
+    ):
         await get_named_config(cm, "enterprise_systems", "bar")
+
 
 @pytest.mark.asyncio
 async def test_config_manager_set_and_clear_cache():
     from deephaven_mcp import config
+
     cm = config.ConfigManager()
     await cm.set_config_cache({"community_sessions": {"a_session": {}}})
     cfg1 = await cm.get_config()
@@ -1588,33 +1708,45 @@ async def test_config_manager_set_and_clear_cache():
     assert "b_session" in cfg2["community_sessions"]
     assert "a_session" not in cfg2["community_sessions"]
 
+
 @pytest.mark.asyncio
 async def test_get_config_missing_env(monkeypatch):
     from deephaven_mcp import config
+
     monkeypatch.delenv("DH_MCP_CONFIG_FILE", raising=False)
     with pytest.raises(
         RuntimeError, match="Environment variable DH_MCP_CONFIG_FILE is not set"
     ):
         await config.ConfigManager().get_config()
 
+
 @pytest.mark.asyncio
 async def test_validate_config_missing_required_key_runtime(monkeypatch, caplog):
     import json
     from unittest import mock
+
     import aiofiles
+
     from deephaven_mcp import config
+
     # Patch the module-level _REQUIRED_TOP_LEVEL_KEYS
     monkeypatch.setattr(config, "_REQUIRED_TOP_LEVEL_KEYS", {"must_have_this"})
     config_file_path = "/fake/path/missing_required_key.json"
     monkeypatch.setenv("DH_MCP_CONFIG_FILE", config_file_path)
     config_data = {"community_sessions": {}}
     aiofiles_open_ctx = mock.AsyncMock()
-    aiofiles_open_ctx.__aenter__.return_value.read = mock.AsyncMock(return_value=json.dumps(config_data))
+    aiofiles_open_ctx.__aenter__.return_value.read = mock.AsyncMock(
+        return_value=json.dumps(config_data)
+    )
     monkeypatch.setattr(aiofiles, "open", mock.Mock(return_value=aiofiles_open_ctx))
     cm = config.ConfigManager()
     await cm.clear_config_cache()
-    with pytest.raises(config.McpConfigurationError, match="Missing required top-level keys in Deephaven MCP config: {'must_have_this'}"):
+    with pytest.raises(
+        config.McpConfigurationError,
+        match="Missing required top-level keys in Deephaven MCP config: {'must_have_this'}",
+    ):
         await cm.get_config()
+
 
 @pytest.mark.asyncio
 async def test_get_named_config_success():
@@ -1624,10 +1756,13 @@ async def test_get_named_config_success():
     result = await get_named_config(cm, "community_sessions", "foo")
     assert result == {"host": "localhost"}
 
+
 @pytest.mark.asyncio
 async def test_get_all_config_names_returns_keys():
     cm = ConfigManager()
-    config = {"community_sessions": {"a": {"host": "localhost"}, "b": {"host": "localhost"}}}
+    config = {
+        "community_sessions": {"a": {"host": "localhost"}, "b": {"host": "localhost"}}
+    }
     await cm.set_config_cache(config)
     names = await get_all_config_names(cm, "community_sessions")
     assert set(names) == {"a", "b"}
@@ -1638,25 +1773,34 @@ async def test_get_all_config_names_returns_keys():
     names3 = await get_all_config_names(cm, "enterprise_systems")
     assert names3 == []
 
+
 @pytest.mark.asyncio
 async def test_get_all_config_names_not_dict_raises():
     cm = ConfigManager()
     config = {"community_sessions": "not_a_dict"}
-    with pytest.raises(CommunitySessionConfigurationError, match="'community_sessions' must be a dictionary in Deephaven community session config"):
+    with pytest.raises(
+        CommunitySessionConfigurationError,
+        match="'community_sessions' must be a dictionary in Deephaven community session config",
+    ):
         await cm.set_config_cache(config)
+
 
 @pytest.mark.asyncio
 async def test_named_config_missing():
     cm = ConfigManager()
     config = {"community_sessions": {"foo": {"host": "localhost"}}}
     await cm.set_config_cache(config)
-    with pytest.raises(ValueError, match="Config for 'community_sessions:bar' not found in configuration"):
+    with pytest.raises(
+        ValueError,
+        match="Config for 'community_sessions:bar' not found in configuration",
+    ):
         await get_named_config(cm, "community_sessions", "bar")
 
 
 @pytest.mark.asyncio
 async def test_get_all_config_names_returns_empty_for_non_dict_section(caplog):
     from deephaven_mcp import config
+
     cm = config.ConfigManager()
     # Set a valid config
     cm._cache = {"not_a_section": "not_a_dict"}
@@ -1664,11 +1808,17 @@ async def test_get_all_config_names_returns_empty_for_non_dict_section(caplog):
     # Call with a non-dict section
     result = await get_all_config_names(cm, "not_a_section")
     assert result == []
-    assert "'not_a_section' is not a dictionary, returning empty list of names." in caplog.text
+    assert (
+        "'not_a_section' is not a dictionary, returning empty list of names."
+        in caplog.text
+    )
 
-import aiofiles
+
 import json
 from unittest import mock
+
+import aiofiles
+
 from deephaven_mcp import config
 
 
@@ -1678,7 +1828,11 @@ def test_log_config_summary_enterprise_systems_present(caplog):
     caplog.set_level("INFO", logger="deephaven_mcp.config.__init__")
     test_config = {
         "enterprise_systems": {
-            "prod": {"connection_json_url": "url", "auth_type": "api_key", "api_key": "SECRET"}
+            "prod": {
+                "connection_json_url": "url",
+                "auth_type": "api_key",
+                "api_key": "SECRET",
+            }
         }
     }
     config._log_config_summary(test_config)
@@ -1702,47 +1856,72 @@ def test_log_config_summary_no_enterprise_systems(caplog):
     config._log_config_summary({"enterprise_systems": {}})
     assert "No Enterprise Systems configured." in caplog.text
 
+
 @pytest.mark.asyncio
 async def test_load_config_from_file_filenotfound(monkeypatch):
     monkeypatch.setattr(aiofiles, "open", mock.Mock(side_effect=FileNotFoundError))
-    with pytest.raises(config.McpConfigurationError, match="Configuration file not found: /does/not/exist.json"):
+    with pytest.raises(
+        config.McpConfigurationError,
+        match="Configuration file not found: /does/not/exist.json",
+    ):
         await config._load_config_from_file("/does/not/exist.json")
+
 
 @pytest.mark.asyncio
 async def test_load_config_from_file_permissionerror(monkeypatch):
     monkeypatch.setattr(aiofiles, "open", mock.Mock(side_effect=PermissionError))
-    with pytest.raises(config.McpConfigurationError, match="Permission denied when trying to read configuration file: /no/perm.json"):
+    with pytest.raises(
+        config.McpConfigurationError,
+        match="Permission denied when trying to read configuration file: /no/perm.json",
+    ):
         await config._load_config_from_file("/no/perm.json")
+
 
 @pytest.mark.asyncio
 async def test_load_config_from_file_jsondecodeerror(monkeypatch):
     class DummyJSONDecodeError(json.JSONDecodeError):
         def __init__(self):
             super().__init__("msg", "doc", 0)
+
     aiofiles_open_ctx = mock.AsyncMock()
-    aiofiles_open_ctx.__aenter__.return_value.read = mock.AsyncMock(return_value="not json")
+    aiofiles_open_ctx.__aenter__.return_value.read = mock.AsyncMock(
+        return_value="not json"
+    )
     monkeypatch.setattr(aiofiles, "open", mock.Mock(return_value=aiofiles_open_ctx))
     orig_json_loads = json.loads
+
     def raise_json_decode_error(*args, **kwargs):
         raise DummyJSONDecodeError()
+
     monkeypatch.setattr(json, "loads", raise_json_decode_error)
-    with pytest.raises(config.McpConfigurationError, match="Invalid JSON in configuration file /bad.json"):
+    with pytest.raises(
+        config.McpConfigurationError,
+        match="Invalid JSON in configuration file /bad.json",
+    ):
         await config._load_config_from_file("/bad.json")
     monkeypatch.setattr(json, "loads", orig_json_loads)
+
 
 @pytest.mark.asyncio
 async def test_load_and_validate_config_valueerror(monkeypatch):
     # Patch validate_config to raise ValueError
-    monkeypatch.setattr(config, "validate_config", mock.Mock(side_effect=ValueError("bad value")))
+    monkeypatch.setattr(
+        config, "validate_config", mock.Mock(side_effect=ValueError("bad value"))
+    )
     aiofiles_open_ctx = mock.AsyncMock()
     aiofiles_open_ctx.__aenter__.return_value.read = mock.AsyncMock(return_value="{}")
     monkeypatch.setattr(aiofiles, "open", mock.Mock(return_value=aiofiles_open_ctx))
-    with pytest.raises(config.McpConfigurationError, match="General configuration validation error: bad value"):
+    with pytest.raises(
+        config.McpConfigurationError,
+        match="General configuration validation error: bad value",
+    ):
         await config._load_and_validate_config("/any.json")
 
 
 @pytest.mark.asyncio
-async def test_validate_enterprise_systems_config_logs_non_dict_item_in_map(monkeypatch, caplog):
+async def test_validate_enterprise_systems_config_logs_non_dict_item_in_map(
+    monkeypatch, caplog
+):
     """
     Tests that validate_enterprise_systems_config correctly logs and raises an error
     when an item within 'enterprise_systems' is not a dictionary, ensuring the
@@ -1751,16 +1930,28 @@ async def test_validate_enterprise_systems_config_logs_non_dict_item_in_map(monk
     import logging
     import re
     from unittest import mock
+
     import aiofiles
+
     from deephaven_mcp import config
+
     config_file_path = "/fake/path/enterprise_non_dict_item.json"
     monkeypatch.setenv("DH_MCP_CONFIG_FILE", config_file_path)
-    config_data = {"enterprise_systems": {
-        "good_system": {"connection_json_url": "http://good", "auth_type": "password", "username": "gooduser", "password": "goodpass"},
-        "bad_system_item": "this is not a dict"
-    }}
+    config_data = {
+        "enterprise_systems": {
+            "good_system": {
+                "connection_json_url": "http://good",
+                "auth_type": "password",
+                "username": "gooduser",
+                "password": "goodpass",
+            },
+            "bad_system_item": "this is not a dict",
+        }
+    }
     aiofiles_open_ctx = mock.AsyncMock()
-    aiofiles_open_ctx.__aenter__.return_value.read = mock.AsyncMock(return_value=json.dumps(config_data))
+    aiofiles_open_ctx.__aenter__.return_value.read = mock.AsyncMock(
+        return_value=json.dumps(config_data)
+    )
     monkeypatch.setattr(aiofiles, "open", mock.Mock(return_value=aiofiles_open_ctx))
     caplog.set_level(logging.DEBUG)
     cm = config.ConfigManager()
@@ -1770,6 +1961,12 @@ async def test_validate_enterprise_systems_config_logs_non_dict_item_in_map(monk
     specific_error_detail = "Enterprise system 'bad_system_item' configuration must be a dictionary, but got str."
     assert specific_error_detail in str(excinfo.value)
     expected_log_map_str = "{'good_system': {'connection_json_url': 'http://good', 'auth_type': 'password', 'username': 'gooduser', 'password': '[REDACTED]'}, 'bad_system_item': 'this is not a dict'}"
-    assert f"Validating enterprise_systems configuration: {expected_log_map_str}" in caplog.text
+    assert (
+        f"Validating enterprise_systems configuration: {expected_log_map_str}"
+        in caplog.text
+    )
     assert specific_error_detail in caplog.text
-    assert f"Configuration validation failed for {config_file_path}: {specific_error_detail}" in caplog.text
+    assert (
+        f"Configuration validation failed for {config_file_path}: {specific_error_detail}"
+        in caplog.text
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,8 +18,8 @@ from deephaven_mcp.config import (
     ConfigManager,
     EnterpriseSystemConfigurationError,
     McpConfigurationError,
-    _get_config_path,
-    _load_and_validate_config,
+    get_config_path,
+    load_and_validate_config,
     _load_config_from_file,
     _log_config_summary,
     get_all_config_names,
@@ -151,7 +151,7 @@ def test_community_sessions_redact():
 # --- Enterprise system validation ---
 from deephaven_mcp.config.enterprise_system import (
     _validate_and_get_auth_type,
-    _validate_single_enterprise_system,
+    validate_single_enterprise_system,
     redact_enterprise_system_config,
     validate_enterprise_systems_config,
 )
@@ -178,38 +178,38 @@ def test_enterprise_systems_invalid_system_name_type():
 
 def test_enterprise_systems_missing_connection_json_url():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system("foo", {"auth_type": "password"})
+        validate_single_enterprise_system("foo", {"auth_type": "password"})
 
 
 def test_enterprise_systems_invalid_connection_json_url_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system(
+        validate_single_enterprise_system(
             "foo", {"connection_json_url": 1, "auth_type": "password"}
         )
 
 
 def test_enterprise_systems_missing_auth_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system("foo", {"connection_json_url": "url"})
+        validate_single_enterprise_system("foo", {"connection_json_url": "url"})
 
 
 def test_enterprise_systems_invalid_auth_type_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system(
+        validate_single_enterprise_system(
             "foo", {"connection_json_url": "url", "auth_type": 1}
         )
 
 
 def test_enterprise_systems_unknown_auth_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system(
+        validate_single_enterprise_system(
             "foo", {"connection_json_url": "url", "auth_type": "badtype"}
         )
 
 
 def test_enterprise_systems_unknown_key():
     # Should log a warning but not raise
-    _validate_single_enterprise_system(
+    validate_single_enterprise_system(
         "foo",
         {
             "connection_json_url": "url",
@@ -223,7 +223,7 @@ def test_enterprise_systems_unknown_key():
 
 def test_enterprise_systems_password_auth_missing_username():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system(
+        validate_single_enterprise_system(
             "foo",
             {"connection_json_url": "url", "auth_type": "password", "password": "p"},
         )
@@ -231,7 +231,7 @@ def test_enterprise_systems_password_auth_missing_username():
 
 def test_enterprise_systems_password_auth_invalid_username_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system(
+        validate_single_enterprise_system(
             "foo",
             {
                 "connection_json_url": "url",
@@ -244,7 +244,7 @@ def test_enterprise_systems_password_auth_invalid_username_type():
 
 def test_enterprise_systems_password_auth_missing_password_keys():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system(
+        validate_single_enterprise_system(
             "foo",
             {"connection_json_url": "url", "auth_type": "password", "username": "u"},
         )
@@ -252,7 +252,7 @@ def test_enterprise_systems_password_auth_missing_password_keys():
 
 def test_enterprise_systems_password_auth_invalid_password_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system(
+        validate_single_enterprise_system(
             "foo",
             {
                 "connection_json_url": "url",
@@ -265,7 +265,7 @@ def test_enterprise_systems_password_auth_invalid_password_type():
 
 def test_enterprise_systems_password_auth_invalid_password_env_var_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system(
+        validate_single_enterprise_system(
             "foo",
             {
                 "connection_json_url": "url",
@@ -278,7 +278,7 @@ def test_enterprise_systems_password_auth_invalid_password_env_var_type():
 
 def test_enterprise_systems_password_auth_both_passwords_present():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system(
+        validate_single_enterprise_system(
             "foo",
             {
                 "connection_json_url": "url",
@@ -292,14 +292,14 @@ def test_enterprise_systems_password_auth_both_passwords_present():
 
 def test_enterprise_systems_private_key_auth_missing_key():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system(
+        validate_single_enterprise_system(
             "foo", {"connection_json_url": "url", "auth_type": "private_key"}
         )
 
 
 def test_enterprise_systems_private_key_auth_invalid_key_type():
     with pytest.raises(EnterpriseSystemConfigurationError):
-        _validate_single_enterprise_system(
+        validate_single_enterprise_system(
             "foo",
             {
                 "connection_json_url": "url",
@@ -727,7 +727,7 @@ async def test_validate_enterprise_systems_config_logs_non_dict_item_in_map(
     cm = config.ConfigManager()
     caplog.set_level(logging.DEBUG, logger="deephaven_mcp.config")
 
-    # Error from _validate_single_enterprise_system for 'bad_system_item'
+    # Error from validate_single_enterprise_system for 'bad_system_item'
     specific_error_detail = "Enterprise system 'bad_system_item' configuration must be a dictionary, but got str."
 
     with pytest.raises(
@@ -745,7 +745,7 @@ async def test_validate_enterprise_systems_config_logs_non_dict_item_in_map(
     )
     assert (
         specific_error_detail in caplog.text
-    )  # From _validate_single_enterprise_system
+    )  # From validate_single_enterprise_system
     assert (
         f"Configuration validation failed for {config_file_path}: {specific_error_detail}"
         in caplog.text
@@ -834,16 +834,16 @@ async def test_validate_enterprise_systems_config_invalid_system_name_type(caplo
     ), f"Expected ERROR log message '{specific_error_detail}' not found from enterprise_system logger."
 
 
-def test_validate_single_enterprise_system_missing_connection_json_url(caplog):
+def testvalidate_single_enterprise_system_missing_connection_json_url(caplog):
     """
-    Tests _validate_single_enterprise_system when 'connection_json_url' is missing.
+    Tests validate_single_enterprise_system when 'connection_json_url' is missing.
     """
     import logging
     import re
 
     from deephaven_mcp.config.enterprise_system import (
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)  # Capture all logs for thorough checking
@@ -856,7 +856,7 @@ def test_validate_single_enterprise_system_missing_connection_json_url(caplog):
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -872,16 +872,16 @@ def test_validate_single_enterprise_system_missing_connection_json_url(caplog):
     ), f"Expected ERROR log message '{expected_error_message}' not found. Logs: {caplog.text}"
 
 
-def test_validate_single_enterprise_system_invalid_connection_json_url_type(caplog):
+def testvalidate_single_enterprise_system_invalid_connection_json_url_type(caplog):
     """
-    Tests _validate_single_enterprise_system when 'connection_json_url' is not a string.
+    Tests validate_single_enterprise_system when 'connection_json_url' is not a string.
     """
     import logging
     import re
 
     from deephaven_mcp.config.enterprise_system import (
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -901,7 +901,7 @@ def test_validate_single_enterprise_system_invalid_connection_json_url_type(capl
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -917,16 +917,16 @@ def test_validate_single_enterprise_system_invalid_connection_json_url_type(capl
     ), f"Expected ERROR log message '{expected_error_message}' not found. Logs: {caplog.text}"
 
 
-def test_validate_single_enterprise_system_missing_auth_type(caplog):
+def testvalidate_single_enterprise_system_missing_auth_type(caplog):
     """
-    Tests _validate_single_enterprise_system when 'auth_type' is missing.
+    Tests validate_single_enterprise_system when 'auth_type' is missing.
     """
     import logging
     import re
 
     from deephaven_mcp.config.enterprise_system import (
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -943,7 +943,7 @@ def test_validate_single_enterprise_system_missing_auth_type(caplog):
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -959,16 +959,16 @@ def test_validate_single_enterprise_system_missing_auth_type(caplog):
     ), f"Expected ERROR log message '{expected_error_message}' not found. Logs: {caplog.text}"
 
 
-def test_validate_single_enterprise_system_invalid_auth_type_type(caplog):
+def testvalidate_single_enterprise_system_invalid_auth_type_type(caplog):
     """
-    Tests _validate_single_enterprise_system when 'auth_type' is not a string.
+    Tests validate_single_enterprise_system when 'auth_type' is not a string.
     """
     import logging
     import re
 
     from deephaven_mcp.config.enterprise_system import (
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -986,7 +986,7 @@ def test_validate_single_enterprise_system_invalid_auth_type_type(caplog):
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -1002,9 +1002,9 @@ def test_validate_single_enterprise_system_invalid_auth_type_type(caplog):
     ), f"Expected ERROR log message '{expected_error_message}' not found. Logs: {caplog.text}"
 
 
-def test_validate_single_enterprise_system_unknown_auth_type_value(caplog):
+def testvalidate_single_enterprise_system_unknown_auth_type_value(caplog):
     """
-    Tests _validate_single_enterprise_system when 'auth_type' is an unknown string value.
+    Tests validate_single_enterprise_system when 'auth_type' is an unknown string value.
     """
     import logging
     import re
@@ -1012,7 +1012,7 @@ def test_validate_single_enterprise_system_unknown_auth_type_value(caplog):
     from deephaven_mcp.config.enterprise_system import (
         _AUTH_SPECIFIC_FIELDS,
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -1028,7 +1028,7 @@ def test_validate_single_enterprise_system_unknown_auth_type_value(caplog):
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -1044,14 +1044,14 @@ def test_validate_single_enterprise_system_unknown_auth_type_value(caplog):
     ), f"Expected ERROR log message '{expected_error_message}' not found. Logs: {caplog.text}"
 
 
-def test_validate_single_enterprise_system_unknown_key(caplog):
+def testvalidate_single_enterprise_system_unknown_key(caplog):
     """
-    Tests _validate_single_enterprise_system logs a warning for an unknown key.
+    Tests validate_single_enterprise_system logs a warning for an unknown key.
     """
     import logging
 
     from deephaven_mcp.config.enterprise_system import (
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.WARNING)  # We only care about the warning here
@@ -1066,7 +1066,7 @@ def test_validate_single_enterprise_system_unknown_key(caplog):
     expected_warning_message = f"Unknown field 'some_unknown_field' in enterprise system '{system_name}' configuration. It will be ignored."
 
     # This should not raise an error, only log a warning
-    _validate_single_enterprise_system(system_name, config_with_unknown_key)
+    validate_single_enterprise_system(system_name, config_with_unknown_key)
 
     found_log = False
     for record in caplog.records:
@@ -1082,11 +1082,11 @@ def test_validate_single_enterprise_system_unknown_key(caplog):
     ), f"Expected WARNING log message '{expected_warning_message}' not found. Logs: {caplog.text}"
 
 
-def test_validate_single_enterprise_system_base_field_invalid_tuple_type(
+def testvalidate_single_enterprise_system_base_field_invalid_tuple_type(
     monkeypatch, caplog
 ):
     """
-    Tests _validate_single_enterprise_system when a base field expects a tuple of types
+    Tests validate_single_enterprise_system when a base field expects a tuple of types
     and an invalid type is provided.
     """
     import logging
@@ -1095,7 +1095,7 @@ def test_validate_single_enterprise_system_base_field_invalid_tuple_type(
     from deephaven_mcp.config import enterprise_system  # Import the module itself
     from deephaven_mcp.config.enterprise_system import (
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -1127,7 +1127,7 @@ def test_validate_single_enterprise_system_base_field_invalid_tuple_type(
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -1148,11 +1148,11 @@ def test_validate_single_enterprise_system_base_field_invalid_tuple_type(
     )
 
 
-def test_validate_single_enterprise_system_auth_specific_field_invalid_tuple_type(
+def testvalidate_single_enterprise_system_auth_specific_field_invalid_tuple_type(
     monkeypatch, caplog
 ):
     """
-    Tests _validate_single_enterprise_system when an auth-specific field expects a tuple of types
+    Tests validate_single_enterprise_system when an auth-specific field expects a tuple of types
     and an invalid type is provided.
     """
     import logging
@@ -1162,7 +1162,7 @@ def test_validate_single_enterprise_system_auth_specific_field_invalid_tuple_typ
     from deephaven_mcp.config.enterprise_system import (
         _AUTH_SPECIFIC_FIELDS,
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -1200,7 +1200,7 @@ def test_validate_single_enterprise_system_auth_specific_field_invalid_tuple_typ
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -1221,9 +1221,9 @@ def test_validate_single_enterprise_system_auth_specific_field_invalid_tuple_typ
     )
 
 
-def test_validate_single_enterprise_system_password_auth_missing_username(caplog):
+def testvalidate_single_enterprise_system_password_auth_missing_username(caplog):
     """
-    Tests _validate_single_enterprise_system for auth_type 'password'
+    Tests validate_single_enterprise_system for auth_type 'password'
     when 'username' is missing.
     """
     import logging
@@ -1231,7 +1231,7 @@ def test_validate_single_enterprise_system_password_auth_missing_username(caplog
 
     from deephaven_mcp.config.enterprise_system import (
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -1247,7 +1247,7 @@ def test_validate_single_enterprise_system_password_auth_missing_username(caplog
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -1263,9 +1263,9 @@ def test_validate_single_enterprise_system_password_auth_missing_username(caplog
     ), f"Expected ERROR log message '{expected_error_message}' not found. Logs: {caplog.text}"
 
 
-def test_validate_single_enterprise_system_password_auth_invalid_username_type(caplog):
+def testvalidate_single_enterprise_system_password_auth_invalid_username_type(caplog):
     """
-    Tests _validate_single_enterprise_system for auth_type 'password'
+    Tests validate_single_enterprise_system for auth_type 'password'
     when 'username' has an invalid type.
     """
     import logging
@@ -1273,7 +1273,7 @@ def test_validate_single_enterprise_system_password_auth_invalid_username_type(c
 
     from deephaven_mcp.config.enterprise_system import (
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -1290,7 +1290,7 @@ def test_validate_single_enterprise_system_password_auth_invalid_username_type(c
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -1306,9 +1306,9 @@ def test_validate_single_enterprise_system_password_auth_invalid_username_type(c
     ), f"Expected ERROR log message '{expected_error_message}' not found. Logs: {caplog.text}"
 
 
-def test_validate_single_enterprise_system_password_auth_missing_password_keys(caplog):
+def testvalidate_single_enterprise_system_password_auth_missing_password_keys(caplog):
     """
-    Tests _validate_single_enterprise_system for auth_type 'password'
+    Tests validate_single_enterprise_system for auth_type 'password'
     when both 'password' and 'password_env_var' are missing.
     """
     import logging
@@ -1316,7 +1316,7 @@ def test_validate_single_enterprise_system_password_auth_missing_password_keys(c
 
     from deephaven_mcp.config.enterprise_system import (
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -1333,7 +1333,7 @@ def test_validate_single_enterprise_system_password_auth_missing_password_keys(c
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -1349,9 +1349,9 @@ def test_validate_single_enterprise_system_password_auth_missing_password_keys(c
     ), f"Expected ERROR log message '{expected_error_message}' not found. Logs: {caplog.text}"
 
 
-def test_validate_single_enterprise_system_password_auth_invalid_password_type(caplog):
+def testvalidate_single_enterprise_system_password_auth_invalid_password_type(caplog):
     """
-    Tests _validate_single_enterprise_system for auth_type 'password'
+    Tests validate_single_enterprise_system for auth_type 'password'
     when 'password' has an invalid type.
     """
     import logging
@@ -1359,7 +1359,7 @@ def test_validate_single_enterprise_system_password_auth_invalid_password_type(c
 
     from deephaven_mcp.config.enterprise_system import (
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -1377,7 +1377,7 @@ def test_validate_single_enterprise_system_password_auth_invalid_password_type(c
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -1393,11 +1393,11 @@ def test_validate_single_enterprise_system_password_auth_invalid_password_type(c
     ), f"Expected ERROR log message '{expected_error_message}' not found. Logs: {caplog.text}"
 
 
-def test_validate_single_enterprise_system_password_auth_invalid_password_env_var_type(
+def testvalidate_single_enterprise_system_password_auth_invalid_password_env_var_type(
     caplog,
 ):
     """
-    Tests _validate_single_enterprise_system for auth_type 'password'
+    Tests validate_single_enterprise_system for auth_type 'password'
     when 'password_env_var' has an invalid type.
     """
     import logging
@@ -1405,7 +1405,7 @@ def test_validate_single_enterprise_system_password_auth_invalid_password_env_va
 
     from deephaven_mcp.config.enterprise_system import (
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -1423,7 +1423,7 @@ def test_validate_single_enterprise_system_password_auth_invalid_password_env_va
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -1439,9 +1439,9 @@ def test_validate_single_enterprise_system_password_auth_invalid_password_env_va
     ), f"Expected ERROR log message '{expected_error_message}' not found. Logs: {caplog.text}"
 
 
-def test_validate_single_enterprise_system_private_key_auth_missing_key(caplog):
+def testvalidate_single_enterprise_system_private_key_auth_missing_key(caplog):
     """
-    Tests _validate_single_enterprise_system for auth_type 'private_key'
+    Tests validate_single_enterprise_system for auth_type 'private_key'
     when 'private_key' is missing.
     """
     import logging
@@ -1449,7 +1449,7 @@ def test_validate_single_enterprise_system_private_key_auth_missing_key(caplog):
 
     from deephaven_mcp.config.enterprise_system import (
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -1465,7 +1465,7 @@ def test_validate_single_enterprise_system_private_key_auth_missing_key(caplog):
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -1481,9 +1481,9 @@ def test_validate_single_enterprise_system_private_key_auth_missing_key(caplog):
     ), f"Expected ERROR log message '{expected_error_message}' not found. Logs: {caplog.text}"
 
 
-def test_validate_single_enterprise_system_private_key_auth_invalid_key_type(caplog):
+def testvalidate_single_enterprise_system_private_key_auth_invalid_key_type(caplog):
     """
-    Tests _validate_single_enterprise_system for auth_type 'private_key'
+    Tests validate_single_enterprise_system for auth_type 'private_key'
     when 'private_key' has an invalid type.
     """
     import logging
@@ -1491,7 +1491,7 @@ def test_validate_single_enterprise_system_private_key_auth_invalid_key_type(cap
 
     from deephaven_mcp.config.enterprise_system import (
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -1508,7 +1508,7 @@ def test_validate_single_enterprise_system_private_key_auth_invalid_key_type(cap
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -1524,9 +1524,9 @@ def test_validate_single_enterprise_system_private_key_auth_invalid_key_type(cap
     ), f"Expected ERROR log message '{expected_error_message}' not found. Logs: {caplog.text}"
 
 
-def test_validate_single_enterprise_system_password_auth_both_passwords_present(caplog):
+def testvalidate_single_enterprise_system_password_auth_both_passwords_present(caplog):
     """
-    Tests _validate_single_enterprise_system for auth_type 'password'
+    Tests validate_single_enterprise_system for auth_type 'password'
     when both 'password' and 'password_env_var' are present.
     """
     import logging
@@ -1534,7 +1534,7 @@ def test_validate_single_enterprise_system_password_auth_both_passwords_present(
 
     from deephaven_mcp.config.enterprise_system import (
         EnterpriseSystemConfigurationError,
-        _validate_single_enterprise_system,
+        validate_single_enterprise_system,
     )
 
     caplog.set_level(logging.DEBUG)
@@ -1552,7 +1552,7 @@ def test_validate_single_enterprise_system_password_auth_both_passwords_present(
         EnterpriseSystemConfigurationError,
         match=re.escape(expected_error_message),
     ):
-        _validate_single_enterprise_system(system_name, invalid_config)
+        validate_single_enterprise_system(system_name, invalid_config)
 
     found_log = False
     for record in caplog.records:
@@ -1699,11 +1699,11 @@ async def test_config_manager_set_and_clear_cache():
     from deephaven_mcp import config
 
     cm = config.ConfigManager()
-    await cm.set_config_cache({"community_sessions": {"a_session": {}}})
+    await cm._set_config_cache({"community_sessions": {"a_session": {}}})
     cfg1 = await cm.get_config()
     assert "a_session" in cfg1["community_sessions"]
     await cm.clear_config_cache()
-    await cm.set_config_cache({"community_sessions": {"b_session": {}}})
+    await cm._set_config_cache({"community_sessions": {"b_session": {}}})
     cfg2 = await cm.get_config()
     assert "b_session" in cfg2["community_sessions"]
     assert "a_session" not in cfg2["community_sessions"]
@@ -1752,7 +1752,7 @@ async def test_validate_config_missing_required_key_runtime(monkeypatch, caplog)
 async def test_get_named_config_success():
     cm = ConfigManager()
     config = {"community_sessions": {"foo": {"host": "localhost"}}}
-    await cm.set_config_cache(config)
+    await cm._set_config_cache(config)
     result = await get_named_config(cm, "community_sessions", "foo")
     assert result == {"host": "localhost"}
 
@@ -1763,13 +1763,13 @@ async def test_get_all_config_names_returns_keys():
     config = {
         "community_sessions": {"a": {"host": "localhost"}, "b": {"host": "localhost"}}
     }
-    await cm.set_config_cache(config)
+    await cm._set_config_cache(config)
     names = await get_all_config_names(cm, "community_sessions")
     assert set(names) == {"a", "b"}
-    await cm.set_config_cache({"community_sessions": {}})
+    await cm._set_config_cache({"community_sessions": {}})
     names2 = await get_all_config_names(cm, "community_sessions")
     assert names2 == []
-    await cm.set_config_cache({"community_sessions": {}})
+    await cm._set_config_cache({"community_sessions": {}})
     names3 = await get_all_config_names(cm, "enterprise_systems")
     assert names3 == []
 
@@ -1782,14 +1782,14 @@ async def test_get_all_config_names_not_dict_raises():
         CommunitySessionConfigurationError,
         match="'community_sessions' must be a dictionary in Deephaven community session config",
     ):
-        await cm.set_config_cache(config)
+        await cm._set_config_cache(config)
 
 
 @pytest.mark.asyncio
 async def test_named_config_missing():
     cm = ConfigManager()
     config = {"community_sessions": {"foo": {"host": "localhost"}}}
-    await cm.set_config_cache(config)
+    await cm._set_config_cache(config)
     with pytest.raises(
         ValueError,
         match="Config for 'community_sessions:bar' not found in configuration",
@@ -1903,7 +1903,7 @@ async def test_load_config_from_file_jsondecodeerror(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_load_and_validate_config_valueerror(monkeypatch):
+async def testload_and_validate_config_valueerror(monkeypatch):
     # Patch validate_config to raise ValueError
     monkeypatch.setattr(
         config, "validate_config", mock.Mock(side_effect=ValueError("bad value"))
@@ -1915,7 +1915,7 @@ async def test_load_and_validate_config_valueerror(monkeypatch):
         config.McpConfigurationError,
         match="General configuration validation error: bad value",
     ):
-        await config._load_and_validate_config("/any.json")
+        await config.load_and_validate_config("/any.json")
 
 
 @pytest.mark.asyncio

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,12 +18,12 @@ from deephaven_mcp.config import (
     ConfigManager,
     EnterpriseSystemConfigurationError,
     McpConfigurationError,
-    get_config_path,
-    load_and_validate_config,
     _load_config_from_file,
     _log_config_summary,
     get_all_config_names,
+    get_config_path,
     get_named_config,
+    load_and_validate_config,
     validate_config,
 )
 
@@ -151,9 +151,9 @@ def test_community_sessions_redact():
 # --- Enterprise system validation ---
 from deephaven_mcp.config.enterprise_system import (
     _validate_and_get_auth_type,
-    validate_single_enterprise_system,
     redact_enterprise_system_config,
     validate_enterprise_systems_config,
+    validate_single_enterprise_system,
 )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1903,7 +1903,7 @@ async def test_load_config_from_file_jsondecodeerror(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def testload_and_validate_config_valueerror(monkeypatch):
+async def test_load_and_validate_config_valueerror(monkeypatch):
     # Patch validate_config to raise ValueError
     monkeypatch.setattr(
         config, "validate_config", mock.Mock(side_effect=ValueError("bad value"))


### PR DESCRIPTION
This pull request introduces changes to streamline configuration handling for community and enterprise session management in the Deephaven MCP project. The most significant updates include replacing direct calls to specific configuration methods with a unified `get_config` approach, exposing key functions via `__all__` for better module clarity, and enhancing test coverage to reflect these changes.

### Configuration Handling Updates:
* Replaced `get_community_session_names` and `get_community_session_config` with the unified `config.get_all_config_names` and `config.get_named_config` methods for community session management. (`src/deephaven_mcp/community/_mcp.py` [[1]](diffhunk://#diff-9a2050f2673136ead557592d59eafd6d855fe46204438df53705d4cd99257decL221-R221) `src/deephaven_mcp/community/_sessions.py` [[2]](diffhunk://#diff-ccef280987eeb21432a1fe788e318ffcd717775ebc97df8d5924cb79342f4801L459-R460)

### Codebase Improvements:
* Updated `src/deephaven_mcp/config/community_session.py` and `src/deephaven_mcp/config/enterprise_system.py` to expose key functions (`validate_community_sessions_config`, `validate_single_community_session_config`, etc.) via `__all__` for improved module clarity and usability. [[1]](diffhunk://#diff-193eabd27f105adb7ef66c105e59fd7fdc1d885529073da2987769a0428deb4cR11-R16) [[2]](diffhunk://#diff-b0bf8cb171321efb06b7709078b0948a55007610cd647bfd30e5feb790c40eadR5-R11)
* Renamed `_validate_single_enterprise_system` to `validate_single_enterprise_system` and updated its references to align with the new naming convention. (`src/deephaven_mcp/config/enterprise_system.py` [src/deephaven_mcp/config/enterprise_system.pyL120-R134](diffhunk://#diff-b0bf8cb171321efb06b7709078b0948a55007610cd647bfd30e5feb790c40eadL120-R134))

### Test Enhancements:
* Updated multiple test cases in `tests/test_community__mcp.py` and `tests/test_community_sessions.py` to mock `get_config` calls, ensuring compatibility with the new configuration handling approach. [[1]](diffhunk://#diff-8fb7ab7933893868f37ea6ecbbda7900b4626ae39f2c3f56e86362de85ed47b2R151-R158) [[2]](diffhunk://#diff-8fb7ab7933893868f37ea6ecbbda7900b4626ae39f2c3f56e86362de85ed47b2R200-R207) [[3]](diffhunk://#diff-03ec126d591c36f5b07ca39279f31ebb8c3e591d39130ed270bbca48f6a21743R280-R282) [[4]](diffhunk://#diff-03ec126d591c36f5b07ca39279f31ebb8c3e591d39130ed270bbca48f6a21743R460-R462)
* Enhanced test coverage by adding new assertions and mocking additional configuration scenarios, such as handling unavailable workers and version mismatches. [[1]](diffhunk://#diff-8fb7ab7933893868f37ea6ecbbda7900b4626ae39f2c3f56e86362de85ed47b2R367-R375) [[2]](diffhunk://#diff-03ec126d591c36f5b07ca39279f31ebb8c3e591d39130ed270bbca48f6a21743R500-R503)

These changes improve maintainability, consistency, and test coverage across the codebase.