### PR TITLE
feat: add a global exception logger for the docs server

### DIFF
--- a/src/deephaven_mcp/mcp_docs_server/__init__.py
+++ b/src/deephaven_mcp/mcp_docs_server/__init__.py
@@ -16,16 +16,78 @@ Usage:
 See the project README for configuration details, available tools, and usage examples.
 """
 
+import asyncio
 import logging
 import os
 import sys
-from typing import Literal
+from types import TracebackType
+from typing import Any, Literal
 
 from ._mcp import mcp_server
 
 __all__ = ["mcp_server", "run_server"]
 
 _LOGGER = logging.getLogger(__name__)
+
+
+# TODO: make this generic for all MCP servers
+def setup_global_exception_logging() -> None:
+    """
+    Set up global logging for all unhandled exceptions (synchronous and asynchronous) in the process.
+
+    This function ensures that:
+        - All uncaught exceptions in synchronous code (main thread and others) are logged using the root logger.
+        - All uncaught exceptions in asynchronous code (asyncio event loops) are logged, regardless of which event loop is used or where it is created.
+        - The function monkey-patches `asyncio.new_event_loop` so that every new event loop created in the process will have the async exception handler set automatically.
+        - The handler is also set on the current event loop, if one exists.
+
+    Why use this:
+        - Guarantees that no unhandled error (sync or async) will go unnoticed in logs, even if event loops are created by libraries or frameworks outside your control.
+        - Useful for debugging, production monitoring, and ensuring robust error visibility in long-running server processes.
+
+    Usage:
+        Call this function once at process startup (e.g., at the top of your main() entrypoint) before any event loops are created or server code is run.
+    """
+
+    def _log_unhandled_exception(
+        exc_type: type[BaseException],
+        exc_value: BaseException,
+        exc_traceback: TracebackType | None,
+    ) -> None:
+        if issubclass(exc_type, KeyboardInterrupt):
+            return
+        # Logger.error expects exc_info to be a tuple of (type, value, traceback) or True
+        _LOGGER.error(
+            "UNHANDLED EXCEPTION", exc_info=(exc_type, exc_value, exc_traceback)
+        )
+
+    # sys.excepthook expects a function with this signature
+    sys.excepthook = _log_unhandled_exception
+
+    def _asyncio_exception_handler(
+        loop: asyncio.AbstractEventLoop, context: dict[str, Any]
+    ) -> None:
+        _LOGGER.error(
+            f"UNHANDLED ASYNC EXCEPTION: {context.get('message')}",
+            exc_info=context.get("exception"),
+        )
+
+    # Patch new_event_loop to always set the handler
+    _orig_new_event_loop = asyncio.new_event_loop
+
+    def _patched_new_event_loop(*args: Any, **kwargs: Any) -> asyncio.AbstractEventLoop:
+        loop = _orig_new_event_loop(*args, **kwargs)
+        loop.set_exception_handler(_asyncio_exception_handler)
+        return loop
+
+    asyncio.new_event_loop = _patched_new_event_loop
+
+    # Also set on the current loop if possible
+    try:
+        asyncio.get_event_loop().set_exception_handler(_asyncio_exception_handler)
+    except RuntimeError:
+        # If no event loop is running, this is fine; it will be set when the loop is created
+        pass
 
 
 def run_server(
@@ -71,6 +133,7 @@ def main() -> None:
     """
     import argparse
 
