### PR TITLE
ci: add copilot to the CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -30,4 +30,6 @@ jobs:
           remote-repository-name:  cla
           branch: 'main'
           path-to-signatures: 'signatures/version1/cla.json'
-          #allowlist: user1,bot*
+          allowlist: |
+            github-copilot[bot]
+            github-actions[bot]


### PR DESCRIPTION
This pull request updates the CLA workflow configuration to explicitly allow certain GitHub bot accounts to bypass the Contributor License Agreement check.

Workflow configuration update:

* [`.github/workflows/cla.yml`](diffhunk://#diff-7aa0bb52169dde77e9033b3f574e1c8e686f567ea884691c7aace8f6297d216eL33-R35): Added `github-copilot[bot]` and `github-actions[bot]` to the `allowlist` for CLA checks, ensuring these bots are not blocked by the CLA requirement.