### PR TITLE
docs: Update README with accurate Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ graph TD
 
 ## Prerequisites
 
-*   **Python**: Version 3.9 or later. ([Download Python](https://www.python.org/downloads/))
+*   **Python**: Version 3.10 or later. ([Download Python](https://www.python.org/downloads/))
 *   **Access to [Deephaven Community Core](https://deephaven.io/community/) instance(s):** To use the [MCP Systems Server](#systems-server-architecture) for interacting with Deephaven, you will need one or more [Deephaven Community Core](https://deephaven.io/community/) instances running and network-accessible.
 *   **Choose your Python environment setup method:**
     *   **Option A: [`uv`](https://docs.astral.sh/uv/) (Recommended)**: A very fast Python package installer and resolver. If you don't have it, you can install it via `pip install uv` or see the [uv installation guide](https://github.com/astral-sh/uv#installation).
@@ -97,11 +97,11 @@ Choose one of the following Python environment and package management tools:
 If you have [`uv`](docs/UV.md) installed (or install it via `pip install uv`):
 
 1.  **Create and activate a virtual environment with your desired Python version:**
-    [uv](docs/UV.md) works best when operating within a virtual environment. To create one (e.g., named `.venv`) using a specific Python interpreter (e.g., Python 3.9), run:
+    [uv](docs/UV.md) works best when operating within a virtual environment. To create one (e.g., named `.venv`) using a specific Python interpreter (e.g., Python 3.10), run:
     ```sh
-    uv venv .venv -p 3.9 
+    uv venv .venv -p 3.10 
     ```
-    Replace `3.9` with your target Python version (e.g., `3.10`, `3.11`) or the full path to a Python executable.
+    Replace `3.10` with your target Python version (e.g., `3.11`, `3.12`, etc.) or the full path to a Python executable.
     Then, activate it:
     *   On macOS/Linux: `source .venv/bin/activate`
     *   On Windows (PowerShell): `.venv\Scripts\Activate.ps1`


### PR DESCRIPTION
`pip install deephaven-mcp` failed in Python 3.9 for me. 3.10 appears to be the minimum required version.