+    setup_global_exception_logging()
     parser = argparse.ArgumentParser(description="Start the Deephaven MCP Docs server.")
     parser.add_argument(
         "-t",

--- a/src/deephaven_mcp/mcp_docs_server/__init__.py
+++ b/src/deephaven_mcp/mcp_docs_server/__init__.py
@@ -77,7 +77,11 @@ def setup_global_exception_logging() -> None:
         exception = context.get("exception")
         _LOGGER.error(
             f"UNHANDLED ASYNC EXCEPTION: {context.get('message')}",
-            exc_info=(type(exception), exception, exception.__traceback__) if exception else None,
+            exc_info=(
+                (type(exception), exception, exception.__traceback__)
+                if exception
+                else None
+            ),
         )
 
     # Patch new_event_loop to always set the handler

--- a/src/deephaven_mcp/mcp_docs_server/__init__.py
+++ b/src/deephaven_mcp/mcp_docs_server/__init__.py
@@ -29,6 +29,9 @@ __all__ = ["mcp_server", "run_server"]
 
 _LOGGER = logging.getLogger(__name__)
 
+# Idempotency guard for global exception logging setup
+_EXC_LOGGING_INSTALLED = False
+
 
 # TODO: make this generic for all MCP servers
 def setup_global_exception_logging() -> None:
@@ -48,6 +51,10 @@ def setup_global_exception_logging() -> None:
     Usage:
         Call this function once at process startup (e.g., at the top of your main() entrypoint) before any event loops are created or server code is run.
     """
+    global _EXC_LOGGING_INSTALLED
+    if _EXC_LOGGING_INSTALLED:
+        return
+    _EXC_LOGGING_INSTALLED = True
 
     def _log_unhandled_exception(
         exc_type: type[BaseException],

--- a/src/deephaven_mcp/mcp_docs_server/_mcp.py
+++ b/src/deephaven_mcp/mcp_docs_server/_mcp.py
@@ -78,6 +78,12 @@ FastMCP: The server instance for the Deephaven documentation tools.
 
 @mcp_server.exception_handler(Exception)
 async def global_exception_handler(request: Request, exc: Exception):
+    from starlette.exceptions import HTTPException
+    
+    if isinstance(exc, HTTPException):
+        # Re-raise HTTPException to preserve its status code and message
+        raise exc
+    
     _LOGGER.exception(f"Unhandled exception for request {request.method} {request.url}: {exc}")
     return JSONResponse(
         status_code=500,

--- a/src/deephaven_mcp/mcp_docs_server/_mcp.py
+++ b/src/deephaven_mcp/mcp_docs_server/_mcp.py
@@ -29,7 +29,6 @@ Example (agentic usage):
     To install Deephaven, ...
 """
 
-import logging
 import os
 
 from mcp.server.fastmcp import FastMCP
@@ -37,8 +36,6 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from ..openai import OpenAIClient
-
-_LOGGER = logging.getLogger(__name__)
 
 #: The API key for authenticating with the Inkeep-powered LLM API. Must be set in the environment. Private to this module.
 _INKEEP_API_KEY = os.environ.get("INKEEP_API_KEY")
@@ -76,20 +73,7 @@ FastMCP: The server instance for the Deephaven documentation tools.
 - Host binding is controlled by the MCP_DOCS_HOST environment variable (default: 127.0.0.1).
 """
 
-@mcp_server.exception_handler(Exception)
-async def global_exception_handler(request: Request, exc: Exception):
-    from starlette.exceptions import HTTPException
-    
-    if isinstance(exc, HTTPException):
-        # Re-raise HTTPException to preserve its status code and message
-        raise exc
-    
-    _LOGGER.exception(f"Unhandled exception for request {request.method} {request.url}: {exc}")
-    return JSONResponse(
-        status_code=500,
-        content={"detail": "Internal Server Error"},
-    )
-    
+
 @mcp_server.custom_route("/health", methods=["GET"])  # type: ignore[misc]
 async def health_check(request: Request) -> JSONResponse:
     """


### PR DESCRIPTION
This pull request introduces logging functionality and a global exception handler to improve error handling in the `mcp_docs_server` module. The changes include setting up a logger, defining a global exception handler to log unhandled exceptions, and ensuring consistent error responses.

### Logging Enhancements:
* Added a `_LOGGER` instance using the `logging` module to enable logging within the module. (`src/deephaven_mcp/mcp_docs_server/_mcp.py`, [[1]](diffhunk://#diff-070b912a5a632c8fe1653a97389742b603e6b5332189595cc08ad96af9f94d01R32) [[2]](diffhunk://#diff-070b912a5a632c8fe1653a97389742b603e6b5332189595cc08ad96af9f94d01R41-R42)

### Error Handling Improvements:
* Implemented a `global_exception_handler` to log unhandled exceptions and return a standardized JSON response with a 500 status code. (`src/deephaven_mcp/mcp_docs_server/_mcp.py`, [src/deephaven_mcp/mcp_docs_server/_mcp.pyR79-R85](diffhunk://#diff-070b912a5a632c8fe1653a97389742b603e6b5332189595cc08ad96af9f94d01R79-R85))feat: add a global exception logger for the docs server