### PR TITLE
refactor: restructure config schema to use nested sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,3 +412,4 @@ We warmly welcome contributions to Deephaven MCP! Whether it's bug reports, feat
 ## License
 
 This project is licensed under the [Apache 2.0 License](./LICENSE). See the [LICENSE](./LICENSE) file for details.
+

--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ This section explains how to configure the [Deephaven MCP Systems Server](#commu
 The [Deephaven MCP Systems Server](#community-server) requires a JSON configuration file that describes the [Deephaven Community Core](https://deephaven.io/) worker instances it can connect to. 
 
 *   The file must be a JSON object. It can be an empty object `{}` if no community sessions are to be configured.
-*   Optionally, it can contain a top-level key named `"community_sessions"`.
+*   Optionally, it can contain a top-level key named `"community"` with a nested `"sessions"` key.
     *   If this key is present, its value must be an object (which can be empty, e.g., `{}`) where each key is a unique session name (e.g., `"local_session"`, `"prod_cluster_1_session"`) and the value is a configuration object for that session. An empty object signifies no sessions are configured under this key.
     *   If this key is absent from the JSON file, it is treated as a valid configuration with no community sessions defined.
 
-In addition to `"community_sessions"`, the `deephaven_mcp.json` file can optionally include an `"enterprise_systems"` key for configuring connections to Deephaven Enterprise instances. The configuration details for both `community_sessions` and `enterprise_systems` are provided below.
+In addition to `"community"`, the `deephaven_mcp.json` file can optionally include an `"enterprise"` key with a nested `"systems"` key for configuring connections to Deephaven Enterprise instances. The configuration details for both `community.sessions` and `enterprise.systems` are provided below.
 
 #### Community Session Configuration Fields
 
@@ -160,7 +160,7 @@ In addition to `"community_sessions"`, the `deephaven_mcp.json` file can optiona
 
 #### Enterprise System Configuration Fields
 
-The `enterprise_systems` key in `deephaven_mcp.json` is a dictionary mapping custom system names (e.g., `"prod_cluster"`, `"data_science_env"`) to their specific configuration objects. Each configuration object supports the following fields:
+The `enterprise` key with nested `"systems"` in `deephaven_mcp.json` is a dictionary mapping custom system names (e.g., `"prod_cluster"`, `"data_science_env"`) to their specific configuration objects. Each configuration object supports the following fields:
 
 **Required Fields:**
 
@@ -185,32 +185,36 @@ The `enterprise_systems` key in `deephaven_mcp.json` is a dictionary mapping cus
 
 ```json
 {
-  "community_sessions": {
-    "my_local_deephaven": {
-      "host": "localhost",
-      "port": 10000,
-      "session_type": "python"
-    },
-    "secure_community_worker": {
-      "host": "secure.deephaven.example.com",
-      "port": 10001,
-      "auth_type": "token",
-      "auth_token": "your-community-secret-api-token-here",
-      "use_tls": true,
-      "tls_root_certs": "/path/to/community_root.crt"
+  "community": {
+    "sessions": {
+      "my_local_deephaven": {
+        "host": "localhost",
+        "port": 10000,
+        "session_type": "python"
+      },
+      "secure_community_worker": {
+        "host": "secure.deephaven.example.com",
+        "port": 10001,
+        "auth_type": "token",
+        "auth_token": "your-community-secret-api-token-here",
+        "use_tls": true,
+        "tls_root_certs": "/path/to/community_root.crt"
+      }
     }
   },
-  "enterprise_sessions": {
-    "prod_enterprise_cluster": {
-      "connection_json_url": "https://enterprise.example.com/iris/connection.json",
-      "auth_type": "api_key",
-      "api_key_env_var": "PROD_ENTERPRISE_API_KEY"
-    },
-    "staging_enterprise_env": {
-      "connection_json_url": "https://staging.enterprise.example.com/iris/connection.json",
-      "auth_type": "password",
-      "username": "testuser",
-      "password_env_var": "STAGING_USER_PASSWORD"
+  "enterprise": {
+    "systems": {
+      "prod_cluster": {
+        "connection_json_url": "https://prod.enterprise.example.com/iris/connection.json",
+        "auth_type": "password",
+        "username": "your_username",
+        "password_env_var": "ENTERPRISE_PASSWORD"
+      },
+      "data_science_env": {
+        "connection_json_url": "https://data-science.enterprise.example.com/iris/connection.json",
+        "auth_type": "private_key",
+        "private_key_path": "/path/to/your/private_key.pem"
+      }
     }
   }
 }

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -141,10 +141,12 @@ Users or API clients send natural language questions or documentation queries ov
    Create a JSON configuration file for your Deephaven MCP:
    ```json
    {
-     "community_sessions": {
-       "local_session": {
-         "host": "localhost",
-         "port": 10000
+     "community": {
+       "sessions": {
+         "local_session": {
+           "host": "localhost",
+           "port": 10000
+         }
        }
      }
    }
@@ -232,16 +234,16 @@ The Systems Server's behavior, particularly how it finds its configuration, can 
 
 ###### File Structure Overview
 
-The `deephaven_mcp.json` file is a JSON object that can contain two primary top-level keys: `"community_sessions"` and `"enterprise_sessions"`. Both are optional.
+The `deephaven_mcp.json` file is a JSON object that can contain two primary top-level keys: `"community"` and `"enterprise"`. Both are optional.
 
-*   `"community_sessions"`: If present, its value must be an object mapping user-defined session names to their specific configurations for Deephaven Community Core instances. Details for these configurations are below.
-*   `"enterprise_sessions"`: If present, its value must be an object mapping user-defined session names to their specific configurations for Deephaven Enterprise instances. Details for these configurations are provided in a subsequent section.
+*   `"community"`: If present, its value must be an object containing a `"sessions"` key that maps user-defined session names to their specific configurations for Deephaven Community Core instances. Details for these configurations are below.
+*   `"enterprise"`: If present, its value must be an object containing a `"systems"` key that maps user-defined system names to their specific configurations for Deephaven Enterprise instances. Details for these configurations are provided in a subsequent section.
 
 If both keys are absent, or if the `deephaven_mcp.json` file itself is an empty JSON object (e.g., `{}`), it signifies that no sessions of either type are configured. This is a valid state.
 
 #### Systems Sessions Configuration
 
-This section details the configuration for individual sessions listed under the `"community_sessions"` key in the `deephaven_mcp.json` file.
+This section details the configuration for individual sessions listed under the `"community"` → `"sessions"` key in the `deephaven_mcp.json` file.
 
 **Systems Session Configuration Fields:**
 
@@ -266,24 +268,26 @@ All fields within a session's configuration object are optional. If a field is o
 
 ```json
 {
-  "community_sessions": {
-    "my_local_deephaven": {
-      "host": "localhost",
-      "port": 10000,
-      "session_type": "python"
-    },
-    "secure_remote_worker": {
-      "host": "secure.deephaven.example.com",
-      "port": 10001,
-      "auth_type": "token",
-      // "auth_token": "your-secret-api-token-here", // Option 1: Direct token (less secure for shared configs)
-      "auth_token_env_var": "MY_REMOTE_TOKEN_ENV_VAR", // Option 2: Token from environment variable (recommended)
-      "never_timeout": true,
-      "session_type": "groovy",
-      "use_tls": true,
-      "tls_root_certs": "/path/to/trusted_cas.pem",
-      "client_cert_chain": "/path/to/client_cert_and_chain.pem",
-      "client_private_key": "/path/to/client_private_key.pem"
+  "community": {
+    "sessions": {
+      "my_local_deephaven": {
+        "host": "localhost",
+        "port": 10000,
+        "session_type": "python"
+      },
+      "secure_remote_worker": {
+        "host": "secure.deephaven.example.com",
+        "port": 10001,
+        "auth_type": "token",
+        // "auth_token": "your-secret-api-token-here", // Option 1: Direct token (less secure for shared configs)
+        "auth_token_env_var": "MY_REMOTE_TOKEN_ENV_VAR", // Option 2: Token from environment variable (recommended)
+        "never_timeout": true,
+        "session_type": "groovy",
+        "use_tls": true,
+        "tls_root_certs": "/path/to/trusted_cas.pem",
+        "client_cert_chain": "/path/to/client_cert_and_chain.pem",
+        "client_private_key": "/path/to/client_private_key.pem"
+      }
     }
   }
 }
@@ -291,9 +295,9 @@ All fields within a session's configuration object are optional. If a field is o
 
 #### Enterprise Server Configuration
 
-The `deephaven_mcp.json` file can also optionally include a top-level key named `"enterprise_systems"` to configure connections to Deephaven Enterprise instances. This key holds a dictionary where each entry maps a custom system name (e.g., `"prod_cluster"`, `"data_science_env"`) to its specific configuration object.
+The `deephaven_mcp.json` file can also optionally include a top-level key named `"enterprise"` to configure connections to Deephaven Enterprise instances. This key holds a dictionary where each entry maps a custom system name (e.g., `"prod_cluster"`, `"data_science_env"`) to its specific configuration object.
 
-If the `"enterprise_systems"` key is present, it must be a dictionary. Each individual enterprise system configuration within this dictionary supports the following fields:
+If the `"enterprise"` key is present, it must be a dictionary. Each individual enterprise system configuration within this dictionary supports the following fields:
 
 *   `connection_json_url` (string, **required**): The URL pointing to the `connection.json` file of the Deephaven Enterprise server. This file provides necessary connection details for the client.
     *   Example: `"https://enterprise.example.com/iris/connection.json"`
@@ -314,23 +318,27 @@ If the `"enterprise_systems"` key is present, it must be a dictionary. Each indi
 
 ```json
 {
-  "community_sessions": {
-    "local_dev": {
-      "host": "localhost",
-      "port": 10000
+  "community": {
+    "sessions": {
+      "local_dev": {
+        "host": "localhost",
+        "port": 10000
+      }
     }
   },
-  "enterprise_systems": {
-    "staging_env": {
-      "connection_json_url": "https://staging.internal/iris/connection.json",
-      "auth_type": "password",
-      "username": "test_user",
-      "password_env_var": "STAGING_PASSWORD"
-    },
-    "analytics_private_key_auth": {
+  "enterprise": {
+    "systems": {
+      "staging_env": {
+        "connection_json_url": "https://staging.internal/iris/connection.json",
+        "auth_type": "password",
+        "username": "test_user",
+        "password_env_var": "STAGING_PASSWORD"
+      },
+      "analytics_private_key_auth": {
         "connection_json_url": "https://analytics.dept.com/iris/connection.json",
         "auth_type": "private_key",
         "private_key_path": "/secure/keys/analytics_service_account.key"
+      }
     }
   }
 }
@@ -1180,7 +1188,7 @@ uv run isort . --skip _version.py --skip .venv
 uv run isort . --check-only --diff --skip _version.py --skip .venv
 
 # Format code (fixes in place)
-uv run black .
+uv run black . --exclude '(_version.py|.venv)'
 # Check formatting only (no changes)
 uv run black . --check
 
@@ -1198,54 +1206,48 @@ deephaven-mcp/
 │   └── deephaven_mcp/
 │       ├── __init__.py
 │       ├── _version.py
-│       ├── config/                  # Configuration management and validation
+│       ├── config/                    # Configuration management and validation
 │       │   ├── __init__.py
-│       │   ├── community_session.py
-│       │   ├── enterprise_system.py
-│       │   └── errors.py
-│       ├── mcp_docs_server/         # Docs Server module
+│       │   ├── _community_session.py
+│       │   ├── _enterprise_system.py
+│       │   └── _errors.py
+│       ├── io.py                     # I/O utilities
+│       ├── mcp_docs_server/          # Docs Server module
 │       │   ├── __init__.py
 │       │   └── _mcp.py
-│       ├── mcp_systems_server/      # Systems Server module
+│       ├── mcp_systems_server/       # Systems Server module
 │       │   ├── __init__.py
-│       │   ├── _mcp.py
-│       │   └── _sessions.py
-│       ├── enterprise/              # Enterprise Server module
-│       │   └── __init__.py
-│       └── openai.py                # OpenAI API client for LLM integration
+│       │   └── _mcp.py
+│       ├── openai.py                 # OpenAI API client for LLM integration
+│       └── sessions/                 # Session management
+│           ├── __init__.py
+│           ├── _errors.py
+│           ├── _lifecycle/
+│           │   ├── __init__.py
+│           │   ├── community.py
+│           │   └── shared.py
+│           ├── _queries.py
+│           └── _sessions.py
 ├── tests/                           # Unit and integration tests
-│   ├── test__version.py
-│   ├── test_config.py
-│   ├── test_config__community_session.py
-│   ├── test_config__enterprise_system.py
-│   ├── test_config_errors.py
-│   ├── test_mcp_docs_server_init.py
-│   ├── test_mcp_docs_server_mcp.py
-│   ├── test_enterprise_init.py
-│   ├── test_openai.py
-│   ├── test_package_init.py
-│   ├── test_mcp_systems_server__mcp.py
-│   ├── test_mcp_systems_server_init.py
-│   └── test_mcp_systems_server_sessions.py
-├── scripts/                         # Utility scripts for dev and testing
-│   ├── run_deephaven_test_server.py
-│   ├── mcp_community_test_client.py
-│   ├── mcp_docs_test_client.py
-│   └── mcp_docs_stress_sse.py
-├── ops/
+│   ├── config/
+│   ├── lifecycle/
+│   ├── mcp_docs_server/
+│   ├── mcp_systems_server/
+│   ├── openai_tests/
+│   ├── package/
+│   ├── queries/
+│   ├── sessions/
+│   └── testio/
+├── ops/                             # Operations and deployment
 │   ├── docker/
-│   │   └── mcp-docs/
-│   │       ├── Dockerfile            # Dockerfile for the MCP Docs server
-│   │       ├── docker-compose.yml    # Docker Compose config for the MCP Docs server
-│   │       └── README.md             # Docker usage notes for the MCP Docs server
 │   └── terraform/
-│       ├── backend-bucket/           # Terraform configs for GCS backend state
-│       ├── docker-repo/              # Terraform configs for Docker Artifact Registry
-│       └── mcp-docs/                 # Terraform configs for MCP Docs infra (Cloud Run, DNS, etc.)
-├── docs/                         # Documentation
-│   └── DEVELOPER_GUIDE.md        # This developer & contributor guide
-├── pyproject.toml                # Package metadata and dependencies
-└── README.md                     # Main user-facing README
+├── docs/                            # Documentation
+│   ├── DEVELOPER_GUIDE.md
+│   └── UV.md
+├── scripts/                         # Utility scripts
+├── pyproject.toml                   # Python project configuration
+├── README.md
+└── ...
 ```
 
 #### Script References

--- a/src/deephaven_mcp/config/__init__.py
+++ b/src/deephaven_mcp/config/__init__.py
@@ -7,7 +7,7 @@ Configuration is loaded from a file specified by the DH_MCP_CONFIG_FILE environm
 Features:
     - Coroutine-safe, cached loading of configuration using asyncio.Lock.
     - Strict validation of configuration structure and values.
-    - Helper functions to access community session-specific config, and community session names.
+    - Helper functions to access configuration sections and retrieve configuration names.
     - Logging of configuration loading, environment variable value, and validation steps.
     - Uses aiofiles for non-blocking, native async config file reads.
 
@@ -15,28 +15,34 @@ Configuration Schema:
 ---------------------
 The configuration file must be a JSON object. It may contain the following top-level keys:
 
-  - `community_sessions` (dict, optional):
-      A dictionary mapping community session names (str) to client session configuration dicts.
+  - `community` (dict, optional):
+      A dictionary mapping community configuration.
       If this key is present, its value must be a dictionary (which can be empty, e.g., {}).
-      If this key is absent, it implies no community sessions are configured.
-      Each community session configuration dict may contain any of the following fields (all are optional):
+      If this key is absent, it implies no community configuration is present.
+      Each community configuration dict may contain any of the following fields (all are optional):
 
-        - `host` (str): Hostname or IP address of the community worker.
-        - `port` (int): Port number for the community worker connection.
-        - `auth_type` (str): Authentication type. Allowed values include:
-            * "token": Use a bearer token for authentication.
-            * "basic": Use HTTP Basic authentication.
-            * "anonymous": No authentication required.
-        - `auth_token` (str, optional): The direct authentication token or password. May be empty if `auth_type` is "anonymous". Use this OR `auth_token_env_var`, but not both.
-        - `auth_token_env_var` (str, optional): The name of an environment variable from which to read the authentication token. Use this OR `auth_token`, but not both.
-        - `never_timeout` (bool): If True, sessions to this community worker never time out.
-        - `session_type` (str): Programming language for the session. Common values include:
-            * "python": For Python-based Deephaven instances.
-            * "groovy": For Groovy-based Deephaven instances.
-        - `use_tls` (bool): Whether to use TLS/SSL for the connection.
-        - `tls_root_certs` (str, optional): Path to a PEM file containing root certificates to trust for TLS.
-        - `client_cert_chain` (str, optional): Path to a PEM file containing the client certificate chain for mutual TLS.
-        - `client_private_key` (str, optional): Path to a PEM file containing the client private key for mutual TLS.
+        - `sessions` (dict, optional):
+            A dictionary mapping community session names (str) to client session configuration dicts.
+            If this key is present, its value must be a dictionary (which can be empty, e.g., {}).
+            If this key is absent, it implies no community sessions are configured.
+            Each community session configuration dict may contain any of the following fields (all are optional):
+
+              - `host` (str): Hostname or IP address of the community worker.
+              - `port` (int): Port number for the community worker connection.
+              - `auth_type` (str): Authentication type. Allowed values include:
+                  * "token": Use a bearer token for authentication.
+                  * "basic": Use HTTP Basic authentication.
+                  * "anonymous": No authentication required.
+              - `auth_token` (str, optional): The direct authentication token or password. May be empty if `auth_type` is "anonymous". Use this OR `auth_token_env_var`, but not both.
+              - `auth_token_env_var` (str, optional): The name of an environment variable from which to read the authentication token. Use this OR `auth_token`, but not both.
+              - `never_timeout` (bool): If True, sessions to this community worker never time out.
+              - `session_type` (str): Programming language for the session. Common values include:
+                  * "python": For Python-based Deephaven instances.
+                  * "groovy": For Groovy-based Deephaven instances.
+              - `use_tls` (bool): Whether to use TLS/SSL for the connection.
+              - `tls_root_certs` (str, optional): Path to a PEM file containing root certificates to trust for TLS.
+              - `client_cert_chain` (str, optional): Path to a PEM file containing the client certificate chain for mutual TLS.
+              - `client_private_key` (str, optional): Path to a PEM file containing the client private key for mutual TLS.
 
       Notes:
         - All fields are optional; if a field is omitted, the consuming code may use an internal default value for that field, or the feature may be disabled.
@@ -45,90 +51,73 @@ The configuration file must be a JSON object. It may contain the following top-l
         - Sensitive fields (`auth_token`, `client_private_key`) are redacted from logs for security.
         - Unknown fields are not allowed and will cause validation to fail.
 
-  - `enterprise_systems` (dict, optional):
-      A dictionary mapping enterprise system names (str) to system configuration dicts.
+  - `enterprise` (dict, optional):
+      A dictionary mapping enterprise configuration.
       If this key is present, its value must be a dictionary (which can be empty).
-      Each enterprise system configuration dict is validated according to the schema defined in
+      Each enterprise configuration dict is validated according to the schema defined in
       `src/deephaven_mcp/config/enterprise_system.py`. Key fields typically include:
 
-        - `connection_json_url` (str): URL to the server's connection.json file.
-        - `auth_type` (str, enum): Authentication type. Allowed values include:
-            * "password": Use username and password for authentication.
-            * "private_key": Use a private key for SAML or similar token-based authentication.
-        - Conditional fields based on `auth_type`:
-            - If `auth_type` is "password":
-                - `username` (str, required): The username.
-                - `password` (str, optional): The password.
-                - `password_env_var` (str, optional): Environment variable for the password.
-                  (Note: `password` and `password_env_var` are mutually exclusive.)
-            - If `auth_type` is "private_key":
-                - `private_key` (str, required): Path to the private key file.
+        - `systems` (dict, optional):
+            A dictionary mapping enterprise system names (str) to system configuration dicts.
+            If this key is present, its value must be a dictionary (which can be empty).
+            Each enterprise system configuration dict must include:
+                - `connection_json_url` (str, required): URL to the server's connection.json file.
+                - `auth_type` (str, required): One of:
+                    * "password":
+                        - `username` (str, required): The username.
+                        - `password` (str, optional): The password.
+                        - `password_env_var` (str, optional): Environment variable for the password.
+                          (Note: `password` and `password_env_var` are mutually exclusive.)
+                    * "private_key":
+                        - `private_key` (str, required): The private key.
 
       Notes:
         - For the detailed schema of individual enterprise system configurations, please refer to the
           `src/deephaven_mcp/config/enterprise_system.py` module and the DEVELOPER_GUIDE.md.
         - Sensitive fields are redacted from logs.
-        - Unknown fields within an enterprise system configuration will cause a warning and be ignored, but unknown top-level keys in the main config will fail validation.
+        - Unknown fields at any level will cause validation to fail.
 
 Validation rules:
-  - If the `community_sessions` key is present, its value must be a dictionary.
-  - Within each session configuration, all field values must have the correct type if present.
-  - No unknown fields are permitted in session configurations.
+  - If the `community` key is present, its value must be a dictionary.
+  - Within each community configuration, all field values must have the correct type if present.
+  - No unknown fields are permitted at any level of the configuration.
   - If TLS fields are provided, referenced files must exist and be readable.
-  - If the `enterprise_systems` key is present, its value must be a dictionary.
+  - If the `enterprise` key is present, its value must be a dictionary.
   - Each enterprise system configuration is validated according to its specific schema.
 
 Configuration JSON Specification:
 ---------------------------------
 - The configuration file must be a JSON object.
-- It may optionally contain `"community_sessions"` and/or `"enterprise_systems"` top-level keys:
-    - `"community_sessions"`: If present, this must be a dictionary mapping community session names to client session configuration dicts for connecting to community workers. An empty dictionary is allowed (e.g., {}).
-    - `"enterprise_systems"`: If present, this must be a dictionary mapping enterprise system names to system configuration dicts. An empty dictionary is allowed (e.g., {}).
+- It may optionally contain `"community"` and/or `"enterprise"` top-level keys:
+    - `"community"`: If present, this must be a dictionary containing community configuration.
+    - `"enterprise"`: If present, this must be a dictionary containing enterprise configuration.
 
-Example Valid Configuration (without community_sessions):
+Example Valid Configuration (without community sessions):
 ---------------------------
 ```json
 {}
 ```
 
-Example Valid Configuration (with community_sessions):
+Example Valid Configuration (with community and enterprise sections):
 ---------------------------
 ```json
 {
-    "community_sessions": {
-        "local": {
-            "host": "localhost",
-            "port": 10000,
-            "auth_type": "token",
-            "auth_token": "your-token-here",
-            "never_timeout": true,
-            "session_type": "python",
-            "use_tls": true,
-            "tls_root_certs": "/path/to/certs.pem",
-            "client_cert_chain": "/path/to/client-cert.pem",
-            "client_private_key": "/path/to/client-key.pem"
-        },
-        "remote": {
-            "host": "remote-server.example.com",
-            "port": 10000,
-            "auth_type": "basic",
-            "auth_token": "basic-auth-token",
-            "never_timeout": false,
-            "session_type": "groovy",
-            "use_tls": true
+    "community": {
+        "sessions": {
+            "local": {
+                "host": "localhost",
+                "port": 10000
+            }
         }
     },
-    "enterprise_systems": {
-        "prod_cluster": {
-            "connection_json_url": "https://enterprise.example.com/iris/connection.json",
-            "auth_type": "api_key",
-            "api_key_env_var": "PROD_CLUSTER_API_KEY"
-        },
-        "dev_system": {
-            "connection_json_url": "http://localhost:8080/iris/connection.json",
-            "auth_type": "password",
-            "username": "dev_user",
-            "password_env_var": "DEV_SYSTEM_PASSWORD"
+    "enterprise": {
+        "systems": {
+            "prod_cluster": {
+                "connection_json_url": "https://enterprise.example.com/iris/connection.json",
+                "auth_type": "password",
+                "username": "admin",
+                "password_env_var": "MY_PASSWORD"
+            }
         }
     }
 }
@@ -139,10 +128,12 @@ Example Invalid Configurations:
 1. Invalid: Session field with wrong type
 ```json
 {
-    "community_sessions": {
-        "local": {
-            "host": 12345,  // Should be a string, not an integer
-            "port": "not-a-port"  // Should be an integer, not a string
+    "community": {
+        "sessions": {
+            "local": {
+                "host": 12345,  // Should be a string, not an integer
+                "port": "not-a-port"  // Should be an integer, not a string
+            }
         }
     }
 }
@@ -156,12 +147,15 @@ Performance Considerations:
 
 Usage Patterns:
 -----------------------------------------------------------------------------
-- The configuration may optionally include a `community_sessions` dictionary as a top-level key.
-- Loading a community session configuration:
-    >>> session_config = await config_manager.get_community_session_config('local_session_name')
-    >>> # connection = connect(**session_config)  # Example usage
-- Listing available configured community sessions:
-    >>> session_names = await config_manager.get_community_session_names()
+- The configuration may optionally include a `community` dictionary.
+- Accessing configuration sections:
+    >>> config_manager = ConfigManager()
+    >>> await config_manager.load_config("/path/to/deephaven_mcp.json")
+    >>> config = await config_manager.get_config()
+    >>> config_section = get_config_section(config, ["community", "sessions"])
+    >>> # Access specific session data from config_section
+- Listing available configured names:
+    >>> session_names = get_all_config_names(config, ["community", "sessions"])
     >>> for session_name in session_names:
     ...     print(f"Available community session: {session_name}")
 
@@ -189,7 +183,7 @@ __all__ = [
     "ConfigManager",
     "CONFIG_ENV_VAR",
     "validate_config",
-    "get_named_config",
+    "get_config_section",
     "get_all_config_names",
     "get_config_path",
     "load_and_validate_config",
@@ -208,8 +202,9 @@ import asyncio
 import json
 import logging
 import os
-from collections.abc import Callable
-from typing import Any, cast
+import copy
+from typing import Any, Optional, Type, cast, Callable, Sequence
+from dataclasses import dataclass
 
 import aiofiles
 
@@ -237,10 +232,45 @@ CONFIG_ENV_VAR = "DH_MCP_CONFIG_FILE"
 str: Name of the environment variable specifying the path to the Deephaven MCP config file.
 """
 
-_REQUIRED_TOP_LEVEL_KEYS: set[str] = set()
-"""Set of top-level keys that MUST be present in the configuration file."""
-_ALLOWED_TOP_LEVEL_KEYS: set[str] = {"community_sessions", "enterprise_systems"}
-"""Set of all allowed top-level keys in the configuration file."""
+@dataclass
+class _ConfigPathSpec:
+    """Specification for a valid configuration path."""
+    required: bool
+    expected_type: type
+    validator: Optional[Callable[[Any], None]] = None
+    redactor: Optional[Callable[[Any], Any]] = None  # Function to redact sensitive data for logging
+
+# Schema defining all valid configuration paths
+_SCHEMA_PATHS: dict[tuple[str, ...], _ConfigPathSpec] = {
+    ("community",): _ConfigPathSpec(
+        required=False,
+        expected_type=dict,
+        validator=None  # Validated by nested paths
+    ),
+    ("community", "sessions"): _ConfigPathSpec(
+        required=False,
+        expected_type=dict,
+        validator=validate_community_sessions_config,
+        redactor=lambda sessions_dict: {
+            name: redact_community_session_config(config) 
+            for name, config in sessions_dict.items()
+        } if isinstance(sessions_dict, dict) else sessions_dict
+    ),
+    ("enterprise",): _ConfigPathSpec(
+        required=False,
+        expected_type=dict,
+        validator=None  # Validated by nested paths  
+    ),
+    ("enterprise", "systems"): _ConfigPathSpec(
+        required=False,
+        expected_type=dict,
+        validator=validate_enterprise_systems_config,
+        redactor=lambda systems_dict: {
+            name: redact_enterprise_system_config(config) 
+            for name, config in systems_dict.items()
+        } if isinstance(systems_dict, dict) else systems_dict
+    ),
+}
 
 
 class ConfigManager:
@@ -298,7 +328,7 @@ class ConfigManager:
 
         Example:
             >>> # Assuming config_manager is an instance of ConfigManager
-            >>> await config_manager._set_config_cache({'community_sessions': {'example_session': {}}})
+            >>> await config_manager._set_config_cache({'community': {'sessions': {'example_session': {}}}})
         """
         async with self._lock:
             self._cache = validate_config(config)
@@ -329,8 +359,7 @@ class ConfigManager:
             >>> # import os
             >>> # os.environ['DH_MCP_CONFIG_FILE'] = '/path/to/config.json'
             >>> config_dict = await config_manager.get_config()
-            >>> print(config_dict['community_sessions']['local_session_name']['host'])
-            'localhost'
+            >>> print(config_dict['community'])
         """
         _LOGGER.debug("Loading Deephaven MCP application configuration...")
         async with self._lock:
@@ -345,71 +374,61 @@ class ConfigManager:
             return validated
 
 
-async def get_named_config(
-    config_manager: "ConfigManager",
-    section: str,
-    name: str,
-) -> dict[str, Any]:
-    """
-    Retrieve a named config dict from a section, with logging and error handling.
 
+
+def get_config_section(
+    config: dict[str, Any],
+    section: Sequence[str],
+) -> Any:
+    """
+    Retrieve a config subsection by path. Raises KeyError if not found.
+    
     Args:
-        config_manager (ConfigManager): The ConfigManager instance to use for config retrieval.
-        section (str): The top-level config section (e.g., 'community_sessions', 'enterprise_systems').
-        name (str): The specific item name to retrieve.
-
+        config (dict[str, Any]): The configuration dictionary to navigate.
+        section (Sequence[str]): The path to the config section (e.g., ['community', 'sessions', 'foo']).
+    
     Returns:
-        dict[str, Any]: The configuration dictionary for the specified item.
-
+        Any: The config subsection at the given path.
+    
     Raises:
-        ValueError: If the named item is not found in the config section.
+        KeyError: If the section path does not exist.
     """
-    _LOGGER.debug(f"Getting config for '{section}:{name}'")
-    config = await config_manager.get_config()
-    section_map = config.get(section, {})
-
-    # get redact fn
-    redact_fn: Callable[[dict[str, Any]], dict[str, Any]]
-    if section == "community_sessions":
-        redact_fn = redact_community_session_config
-    elif section == "enterprise_systems":
-        redact_fn = redact_enterprise_system_config
-    else:
-        raise ValueError(f"Invalid section: {section}")
-
-    if name not in section_map:
-        _LOGGER.error(f"Config for '{section}:{name}' not found in configuration")
-        raise ValueError(f"Config for '{section}:{name}' not found in configuration")
-    _LOGGER.debug(
-        f"Retrieved configuration for '{section}:{name}': {redact_fn(section_map[name])}"
-    )
-    return cast(dict[str, Any], section_map[name])
+    _LOGGER.debug(f"Getting config section for path: {section}")
+    curr = config
+    for key in section:
+        if not isinstance(curr, dict) or key not in curr:
+            raise KeyError(f"Section path {section} does not exist in configuration")
+        curr = curr[key]
+    return curr
 
 
-async def get_all_config_names(
-    config_manager: "ConfigManager",
-    section: str,
+def get_all_config_names(
+    config: dict[str, Any],
+    section: Sequence[str],
 ) -> list[str]:
     """
-    Retrieve all names from a given config section.
+    Retrieve all names from a given config section path.
 
     Args:
-        config_manager (ConfigManager): The ConfigManager instance to use for config retrieval.
-        section (str): The top-level config section to extract names from (e.g., 'community_sessions', 'enterprise_systems').
+        config (dict[str, Any]): The configuration dictionary to search within.
+        section (Sequence[str]): The path to the config section (e.g., ['community', 'sessions']).
 
     Returns:
-        list[str]: List of keys (names) in the specified config section, or empty list if not found or not a dict.
+        list[str]: A list of names from the given config section. If the section doesn't exist, returns an empty list.
     """
-    _LOGGER.debug(f"Getting list of all names from config section '{section}'")
-    config = await config_manager.get_config()
-    section_map = config.get(section, {})
-    if not isinstance(section_map, dict):
-        _LOGGER.warning(
-            f"'{section}' is not a dictionary, returning empty list of names."
-        )
+    _LOGGER.debug(f"Getting list of all names from config section path: {section}")
+    try:
+        section_obj = get_config_section(config, section)
+    except KeyError:
+        _LOGGER.warning(f"Section path {section} does not exist, returning empty list of names.")
         return []
-    names = list(section_map.keys())
-    _LOGGER.debug(f"Found {len(names)} {section} item(s): {names}")
+
+    if not isinstance(section_obj, dict):
+        _LOGGER.warning(f"Section at path {section} is not a dictionary, returning empty list of names.")
+        return []
+
+    names = list(section_obj.keys())
+    _LOGGER.debug(f"Found {len(names)} names in section {section}: {names}")
     return names
 
 
@@ -428,7 +447,7 @@ async def _load_config_from_file(config_path: str) -> dict[str, Any]:
 
     Example:
         >>> config = await _load_config_from_file('/path/to/config.json')
-        >>> print(config['community_sessions'])
+        >>> print(config['community'])
     """
     try:
         async with aiofiles.open(config_path) as f:
@@ -505,63 +524,73 @@ async def load_and_validate_config(config_path: str) -> dict[str, Any]:
 
     Example:
         >>> config = await _load_and_validate_config('/path/to/config.json')
-        >>> print(config['enterprise_systems'])
+        >>> print(config['enterprise'])
     """
     try:
         data = await _load_config_from_file(config_path)
         return validate_config(data)
-    except (
-        CommunitySessionConfigurationError,
-        EnterpriseSystemConfigurationError,
-    ) as specific_e:
-        _LOGGER.error(
-            f"Configuration validation failed for {config_path}: {specific_e}"
-        )
-        raise McpConfigurationError(
-            f"Configuration validation failed: {specific_e}"
-        ) from specific_e
-    except ValueError as ve:
-        _LOGGER.error(f"General configuration validation error for {config_path}: {ve}")
-        raise McpConfigurationError(
-            f"General configuration validation error: {ve}"
-        ) from ve
     except Exception as e:
         _LOGGER.error(f"Error loading configuration file {config_path}: {e}")
         raise McpConfigurationError(f"Error loading configuration file: {e}") from e
+
+
+def _apply_redaction_to_config(config: dict[str, Any]) -> dict[str, Any]:
+    """
+    Apply all configured redaction functions to a deep copy of the config.
+    
+    Args:
+        config (dict[str, Any]): The configuration dictionary to redact.
+        
+    Returns:
+        dict[str, Any]: A deep copy of the config with sensitive data redacted.
+    """
+    config_copy = copy.deepcopy(config)
+    
+    # Apply redaction functions for each configured path
+    for path_tuple, spec in _SCHEMA_PATHS.items():
+        if spec.redactor is not None:
+            try:
+                section = get_config_section(config_copy, list(path_tuple))
+                redacted_section = spec.redactor(section)
+                
+                # Navigate to the parent and set the redacted section
+                current = config_copy
+                for key in path_tuple[:-1]:
+                    current = current[key]
+                current[path_tuple[-1]] = redacted_section
+                
+            except KeyError:
+                # Section doesn't exist, skip redaction
+                continue
+    
+    return config_copy
 
 
 def _log_config_summary(config: dict[str, Any]) -> None:
     """
     Log a summary of the loaded Deephaven MCP configuration.
 
-    This function logs the names and (redacted) details of all configured community sessions and
-    enterprise systems. If no sessions or systems are configured, it logs that information as well.
+    This function logs the configuration with sensitive data redacted as formatted JSON.
 
     Args:
         config (dict[str, Any]): The loaded and validated configuration dictionary.
 
     Example:
-        >>> config = {'community_sessions': {'local': {...}}, 'enterprise_systems': {}}
+        >>> config = {'community': {'sessions': {'local': {...}}}}
         >>> _log_config_summary(config)
     """
-    community_sessions = config.get("community_sessions", {})
-    if community_sessions:
-        _LOGGER.info("Configured Community Sessions:")
-        for name, details in community_sessions.items():
-            _LOGGER.info(
-                f"  Session '{name}': {redact_community_session_config(details)}"
-            )
-    else:
-        _LOGGER.info("No Community Sessions configured.")
-    enterprise_systems = config.get("enterprise_systems", {})
-    if enterprise_systems:
-        _LOGGER.info("Configured Enterprise Systems:")
-        for name, details in enterprise_systems.items():
-            _LOGGER.info(
-                f"  System '{name}': {redact_enterprise_system_config(details)}"
-            )
-    else:
-        _LOGGER.info("No Enterprise Systems configured.")
+    _LOGGER.info("Configuration summary:")
+    
+    # Create a redacted copy of the config for logging
+    redacted_config = _apply_redaction_to_config(config)
+    
+    # Log the redacted config as formatted JSON
+    try:
+        formatted_config = json.dumps(redacted_config, indent=2, sort_keys=True)
+        _LOGGER.info(f"Loaded configuration:\n{formatted_config}")
+    except (TypeError, ValueError) as e:
+        _LOGGER.warning(f"Failed to format config as JSON: {e}")
+        _LOGGER.info(f"Loaded configuration: {redacted_config}")
 
 
 def validate_config(config: dict[str, Any]) -> dict[str, Any]:
@@ -570,81 +599,133 @@ def validate_config(config: dict[str, Any]) -> dict[str, Any]:
 
     This function ensures that the configuration dictionary conforms to the expected schema for Deephaven MCP.
     The configuration may contain the following top-level keys:
-      - 'community_sessions' (dict, optional):
-            A dictionary mapping community session names (str) to session configuration dicts.
-            Each session configuration dict may contain any of the following fields (all optional):
-                - 'host' (str): Hostname or IP address.
-                - 'port' (int): Port number.
-                - 'auth_type' (str): Authentication type ('token', 'basic', 'anonymous').
-                - 'auth_token' (str, optional): Direct authentication token or password.
-                - 'auth_token_env_var' (str, optional): Environment variable for authentication token.
-                - 'never_timeout' (bool): If True, session never times out.
-                - 'session_type' (str): Programming language for the session ('python', 'groovy', etc.).
-                - 'use_tls' (bool): Whether to use TLS/SSL.
-                - 'tls_root_certs' (str, optional): Path to PEM file with root certificates.
-                - 'client_cert_chain' (str, optional): Path to client certificate chain PEM file.
-                - 'client_private_key' (str, optional): Path to client private key PEM file.
-            All fields are optional; unknown fields are not allowed and will cause validation to fail.
-      - 'enterprise_systems' (dict, optional):
-            A dictionary mapping enterprise system names (str) to enterprise system configuration dicts.
-            Each enterprise system configuration dict must include:
-                - 'connection_json_url' (str, required): URL to the server's connection.json file.
-                - 'auth_type' (str, required): One of:
-                    * 'password':
-                        - 'username' (str, required): The username.
-                        - 'password' (str, optional): The password.
-                        - 'password_env_var' (str, optional): Environment variable for the password.
-                          (Exactly one of 'password' or 'password_env_var' must be provided, but not both.)
-                    * 'private_key':
-                        - 'private_key' (str, required): The private key.
-            All fields not listed above are disallowed and will cause validation to fail.
+      - 'community' (dict, optional):
+            A dictionary mapping community configuration.
+            If this key is present, its value must be a dictionary (which can be empty, e.g., {}).
+            If this key is absent, it implies no community configuration is present.
+            Each community configuration dict may contain any of the following fields (all are optional):
 
-    Validation Rules:
-        - Only known top-level keys are allowed ('community_sessions', 'enterprise_systems').
-        - All present sections are validated according to their schema.
-        - Missing required top-level keys (if any) will cause validation to fail.
-        - Unknown or misspelled keys will cause validation to fail.
-        - All field types must be correct if present.
-        - Sensitive fields are redacted from logs.
+              - 'sessions' (dict, optional):
+                  A dictionary mapping community session names (str) to client session configuration dicts.
+                  If this key is present, its value must be a dictionary (which can be empty, e.g., {}).
+                  If this key is absent, it implies no community sessions are configured.
+                  Each community session configuration dict may contain any of the following fields (all are optional):
 
-    Args:
-        config (dict[str, Any]): The configuration dictionary to validate.
+                    - 'host' (str): Hostname or IP address of the community worker.
+                    - 'port' (int): Port number for the community worker connection.
+                    - 'auth_type' (str): Authentication type. Allowed values include:
+                        * "token": Use a bearer token for authentication.
+                        * "basic": Use HTTP Basic authentication.
+                        * "anonymous": No authentication required.
+                    - 'auth_token' (str, optional): The direct authentication token or password. May be empty if `auth_type` is "anonymous". Use this OR `auth_token_env_var`, but not both.
+                    - 'auth_token_env_var' (str, optional): The name of an environment variable from which to read the authentication token. Use this OR `auth_token`, but not both.
+                    - 'never_timeout' (bool): If True, sessions to this community worker never time out.
+                    - 'session_type' (str): Programming language for the session. Common values include:
+                        * "python": For Python-based Deephaven instances.
+                        * "groovy": For Groovy-based Deephaven instances.
+                    - 'use_tls' (bool): Whether to use TLS/SSL for the connection.
+                    - 'tls_root_certs' (str, optional): Path to a PEM file containing root certificates to trust for TLS.
+                    - 'client_cert_chain' (str, optional): Path to a PEM file containing the client certificate chain for mutual TLS.
+                    - 'client_private_key' (str, optional): Path to a PEM file containing the client private key for mutual TLS.
 
-    Returns:
-        dict[str, Any]: The validated configuration dictionary.
+      - 'enterprise' (dict, optional):
+            A dictionary mapping enterprise configuration.
+            If this key is present, its value must be a dictionary (which can be empty).
+            Each enterprise configuration dict is validated according to the schema defined in
+            `src/deephaven_mcp/config/enterprise_system.py`. Key fields typically include:
 
-    Raises:
-        McpConfigurationError: If required top-level keys are missing or unknown keys are present.
-        CommunitySessionConfigurationError: If a community session config is invalid.
-        EnterpriseSystemConfigurationError: If an enterprise system config is invalid.
+              - 'systems' (dict, optional):
+                  A dictionary mapping enterprise system names (str) to system configuration dicts.
+                  If this key is present, its value must be a dictionary (which can be empty).
+                  Each enterprise system configuration dict must include:
+                      - 'connection_json_url' (str, required): URL to the server's connection.json file.
+                      - 'auth_type' (str, required): One of:
+                          * "password":
+                              - 'username' (str, required): The username.
+                              - 'password' (str, optional): The password.
+                              - 'password_env_var' (str, optional): Environment variable for the password.
+                                (Note: `password` and `password_env_var` are mutually exclusive.)
+                          * "private_key":
+                              - 'private_key' (str, required): The private key.
 
-    Example:
-        >>> validated_config = validate_config({'community_sessions': {'local_session': {}}, 'enterprise_systems': {'prod_cluster': {}}})
-        >>> validated_config_empty = validate_config({})  # Also valid
+Validation Rules:
+  - Only known keys are allowed at each level of nesting.
+  - All present sections are validated according to their schema.
+  - Unknown or misspelled keys at any level will cause validation to fail.
+  - All field types must be correct if present.
+  - Sensitive fields are redacted from logs.
+
+Args:
+    config (dict[str, Any]): The configuration dictionary to validate.
+
+Returns:
+    dict[str, Any]: The validated configuration dictionary.
+
+Raises:
+    McpConfigurationError: If validation fails due to unknown keys, wrong types, or invalid nested configurations.
+        This includes cases where community session or enterprise system configurations are invalid.
+
+Example:
+    >>> validated_config = validate_config({'community': {'sessions': {'local_session': {}}}, 'enterprise': {'systems': {'prod_cluster': {}}}})
+    >>> validated_config_empty = validate_config({})  # Also valid
     """
-    top_level_keys = set(config.keys())
-
-    # Check for missing required keys
-    missing_keys = _REQUIRED_TOP_LEVEL_KEYS - top_level_keys
-    if missing_keys:
-        _LOGGER.error(
-            f"Missing required top-level keys in Deephaven MCP config: {missing_keys}"
-        )
-        raise McpConfigurationError(
-            f"Missing required top-level keys in Deephaven MCP config: {missing_keys}"
-        )
-    unknown_keys = top_level_keys - _ALLOWED_TOP_LEVEL_KEYS
-    if unknown_keys:
-        _LOGGER.error(f"Unknown top-level keys in Deephaven MCP config: {unknown_keys}")
-        raise McpConfigurationError(
-            f"Unknown top-level keys in Deephaven MCP config: {unknown_keys}"
-        )
-    if "community_sessions" in top_level_keys:
-        validate_community_sessions_config(config["community_sessions"])
-
-    # Validate 'enterprise_systems' if present
-    if "enterprise_systems" in top_level_keys:
-        validate_enterprise_systems_config(config["enterprise_systems"])
-
+    if not isinstance(config, dict):
+        raise McpConfigurationError("Configuration must be a dictionary")
+    
+    def _validate_section(data: dict[str, Any], path: tuple[str, ...]) -> None:
+        """Validate a configuration section in a single pass."""
+        # Get specs for the current path level
+        current_specs = {
+            nested_path[len(path)]: spec 
+            for nested_path, spec in _SCHEMA_PATHS.items() 
+            if len(nested_path) == len(path) + 1 and nested_path[:len(path)] == path
+        }
+        
+        # Check for unknown keys
+        valid_keys = set(current_specs.keys())
+        unknown_keys = set(data.keys()) - valid_keys
+        if unknown_keys:
+            _LOGGER.error(f"Unknown keys at config path {path}: {unknown_keys}")
+            raise McpConfigurationError(f"Unknown keys at config path {path}: {unknown_keys}")
+        
+        # Check for missing required keys
+        required_keys = {key for key, spec in current_specs.items() if spec.required}
+        missing_keys = required_keys - set(data.keys())
+        if missing_keys:
+            _LOGGER.error(f"Missing required keys at config path {path}: {missing_keys}")
+            raise McpConfigurationError(f"Missing required keys at config path {path}: {missing_keys}")
+        
+        # Validate each present key
+        for key, value in data.items():
+            if key in current_specs:
+                spec = current_specs[key]
+                current_path = path + (key,)
+                
+                # Type validation
+                if not isinstance(value, spec.expected_type):
+                    _LOGGER.error(f"Config path {current_path} must be of type {spec.expected_type.__name__}, got {type(value).__name__}")
+                    raise McpConfigurationError(
+                        f"Config path {current_path} must be of type {spec.expected_type.__name__}, got {type(value).__name__}"
+                    )
+                
+                # Specialized validation
+                if spec.validator:
+                    try:
+                        spec.validator(value)
+                    except (CommunitySessionConfigurationError, EnterpriseSystemConfigurationError) as e:
+                        raise McpConfigurationError(f"Invalid configuration for {'.'.join(current_path)}: {e}") from e
+                
+                # Recurse into nested dictionaries
+                if isinstance(value, dict):
+                    has_nested_paths = any(
+                        nested_path[:len(current_path)] == current_path and len(nested_path) > len(current_path)
+                        for nested_path in _SCHEMA_PATHS.keys()
+                    )
+                    if has_nested_paths:
+                        _validate_section(value, current_path)
+    
+    # Validate the entire configuration
+    _validate_section(config, ())
+    
     _LOGGER.info("Configuration validation passed.")
     return config

--- a/src/deephaven_mcp/mcp_systems_server/_mcp.py
+++ b/src/deephaven_mcp/mcp_systems_server/_mcp.py
@@ -218,7 +218,8 @@ async def describe_workers(context: Context) -> dict:
     try:
         config_manager = context.request_context.lifespan_context["config_manager"]
         session_manager = context.request_context.lifespan_context["session_manager"]
-        names = await config.get_all_config_names(config_manager, "community_sessions")
+        full_config = await config_manager.get_config()
+        names = config.get_all_config_names(full_config, ["community", "sessions"])
         results = []
         for name in names:
             try:

--- a/src/deephaven_mcp/sessions/_lifecycle/community.py
+++ b/src/deephaven_mcp/sessions/_lifecycle/community.py
@@ -172,8 +172,9 @@ async def create_session_for_worker(
     _LOGGER.info(
         f"[Community] Creating new Deephaven Community (Core) session: {session_name}"
     )
-    worker_cfg = await config.get_named_config(
-        config_manager, "community_sessions", session_name
+    full_config = await config_manager.get_config()
+    worker_cfg = config.get_config_section(
+        full_config, ["community", "sessions", session_name]
     )
     session_params = await _get_session_parameters(worker_cfg)
     log_cfg = redact_community_session_config(session_params)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -76,7 +76,7 @@ def valid_full_config(valid_community_config, valid_enterprise_config):
     # Merge nested 'community' and 'enterprise' dicts
     return {
         "community": valid_community_config["community"],
-        "enterprise": valid_enterprise_config["enterprise"]
+        "enterprise": valid_enterprise_config["enterprise"],
     }
 
 
@@ -140,7 +140,9 @@ def test_validate_community_sessions_config_invalid_session_item(caplog):
 def test_validate_community_sessions_config_unknown_field(caplog):
     """Tests that validate_community_sessions_config fails for an unknown field."""
     with pytest.raises(CommunitySessionConfigurationError):
-        validate_community_sessions_config({"sessions": {"foo": {"host": "localhost", "bad": 1}}})
+        validate_community_sessions_config(
+            {"sessions": {"foo": {"host": "localhost", "bad": 1}}}
+        )
 
 
 def test_community_sessions_wrong_type():
@@ -342,10 +344,10 @@ def test_validate_and_get_auth_type_invalid():
 
 @pytest.mark.asyncio
 async def test_get_config_other_os_error_on_read(monkeypatch, caplog):
+    import os
     from unittest import mock
 
     import aiofiles
-    import os
 
     from deephaven_mcp import config
 
@@ -389,21 +391,23 @@ async def test_validate_config_missing_required_key_runtime(caplog, monkeypatch)
     original_schema = config._SCHEMA_PATHS.copy()
     test_schema = original_schema.copy()
     test_schema[("must_have_this",)] = config._ConfigPathSpec(
-        required=True,
-        expected_type=dict,
-        validator=None
+        required=True, expected_type=dict, validator=None
     )
-    
-    with patch.object(config, '_SCHEMA_PATHS', {
-        **config._SCHEMA_PATHS,
-        ("must_have_this",): config._ConfigPathSpec(
-            required=True,
-            expected_type=dict,
-            validator=None
-        )
-    }):
+
+    with patch.object(
+        config,
+        "_SCHEMA_PATHS",
+        {
+            **config._SCHEMA_PATHS,
+            ("must_have_this",): config._ConfigPathSpec(
+                required=True, expected_type=dict, validator=None
+            ),
+        },
+    ):
         cm = config.ConfigManager()
-        invalid_config_data = {"community": {"sessions": {}}}  # Missing 'must_have_this'
+        invalid_config_data = {
+            "community": {"sessions": {}}
+        }  # Missing 'must_have_this'
 
         config_file_path = "/fake/path/config_missing_req.json"
         monkeypatch.setenv(config.CONFIG_ENV_VAR, config_file_path)
@@ -421,13 +425,14 @@ async def test_validate_config_missing_required_key_runtime(caplog, monkeypatch)
 
         with pytest.raises(
             config.McpConfigurationError,
-            match=re.escape("Error loading configuration file: Missing required keys at config path (): {'must_have_this'}"),
+            match=re.escape(
+                "Error loading configuration file: Missing required keys at config path (): {'must_have_this'}"
+            ),
         ):
             await cm.get_config()  # This will load, then validate
 
         assert (
-            "Missing required keys at config path (): {'must_have_this'}"
-            in caplog.text
+            "Missing required keys at config path (): {'must_have_this'}" in caplog.text
         )
 
         aiofiles.open = original_aio_open_req
@@ -444,7 +449,9 @@ async def test_get_config_uses_cache_and_logs(monkeypatch, caplog):
 
     config_file_path = "/fake/path/config_for_cache_test.json"
     monkeypatch.setenv(config.CONFIG_ENV_VAR, config_file_path)
-    valid_config_data = {"community": {"sessions": {"test_session": {"host": "localhost"}}}}
+    valid_config_data = {
+        "community": {"sessions": {"test_session": {"host": "localhost"}}}
+    }
 
     # Mock aiofiles.open to be called only once for the read
     mock_file_read_content = mock.AsyncMock(
@@ -507,14 +514,13 @@ async def test_get_config_unknown_top_level_key(monkeypatch, caplog):
     cm = config.ConfigManager()
     with pytest.raises(
         config.McpConfigurationError,
-        match=re.escape(r"Error loading configuration file: Unknown keys at config path (): {'some_unknown_key'}"),
+        match=re.escape(
+            r"Error loading configuration file: Unknown keys at config path (): {'some_unknown_key'}"
+        ),
     ):
         await cm.get_config()
 
-    assert (
-        r"Unknown keys at config path (): {'some_unknown_key'}"
-        in caplog.text
-    )
+    assert r"Unknown keys at config path (): {'some_unknown_key'}" in caplog.text
 
     aiofiles.open = original_aio_open
 
@@ -555,7 +561,9 @@ async def test_get_config_invalid_community_session_schema_from_file(
 
     cm = config.ConfigManager()
     # The error will now come from validate_community_sessions_config via validate_config
-    expected_error_pattern = re.escape("Error loading configuration file: Invalid configuration for community.sessions: Field 'host' in community session config for bad_session must be of type str, got int")
+    expected_error_pattern = re.escape(
+        "Error loading configuration file: Invalid configuration for community.sessions: Field 'host' in community session config for bad_session must be of type str, got int"
+    )
 
     with pytest.raises(
         config.McpConfigurationError,
@@ -615,7 +623,9 @@ async def test_validate_enterprise_systems_config_logs_non_dict_map(
     )  # For validate_enterprise_systems_config debug log
 
     # The error will now come from validate_config checking _SCHEMA_PATHS
-    expected_error_pattern = re.escape("Error loading configuration file: Config path ('enterprise', 'systems') must be of type dict, got list")
+    expected_error_pattern = re.escape(
+        "Error loading configuration file: Config path ('enterprise', 'systems') must be of type dict, got list"
+    )
 
     with pytest.raises(
         config.McpConfigurationError,
@@ -677,7 +687,9 @@ async def test_validate_enterprise_systems_config_logs_non_dict_item_in_map(
 
     with pytest.raises(
         config.McpConfigurationError,
-        match=re.escape("Error loading configuration file: Invalid configuration for enterprise.systems: Enterprise system 'bad_system_item' configuration must be a dictionary, but got str."),
+        match=re.escape(
+            "Error loading configuration file: Invalid configuration for enterprise.systems: Enterprise system 'bad_system_item' configuration must be a dictionary, but got str."
+        ),
     ):
         await cm.get_config()
 
@@ -1592,7 +1604,9 @@ async def test_get_config_no_community_sessions_key_from_file(monkeypatch, caplo
 
     with pytest.raises(
         KeyError,
-        match=re.escape("Section path ['community', 'sessions', 'any_session_name'] does not exist in configuration"),
+        match=re.escape(
+            "Section path ['community', 'sessions', 'any_session_name'] does not exist in configuration"
+        ),
     ):
         get_config_section(cfg, ["community", "sessions", "any_session_name"])
 
@@ -1606,7 +1620,12 @@ import pytest
 async def test_get_config_section_invalid_section():
     cm = ConfigManager()
     cm._cache = {"community_sessions": {}}
-    with pytest.raises(KeyError, match=re.escape("Section path ['not_a_section', 'foo'] does not exist in configuration")):
+    with pytest.raises(
+        KeyError,
+        match=re.escape(
+            "Section path ['not_a_section', 'foo'] does not exist in configuration"
+        ),
+    ):
         get_config_section(cm._cache, ["not_a_section", "foo"])
 
 
@@ -1622,7 +1641,12 @@ async def test_get_config_section_invalid_name_enterprise_systems():
             }
         }
     }
-    with pytest.raises(KeyError, match=re.escape("Section path ['enterprise', 'systems', 'bar'] does not exist in configuration")):
+    with pytest.raises(
+        KeyError,
+        match=re.escape(
+            "Section path ['enterprise', 'systems', 'bar'] does not exist in configuration"
+        ),
+    ):
         get_config_section(cm._cache, ["enterprise", "systems", "bar"])
 
 
@@ -1663,26 +1687,32 @@ async def test_validate_config_missing_required_key_runtime(monkeypatch, caplog)
 
     config_file_path = "/fake/path/missing_required_key.json"
     monkeypatch.setenv("DH_MCP_CONFIG_FILE", config_file_path)
-    config_data = {"community": {"sessions": {}}}  # Use nested format, missing 'must_have_this'
+    config_data = {
+        "community": {"sessions": {}}
+    }  # Use nested format, missing 'must_have_this'
     aiofiles_open_ctx = mock.AsyncMock()
     aiofiles_open_ctx.__aenter__.return_value.read = mock.AsyncMock(
         return_value=json.dumps(config_data)
     )
 
     with (
-        patch.object(config, "_SCHEMA_PATHS", {
-            **config._SCHEMA_PATHS,
-            ("must_have_this",): config._ConfigPathSpec(
-                required=True,
-                expected_type=dict,
-                validator=None
-            )
-        }),
+        patch.object(
+            config,
+            "_SCHEMA_PATHS",
+            {
+                **config._SCHEMA_PATHS,
+                ("must_have_this",): config._ConfigPathSpec(
+                    required=True, expected_type=dict, validator=None
+                ),
+            },
+        ),
         patch("aiofiles.open", mock.Mock(return_value=aiofiles_open_ctx)),
     ):
         cm = config.ConfigManager()
         await cm.clear_config_cache()
-        expected_error = re.escape("Error loading configuration file: Missing required keys at config path (): {'must_have_this'}")
+        expected_error = re.escape(
+            "Error loading configuration file: Missing required keys at config path (): {'must_have_this'}"
+        )
         with pytest.raises(
             config.McpConfigurationError,
             match=expected_error,
@@ -1690,19 +1720,20 @@ async def test_validate_config_missing_required_key_runtime(monkeypatch, caplog)
             await cm.get_config()
 
 
-
 @pytest.mark.asyncio
 async def test_get_all_config_names_returns_keys():
     config = {
-        "community": {"sessions": {"a": {"host": "localhost"}, "b": {"host": "localhost"}}}
+        "community": {
+            "sessions": {"a": {"host": "localhost"}, "b": {"host": "localhost"}}
+        }
     }
     names = get_all_config_names(config, ["community", "sessions"])
     assert set(names) == {"a", "b"}
-    
+
     config2 = {"community": {"sessions": {}}}
     names2 = get_all_config_names(config2, ["community", "sessions"])
     assert names2 == []
-    
+
     config3 = {"community": {"sessions": {}}}
     names3 = get_all_config_names(config3, ["enterprise", "systems"])
     assert names3 == []
@@ -1720,10 +1751,11 @@ async def test_named_config_missing():
     config = {"community": {"sessions": {"foo": {"host": "localhost"}}}}
     with pytest.raises(
         KeyError,
-        match=re.escape("Section path ['community', 'sessions', 'bar'] does not exist in configuration"),
+        match=re.escape(
+            "Section path ['community', 'sessions', 'bar'] does not exist in configuration"
+        ),
     ):
         get_config_section(config, ["community", "sessions", "bar"])
-
 
 
 @pytest.mark.asyncio
@@ -1748,6 +1780,7 @@ async def test_get_all_config_names_returns_empty_for_non_dict_section(caplog):
         "Section at path ['not_a_section'] is not a dictionary, returning empty list of names."
         in caplog.text
     )
+
 
 @pytest.mark.asyncio
 async def test_get_config_no_community_sessions_key_from_file(monkeypatch, caplog):
@@ -1791,172 +1824,196 @@ async def test_get_config_no_community_sessions_key_from_file(monkeypatch, caplo
 
     with pytest.raises(
         KeyError,
-        match=re.escape("Section path ['community', 'sessions', 'any_session_name'] does not exist in configuration"),
+        match=re.escape(
+            "Section path ['community', 'sessions', 'any_session_name'] does not exist in configuration"
+        ),
     ):
         get_config_section(cfg, ["community", "sessions", "any_session_name"])
 
 
 # --- New tests for uncovered exception handling paths ---
 
+
 @pytest.mark.asyncio
 async def test_config_file_not_found_error(monkeypatch):
     """Test FileNotFoundError handling in _load_config_from_file."""
     from deephaven_mcp.config import ConfigManager, McpConfigurationError
-    
+
     monkeypatch.setenv("DH_MCP_CONFIG_FILE", "/nonexistent/path/config.json")
-    
+
     cm = ConfigManager()
     await cm.clear_config_cache()
-    
+
     with pytest.raises(McpConfigurationError, match="Configuration file not found"):
         await cm.get_config()
 
 
-@pytest.mark.asyncio 
+@pytest.mark.asyncio
 async def test_config_permission_error(monkeypatch):
     """Test PermissionError handling in _load_config_from_file."""
     import os
     from unittest.mock import patch
+
     from deephaven_mcp.config import ConfigManager, McpConfigurationError
-    
+
     monkeypatch.setenv("DH_MCP_CONFIG_FILE", "/fake/path/config.json")
-    
+
     with patch("aiofiles.open", side_effect=PermissionError("Permission denied")):
         cm = ConfigManager()
         await cm.clear_config_cache()
-        
-        with pytest.raises(McpConfigurationError, match="Permission denied when trying to read configuration file"):
+
+        with pytest.raises(
+            McpConfigurationError,
+            match="Permission denied when trying to read configuration file",
+        ):
             await cm.get_config()
 
 
 @pytest.mark.asyncio
 async def test_config_invalid_json_error(monkeypatch):
     """Test JSONDecodeError handling in _load_config_from_file."""
-    from unittest.mock import patch, AsyncMock, MagicMock
+    from unittest.mock import AsyncMock, MagicMock, patch
+
     from deephaven_mcp.config import ConfigManager, McpConfigurationError
-    
+
     # Invalid JSON content
     invalid_json = "{ invalid json content"
-    
+
     monkeypatch.setenv("DH_MCP_CONFIG_FILE", "/fake/path/config.json")
-    
+
     # Mock aiofiles.open
     mock_aiofiles_open = MagicMock()
     mock_async_context_manager = AsyncMock()
     mock_file_object = AsyncMock()
-    
+
     mock_aiofiles_open.return_value = mock_async_context_manager
     mock_async_context_manager.__aenter__.return_value = mock_file_object
     mock_file_object.read.return_value = invalid_json
-    
+
     with patch("aiofiles.open", mock_aiofiles_open):
         cm = ConfigManager()
         await cm.clear_config_cache()
-        
-        with pytest.raises(McpConfigurationError, match="Invalid JSON in configuration file"):
+
+        with pytest.raises(
+            McpConfigurationError, match="Invalid JSON in configuration file"
+        ):
             await cm.get_config()
 
 
 def test_validate_config_non_dict():
     """Test validation error when config is not a dictionary."""
-    from deephaven_mcp.config import validate_config, McpConfigurationError
-    
-    with pytest.raises(McpConfigurationError, match="Configuration must be a dictionary"):
+    from deephaven_mcp.config import McpConfigurationError, validate_config
+
+    with pytest.raises(
+        McpConfigurationError, match="Configuration must be a dictionary"
+    ):
         validate_config("not a dict")
-    
-    with pytest.raises(McpConfigurationError, match="Configuration must be a dictionary"):
+
+    with pytest.raises(
+        McpConfigurationError, match="Configuration must be a dictionary"
+    ):
         validate_config(123)
-    
-    with pytest.raises(McpConfigurationError, match="Configuration must be a dictionary"):
+
+    with pytest.raises(
+        McpConfigurationError, match="Configuration must be a dictionary"
+    ):
         validate_config(["list", "not", "dict"])
 
 
 @pytest.mark.asyncio
 async def test_config_validation_error_in_load_and_validate(monkeypatch):
     """Test configuration validation error handling in load_and_validate_config."""
-    from unittest.mock import patch, AsyncMock, MagicMock
+    from unittest.mock import AsyncMock, MagicMock, patch
+
     from deephaven_mcp.config import ConfigManager, McpConfigurationError
-    
+
     # Create invalid config that will fail validation
     invalid_config_json = '{"unknown_top_level_key": "invalid"}'
-    
+
     monkeypatch.setenv("DH_MCP_CONFIG_FILE", "/fake/path/config.json")
-    
+
     # Mock aiofiles.open
     mock_aiofiles_open = MagicMock()
     mock_async_context_manager = AsyncMock()
     mock_file_object = AsyncMock()
-    
+
     mock_aiofiles_open.return_value = mock_async_context_manager
     mock_async_context_manager.__aenter__.return_value = mock_file_object
     mock_file_object.read.return_value = invalid_config_json
-    
+
     with patch("aiofiles.open", mock_aiofiles_open):
         cm = ConfigManager()
         await cm.clear_config_cache()
-        
-        with pytest.raises(McpConfigurationError, match="Configuration validation failed"):
+
+        with pytest.raises(
+            McpConfigurationError, match="Configuration validation failed"
+        ):
             await cm.get_config()
 
 
 @pytest.mark.asyncio
 async def test_json_formatting_error_in_log_config_summary(monkeypatch, caplog):
     """Test JSON formatting error handling in _log_config_summary."""
-    from unittest.mock import patch, AsyncMock, MagicMock
-    from deephaven_mcp.config import ConfigManager
     import json
-    
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from deephaven_mcp.config import ConfigManager
+
     # Valid config JSON
     valid_config_json = '{"community": {"sessions": {}}}'
-    
+
     monkeypatch.setenv("DH_MCP_CONFIG_FILE", "/fake/path/config.json")
-    
+
     # Mock aiofiles.open
     mock_aiofiles_open = MagicMock()
     mock_async_context_manager = AsyncMock()
     mock_file_object = AsyncMock()
-    
+
     mock_aiofiles_open.return_value = mock_async_context_manager
     mock_async_context_manager.__aenter__.return_value = mock_file_object
     mock_file_object.read.return_value = valid_config_json
-    
+
     # Mock json.dumps to raise an error (simulating non-serializable config)
     def mock_json_dumps(*args, **kwargs):
         raise TypeError("Object is not JSON serializable")
-    
+
     with patch("aiofiles.open", mock_aiofiles_open):
         with patch("json.dumps", side_effect=mock_json_dumps):
             cm = ConfigManager()
             await cm.clear_config_cache()
             with caplog.at_level("WARNING"):
                 await cm.get_config()
-    
+
     # Verify the warning was logged
     assert "Failed to format config as JSON" in caplog.text
+
 
 @pytest.mark.asyncio
 async def test_config_validation_error_in_load_and_validate(monkeypatch):
     """Test configuration validation error handling in load_and_validate_config."""
-    from unittest.mock import patch, AsyncMock, MagicMock
+    from unittest.mock import AsyncMock, MagicMock, patch
+
     from deephaven_mcp.config import ConfigManager, McpConfigurationError
-    
+
     # Create invalid config that will fail validation
     invalid_config_json = '{"unknown_top_level_key": "invalid"}'
-    
+
     monkeypatch.setenv("DH_MCP_CONFIG_FILE", "/fake/path/config.json")
-    
+
     # Mock aiofiles.open
     mock_aiofiles_open = MagicMock()
     mock_async_context_manager = AsyncMock()
     mock_file_object = AsyncMock()
-    
+
     mock_aiofiles_open.return_value = mock_async_context_manager
     mock_async_context_manager.__aenter__.return_value = mock_file_object
     mock_file_object.read.return_value = invalid_config_json
-    
+
     with patch("aiofiles.open", mock_aiofiles_open):
         cm = ConfigManager()
         await cm.clear_config_cache()
-        
-        with pytest.raises(McpConfigurationError, match="Error loading configuration file"):
+
+        with pytest.raises(
+            McpConfigurationError, match="Error loading configuration file"
+        ):
             await cm.get_config()

--- a/tests/lifecycle/test_lifecycle__community.py
+++ b/tests/lifecycle/test_lifecycle__community.py
@@ -1,9 +1,9 @@
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from deephaven_mcp.sessions._lifecycle import community as _lifecycle_community
 from deephaven_mcp.sessions._errors import SessionCreationError
+from deephaven_mcp.sessions._lifecycle import community as _lifecycle_community
 
 
 @pytest.mark.asyncio
@@ -133,8 +133,10 @@ async def test_create_session_for_worker(monkeypatch):
         return "SESSION"
 
     cfg_mgr = MagicMock()
-    cfg_mgr.get_config = AsyncMock(return_value={"community": {"sessions": {"workerZ": {"host": "localhost"}}}})
-    
+    cfg_mgr.get_config = AsyncMock(
+        return_value={"community": {"sessions": {"workerZ": {"host": "localhost"}}}}
+    )
+
     monkeypatch.setattr(
         _lifecycle_community.config, "get_config_section", fake_get_config_section
     )
@@ -156,7 +158,9 @@ async def test_create_session_for_worker_config_fail(monkeypatch):
         return {"community": {"sessions": {"workerZ": {"host": "localhost"}}}}
 
     cfg_mgr = MagicMock()
-    cfg_mgr.get_config = AsyncMock(return_value={"community": {"sessions": {"workerZ": {"host": "localhost"}}}})
+    cfg_mgr.get_config = AsyncMock(
+        return_value={"community": {"sessions": {"workerZ": {"host": "localhost"}}}}
+    )
     monkeypatch.setattr(
         _lifecycle_community.config, "get_config_section", fake_get_config_section
     )
@@ -181,8 +185,10 @@ async def test_create_session_for_worker_session_fail(monkeypatch):
         raise RuntimeError("fail-create")
 
     cfg_mgr = MagicMock()
-    cfg_mgr.get_config = AsyncMock(return_value={"community": {"sessions": {"workerZ": {"host": "localhost"}}}})
-    
+    cfg_mgr.get_config = AsyncMock(
+        return_value={"community": {"sessions": {"workerZ": {"host": "localhost"}}}}
+    )
+
     monkeypatch.setattr(
         _lifecycle_community.config, "get_config_section", fake_get_config_section
     )

--- a/tests/mcp_systems_server/test_mcp_systems_server__mcp.py
+++ b/tests/mcp_systems_server/test_mcp_systems_server__mcp.py
@@ -154,9 +154,11 @@ async def test_describe_workers_all_available_with_versions():
     config_manager.get_system_session_names = AsyncMock(return_value=["w1", "w2"])
     config_manager.get_config = AsyncMock(
         return_value={
-            "community_sessions": {
-                "w1": {"session_type": "python"},
-                "w2": {"session_type": "python"},
+            "community": {
+                "sessions": {
+                    "w1": {"session_type": "python"},
+                    "w2": {"session_type": "python"},
+                }
             }
         }
     )
@@ -203,9 +205,11 @@ async def test_describe_workers_all_available_no_versions():
     config_manager.get_community_session_config = AsyncMock(return_value=["w1", "w2"])
     config_manager.get_config = AsyncMock(
         return_value={
-            "community_sessions": {
-                "w1": {"session_type": "python"},
-                "w2": {"session_type": "python"},
+            "community": {
+                "sessions": {
+                    "w1": {"session_type": "python"},
+                    "w2": {"session_type": "python"},
+                }
             }
         }
     )
@@ -243,10 +247,12 @@ async def test_describe_workers_some_unavailable():
     )
     config_manager.get_config = AsyncMock(
         return_value={
-            "community_sessions": {
-                "w1": {"session_type": "python"},
-                "w2": {"session_type": "python"},
-                "w3": {"session_type": "python"},
+            "community": {
+                "sessions": {
+                    "w1": {"session_type": "python"},
+                    "w2": {"session_type": "python"},
+                    "w3": {"session_type": "python"},
+                }
             }
         }
     )
@@ -298,7 +304,13 @@ async def test_describe_workers_non_python():
     session_manager = AsyncMock()
     config_manager.get_community_session_config = AsyncMock(return_value=["w1"])
     config_manager.get_config = AsyncMock(
-        return_value={"community_sessions": {"w1": {"session_type": "groovy"}}}
+        return_value={
+            "community": {
+                "sessions": {
+                    "w1": {"session_type": "groovy"},
+                }
+            }
+        }
     )
     alive_session = MagicMock(is_alive=True)
     session_manager.get_or_create_session = AsyncMock(return_value=alive_session)
@@ -332,7 +344,13 @@ async def test_describe_workers_versions_error():
     session_manager = AsyncMock()
     config_manager.get_community_session_config = AsyncMock(return_value=["w1"])
     config_manager.get_config = AsyncMock(
-        return_value={"community_sessions": {"w1": {"session_type": "python"}}}
+        return_value={
+            "community": {
+                "sessions": {
+                    "w1": {"session_type": "python"},
+                }
+            }
+        }
     )
     alive_session = MagicMock(is_alive=True)
     session_manager.get_or_create_session = AsyncMock(return_value=alive_session)
@@ -370,10 +388,12 @@ async def test_describe_workers_some_unavailable_with_versions():
     )
     config_manager.get_config = AsyncMock(
         return_value={
-            "community_sessions": {
-                "w1": {"session_type": "python"},
-                "w2": {"session_type": "python"},
-                "w3": {"session_type": "python"},
+            "community": {
+                "sessions": {
+                    "w1": {"session_type": "python"},
+                    "w2": {"session_type": "python"},
+                    "w3": {"session_type": "python"},
+                }
             }
         }
     )
@@ -425,7 +445,13 @@ async def test_describe_workers_worker_config_error():
     session_manager = AsyncMock()
     config_manager.get_community_session_config = AsyncMock(return_value=["w1"])
     config_manager.get_config = AsyncMock(
-        return_value={"community_sessions": {"w1": {"session_type": "python"}}}
+        return_value={
+            "community": {
+                "sessions": {
+                    "w1": {"session_type": "python"},
+                }
+            }
+        }
     )
     # Simulate get_worker_config raising an exception
     config_manager.get_community_session_config = AsyncMock(

--- a/tests/sessions/test_sessions.py
+++ b/tests/sessions/test_sessions.py
@@ -28,7 +28,7 @@ def mock_config_manager():
     mock = MagicMock()
     mock.get_system_session_config = AsyncMock(return_value={"host": "localhost"})
     mock.get_config = AsyncMock(
-        return_value={"community_sessions": {"local": {"host": "localhost"}}}
+        return_value={"community": {"sessions": {"local": {"host": "localhost"}}}}
     )
     return mock
 
@@ -65,7 +65,7 @@ async def test_session_manager_concurrent_get_or_create_session():
     mock_cfg_mgr = AsyncMock()
     mock_cfg_mgr.get_worker_config = AsyncMock(return_value={"host": "localhost"})
     mock_cfg_mgr.get_config = AsyncMock(
-        return_value={"community_sessions": {"workerX": {"host": "localhost"}}}
+        return_value={"community": {"sessions": {"workerX": {"host": "localhost"}}}}
     )
     mgr = SessionManager(mock_cfg_mgr)
     # Patch helpers to simulate slow creation and track calls
@@ -103,7 +103,7 @@ async def test_session_manager_concurrent_get_or_create_session_failure():
     mock_cfg_mgr = AsyncMock()
     mock_cfg_mgr.get_worker_config = AsyncMock(return_value={"host": "localhost"})
     mock_cfg_mgr.get_config = AsyncMock(
-        return_value={"community_sessions": {"workerX": {"host": "localhost"}}}
+        return_value={"community": {"sessions": {"workerX": {"host": "localhost"}}}}
     )
     mgr = SessionManager(mock_cfg_mgr)
     with patch(
@@ -125,7 +125,7 @@ async def test_session_manager_delegates_to_helpers():
     mock_cfg_mgr = AsyncMock()
     mock_cfg_mgr.get_worker_config = AsyncMock(return_value={"host": "localhost"})
     mock_cfg_mgr.get_config = AsyncMock(
-        return_value={"community_sessions": {"workerY": {"host": "localhost"}}}
+        return_value={"community": {"sessions": {"workerY": {"host": "localhost"}}}}
     )
     mgr = SessionManager(mock_cfg_mgr)
     with patch(
@@ -189,7 +189,7 @@ async def test_get_or_create_session_liveness_exception(session_manager, caplog)
         return_value={"host": "localhost"}
     )
     session_manager._config_manager.get_config = AsyncMock(
-        return_value={"community_sessions": {"foo": {"host": "localhost"}}}
+        return_value={"community": {"sessions": {"foo": {"host": "localhost"}}}}
     )
     with patch("deephaven_mcp.sessions._lifecycle.community.Session", new=MagicMock()):
         await session_manager.get_or_create_session("foo")
@@ -211,7 +211,7 @@ async def test_get_or_create_session_reuses_alive(session_manager):
         return_value={"host": "localhost"}
     )
     session_manager._config_manager.get_config = AsyncMock(
-        return_value={"community_sessions": {"foo": {"host": "localhost"}}}
+        return_value={"community": {"sessions": {"foo": {"host": "localhost"}}}}
     )
     with patch("deephaven_mcp.sessions._sessions.Session", new=MagicMock()):
         result = await session_manager.get_or_create_session("foo")
@@ -226,7 +226,7 @@ async def test_get_or_create_session_creates_new(session_manager):
         return_value=fake_config
     )
     session_manager._config_manager.get_config = AsyncMock(
-        return_value={"community_sessions": {"foo": {"host": "localhost"}}}
+        return_value={"community": {"sessions": {"foo": {"host": "localhost"}}}}
     )
     mock_session = MagicMock()
     with (
@@ -254,7 +254,7 @@ async def test_get_or_create_session_handles_dead(session_manager):
         return_value=fake_config
     )
     session_manager._config_manager.get_config = AsyncMock(
-        return_value={"community_sessions": {"foo": {"host": "localhost"}}}
+        return_value={"community": {"sessions": {"foo": {"host": "localhost"}}}}
     )
     mock_session = MagicMock()
     with (


### PR DESCRIPTION
This pull request introduces a significant restructuring of the `deephaven_mcp.json` configuration schema, along with updates to related documentation, code, and tests to align with the new structure. The changes primarily focus on renaming and reorganizing the keys for better clarity and consistency.

### Configuration Schema Updates:
* Updated the `deephaven_mcp.json` file structure to replace the top-level keys `"community_sessions"` and `"enterprise_systems"` with `"community"` (containing a nested `"sessions"` key) and `"enterprise"` (containing a nested `"systems"` key). This change improves readability and aligns with naming conventions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L137-R141) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L163-R163) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R203-R217)

### Documentation Updates:
* Updated the `README.md` and `docs/DEVELOPER_GUIDE.md` to reflect the new configuration schema, including examples and detailed descriptions of the new `"community.sessions"` and `"enterprise.systems"` keys. [[1]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092L235-R246) [[2]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092R293-R300) [[3]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092L317-R330)
* Adjusted file structure and formatting instructions in the developer guide to exclude specific files (e.g., `_version.py` and `.venv`) from formatting checks.

### Code Adjustments:
* Updated the logic in `src/deephaven_mcp/mcp_systems_server/_mcp.py` and `src/deephaven_mcp/sessions/_lifecycle/community.py` to use the new `"community.sessions"` and `"enterprise.systems"` paths when accessing configuration data. [[1]](diffhunk://#diff-60092dbbbfa83e400a59c40ac74be5d6e6985843f2134995ac9377921367b207L221-R222) [[2]](diffhunk://#diff-a21f941f4c6bd62017f8b03ab4867debbe4fa98995e3fea379ce6c05278a5124L175-R177)

### Test Updates:
* Refactored tests to align with the new configuration schema, including changes to mock data and method calls for retrieving configuration sections. [[1]](diffhunk://#diff-db7172defcb38b6d04b4183e66a74d1161c4d01753d50d6a7d8d1cd2ed828feaL118-R126) [[2]](diffhunk://#diff-5db528fd840ffd0a4709337fcc98c9f349f5ca4b94c622bb46fa9a203583dcf7L157-R163) [[3]](diffhunk://#diff-5db528fd840ffd0a4709337fcc98c9f349f5ca4b94c622bb46fa9a203583dcf7L246-R257)

### File Structure Adjustments:
* Renamed and reorganized several internal modules and test files to improve clarity and modularity, including moving session-related utilities to a new `sessions/` directory.