### PR TITLE
feat: add server resilience for unsupported HTTP methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "aiohttp>=3.11.18",         # Async HTTP client (stress testing, SSE)
     # MCP protocol and orchestration
     "autogen-ext[mcp]>=0.5.4",  # MCP orchestration and agentic tools
-    "mcp[cli]>=1.12.0",          # CLI and fastmcp server
+    "mcp[cli]>=1.12.4",          # CLI and fastmcp server
     "mcp-proxy",                # SSE/Streamable-HTTP proxy support
     # Deephaven integration
     "pydeephaven>=0.39",      # Deephaven Python API

--- a/scripts/test_server_resilience.py
+++ b/scripts/test_server_resilience.py
@@ -35,19 +35,27 @@ async def run_test_server():
     env["INKEEP_API_KEY"] = "test-key-for-resilience-testing"
     env["MCP_DOCS_HOST"] = SERVER_HOST
     env["MCP_DOCS_PORT"] = str(SERVER_PORT)
-    
+
     # Start the server
     logger.info(f"Starting MCP docs server on {SERVER_URL}")
-    process = subprocess.Popen([
-        sys.executable, "-m", "deephaven_mcp.mcp_docs_server.main",
-        "-t", "streamable-http"
-    ], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "deephaven_mcp.mcp_docs_server.main",
+            "-t",
+            "streamable-http",
+        ],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
     # Wait for server to start
     max_wait = 10  # seconds
     start_time = time.time()
     server_ready = False
-    
+
     while time.time() - start_time < max_wait:
         try:
             async with httpx.AsyncClient() as client:
@@ -59,12 +67,12 @@ async def run_test_server():
         except (httpx.ConnectError, httpx.RequestError):
             pass
         await asyncio.sleep(0.5)
-    
+
     if not server_ready:
         process.terminate()
         process.wait()
         raise RuntimeError("Server failed to start within timeout")
-    
+
     try:
         yield process
     finally:
@@ -82,15 +90,15 @@ async def test_unsupported_methods():
     """Test various unsupported HTTP methods to ensure server resilience."""
     test_methods = ["HEAD", "PUT", "DELETE", "PATCH", "OPTIONS"]
     test_paths = ["/mcp", "/health", "/nonexistent"]
-    
+
     results = []
-    
+
     async with httpx.AsyncClient(timeout=10.0) as client:
         for method in test_methods:
             for path in test_paths:
                 url = f"{SERVER_URL}{path}"
                 logger.info(f"Testing {method} {url}")
-                
+
                 try:
                     response = await client.request(method, url)
                     result = {
@@ -98,31 +106,33 @@ async def test_unsupported_methods():
                         "path": path,
                         "status_code": response.status_code,
                         "success": True,
-                        "error": None
+                        "error": None,
                     }
-                    logger.info(f"  → {response.status_code} (OK - server handled gracefully)")
+                    logger.info(
+                        f"  → {response.status_code} (OK - server handled gracefully)"
+                    )
                 except Exception as e:
                     result = {
                         "method": method,
                         "path": path,
                         "status_code": None,
                         "success": False,
-                        "error": str(e)
+                        "error": str(e),
                     }
                     logger.error(f"  → Exception: {e} (BAD - server may have crashed)")
-                
+
                 results.append(result)
-                
+
                 # Small delay between requests
                 await asyncio.sleep(0.1)
-    
+
     return results
 
 
 async def test_server_still_responsive():
     """Test that the server is still responsive after unsupported method requests."""
     logger.info("Testing server responsiveness after unsupported method tests")
-    
+
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             # Test health endpoint
@@ -141,34 +151,36 @@ async def test_server_still_responsive():
 async def main():
     """Main test function."""
     logger.info("Starting MCP docs server resilience test")
-    
+
     async with run_test_server() as server_process:
         # Test unsupported HTTP methods
         logger.info("\n=== Testing Unsupported HTTP Methods ===")
         results = await test_unsupported_methods()
-        
+
         # Check if server is still responsive
         logger.info("\n=== Testing Server Responsiveness ===")
         server_responsive = await test_server_still_responsive()
-        
+
         # Analyze results
         logger.info("\n=== Test Results ===")
         total_tests = len(results)
         successful_tests = sum(1 for r in results if r["success"])
         failed_tests = total_tests - successful_tests
-        
+
         logger.info(f"Total tests: {total_tests}")
         logger.info(f"Successful (graceful handling): {successful_tests}")
         logger.info(f"Failed (exceptions/crashes): {failed_tests}")
         logger.info(f"Server still responsive: {'Yes' if server_responsive else 'No'}")
-        
+
         # Print detailed results for failures
         if failed_tests > 0:
             logger.info("\nFailed tests:")
             for result in results:
                 if not result["success"]:
-                    logger.info(f"  {result['method']} {result['path']}: {result['error']}")
-        
+                    logger.info(
+                        f"  {result['method']} {result['path']}: {result['error']}"
+                    )
+
         # Overall assessment
         if failed_tests == 0 and server_responsive:
             logger.info("\n✅ SUCCESS: Server is resilient to unsupported HTTP methods")

--- a/scripts/test_server_resilience.py
+++ b/scripts/test_server_resilience.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+Test script to verify MCP docs server resilience against unsupported HTTP methods.
+
+This script tests that the server gracefully handles unsupported HTTP methods
+(like HEAD requests) without crashing, returning proper error responses instead.
+"""
+
+import asyncio
+import logging
+import os
+import signal
+import subprocess
+import sys
+import time
+from contextlib import asynccontextmanager
+
+import httpx
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Server configuration
+SERVER_HOST = "127.0.0.1"
+SERVER_PORT = 8001
+SERVER_URL = f"http://{SERVER_HOST}:{SERVER_PORT}"
+
+
+@asynccontextmanager
+async def run_test_server():
+    """Context manager to start and stop the MCP docs server for testing."""
+    # Set required environment variable
+    env = os.environ.copy()
+    env["INKEEP_API_KEY"] = "test-key-for-resilience-testing"
+    env["MCP_DOCS_HOST"] = SERVER_HOST
+    env["MCP_DOCS_PORT"] = str(SERVER_PORT)
+    
+    # Start the server
+    logger.info(f"Starting MCP docs server on {SERVER_URL}")
+    process = subprocess.Popen([
+        sys.executable, "-m", "deephaven_mcp.mcp_docs_server.main",
+        "-t", "streamable-http"
+    ], env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    
+    # Wait for server to start
+    max_wait = 10  # seconds
+    start_time = time.time()
+    server_ready = False
+    
+    while time.time() - start_time < max_wait:
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(f"{SERVER_URL}/health")
+                if response.status_code == 200:
+                    server_ready = True
+                    logger.info("Server is ready")
+                    break
+        except (httpx.ConnectError, httpx.RequestError):
+            pass
+        await asyncio.sleep(0.5)
+    
+    if not server_ready:
+        process.terminate()
+        process.wait()
+        raise RuntimeError("Server failed to start within timeout")
+    
+    try:
+        yield process
+    finally:
+        # Clean shutdown
+        logger.info("Shutting down server")
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+
+
+async def test_unsupported_methods():
+    """Test various unsupported HTTP methods to ensure server resilience."""
+    test_methods = ["HEAD", "PUT", "DELETE", "PATCH", "OPTIONS"]
+    test_paths = ["/mcp", "/health", "/nonexistent"]
+    
+    results = []
+    
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        for method in test_methods:
+            for path in test_paths:
+                url = f"{SERVER_URL}{path}"
+                logger.info(f"Testing {method} {url}")
+                
+                try:
+                    response = await client.request(method, url)
+                    result = {
+                        "method": method,
+                        "path": path,
+                        "status_code": response.status_code,
+                        "success": True,
+                        "error": None
+                    }
+                    logger.info(f"  → {response.status_code} (OK - server handled gracefully)")
+                except Exception as e:
+                    result = {
+                        "method": method,
+                        "path": path,
+                        "status_code": None,
+                        "success": False,
+                        "error": str(e)
+                    }
+                    logger.error(f"  → Exception: {e} (BAD - server may have crashed)")
+                
+                results.append(result)
+                
+                # Small delay between requests
+                await asyncio.sleep(0.1)
+    
+    return results
+
+
+async def test_server_still_responsive():
+    """Test that the server is still responsive after unsupported method requests."""
+    logger.info("Testing server responsiveness after unsupported method tests")
+    
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            # Test health endpoint
+            response = await client.get(f"{SERVER_URL}/health")
+            if response.status_code == 200:
+                logger.info("  → Health endpoint still responsive ✓")
+                return True
+            else:
+                logger.error(f"  → Health endpoint returned {response.status_code} ✗")
+                return False
+    except Exception as e:
+        logger.error(f"  → Health endpoint failed: {e} ✗")
+        return False
+
+
+async def main():
+    """Main test function."""
+    logger.info("Starting MCP docs server resilience test")
+    
+    async with run_test_server() as server_process:
+        # Test unsupported HTTP methods
+        logger.info("\n=== Testing Unsupported HTTP Methods ===")
+        results = await test_unsupported_methods()
+        
+        # Check if server is still responsive
+        logger.info("\n=== Testing Server Responsiveness ===")
+        server_responsive = await test_server_still_responsive()
+        
+        # Analyze results
+        logger.info("\n=== Test Results ===")
+        total_tests = len(results)
+        successful_tests = sum(1 for r in results if r["success"])
+        failed_tests = total_tests - successful_tests
+        
+        logger.info(f"Total tests: {total_tests}")
+        logger.info(f"Successful (graceful handling): {successful_tests}")
+        logger.info(f"Failed (exceptions/crashes): {failed_tests}")
+        logger.info(f"Server still responsive: {'Yes' if server_responsive else 'No'}")
+        
+        # Print detailed results for failures
+        if failed_tests > 0:
+            logger.info("\nFailed tests:")
+            for result in results:
+                if not result["success"]:
+                    logger.info(f"  {result['method']} {result['path']}: {result['error']}")
+        
+        # Overall assessment
+        if failed_tests == 0 and server_responsive:
+            logger.info("\n✅ SUCCESS: Server is resilient to unsupported HTTP methods")
+            return 0
+        else:
+            logger.error("\n❌ FAILURE: Server is not fully resilient")
+            return 1
+
+
+if __name__ == "__main__":
+    try:
+        exit_code = asyncio.run(main())
+        sys.exit(exit_code)
+    except KeyboardInterrupt:
+        logger.info("Test interrupted by user")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"Test failed with exception: {e}")
+        sys.exit(1)

--- a/src/deephaven_mcp/mcp_docs_server/_mcp.py
+++ b/src/deephaven_mcp/mcp_docs_server/_mcp.py
@@ -92,7 +92,6 @@ from ..openai import OpenAIClient, OpenAIClientError
 _LOGGER = logging.getLogger(__name__)
 
 
-
 # The API key for authenticating with the Inkeep-powered LLM API
 try:
     _INKEEP_API_KEY: str = os.environ["INKEEP_API_KEY"]

--- a/tests/mcp_docs_server/test_mcp_docs_server_mcp.py
+++ b/tests/mcp_docs_server/test_mcp_docs_server_mcp.py
@@ -624,7 +624,7 @@ async def test_error_handling_middleware_success_path(monkeypatch):
     mock_request = MagicMock(spec=Request)
     mock_request.method = "GET"
     mock_request.url.path = "/health"
-    
+
     # Mock successful call_next
     mock_response = MagicMock()
     mock_call_next = AsyncMock(return_value=mock_response)
@@ -648,7 +648,7 @@ async def test_error_handling_middleware_http_exception(monkeypatch):
     mock_request = MagicMock(spec=Request)
     mock_request.method = "HEAD"
     mock_request.url.path = "/mcp"
-    
+
     # Mock call_next that raises HTTPException
     http_exc = HTTPException(status_code=405, detail="Method Not Allowed")
     mock_call_next = AsyncMock(side_effect=http_exc)
@@ -684,7 +684,7 @@ async def test_error_handling_middleware_http_exception_no_detail(monkeypatch):
     mock_request = MagicMock(spec=Request)
     mock_request.method = "HEAD"
     mock_request.url.path = "/mcp"
-    
+
     # Mock call_next that raises HTTPException with no detail
     http_exc = HTTPException(status_code=404, detail=None)
     mock_call_next = AsyncMock(side_effect=http_exc)
@@ -713,7 +713,7 @@ async def test_error_handling_middleware_general_exception(monkeypatch):
     mock_request = MagicMock(spec=Request)
     mock_request.method = "HEAD"
     mock_request.url.path = "/mcp"
-    
+
     # Mock call_next that raises a general exception
     general_exc = ValueError("Something went wrong")
     mock_call_next = AsyncMock(side_effect=general_exc)


### PR DESCRIPTION
This pull request introduces robust error handling for the MCP docs server to ensure resilience against unsupported or invalid HTTP methods. It adds a custom middleware and exception handler to gracefully catch and respond to HTTP errors (such as 405 Method Not Allowed) and unexpected exceptions, preventing server crashes and returning structured error responses. Comprehensive tests have been added to verify the new error handling logic. Additionally, a new script is provided to validate server resilience by simulating unsupported HTTP method requests.

**Server Error Handling Improvements**
* Added `ErrorHandlingMiddleware` to intercept HTTP errors and general exceptions, converting them into structured JSON error responses and preventing server crashes on unsupported HTTP methods. (`src/deephaven_mcp/mcp_docs_server/_mcp.py`)
* Registered the middleware and a custom HTTP exception handler in the MCP docs server setup to ensure all HTTP exceptions are handled consistently and gracefully. (`src/deephaven_mcp/mcp_docs_server/_mcp.py`)

**Testing and Validation**
* Added extensive unit tests for the error handling middleware and custom exception handler, including scenarios for successful requests, HTTP exceptions with/without details, and general exceptions. (`tests/mcp_docs_server/test_mcp_docs_server_mcp.py`)
* Introduced a new script to test server resilience against unsupported HTTP methods, verifying that the server remains responsive and does not crash when receiving such requests. (`scripts/test_server_resilience.py`)

**Test Suite Enhancements**
* Updated test imports to include necessary Starlette exception and response types for new error handling logic. (`tests/mcp_docs_server/test_mcp_docs_server_mcp.py`)