### PR TITLE
fix: Fix community initialization and session_id name

### DIFF
--- a/src/deephaven_mcp/resource_manager/_registry_combined.py
+++ b/src/deephaven_mcp/resource_manager/_registry_combined.py
@@ -240,6 +240,9 @@ class CombinedSessionRegistry(BaseRegistry[BaseItemManager]):
                 len(community_sessions),
             )
 
+            # Mark as initialized before updating enterprise sessions since they check initialization
+            self._initialized = True
+
             # Update enterprise sessions from controller clients
             await self._update_enterprise_sessions()
             _LOGGER.debug(
@@ -247,8 +250,6 @@ class CombinedSessionRegistry(BaseRegistry[BaseItemManager]):
                 self.__class__.__name__,
             )
 
-            # Mark as initialized only after all steps complete successfully
-            self._initialized = True
             _LOGGER.info("[%s] initialization complete", self.__class__.__name__)
 
     @override

--- a/src/deephaven_mcp/resource_manager/_registry_combined.py
+++ b/src/deephaven_mcp/resource_manager/_registry_combined.py
@@ -232,7 +232,8 @@ class CombinedSessionRegistry(BaseRegistry[BaseItemManager]):
                 _LOGGER.debug(
                     "[%s] loading community session '%s'", self.__class__.__name__, name
                 )
-                self._items[name] = session
+                # Use the session's full_name (which is properly encoded) as the key
+                self._items[session.full_name] = session
 
             _LOGGER.debug(
                 "[%s] loaded %d community sessions",

--- a/tests/resource_manager/test_registry_combined.py
+++ b/tests/resource_manager/test_registry_combined.py
@@ -7,7 +7,6 @@ controller client caching, and lifecycle management.
 """
 
 import asyncio
-import logging
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -267,9 +266,11 @@ class TestCombinedSessionRegistryInitialization:
         self, combined_registry, mock_config_manager
     ):
         """Test initialization when community registry has sessions to load."""
-        # Create mock session managers
+        # Create mock session managers with proper full_name attributes
         mock_session1 = MagicMock()
+        mock_session1.full_name = "community:local:session1"
         mock_session2 = MagicMock()
+        mock_session2.full_name = "community:local:session2"
         community_sessions = {
             "community:local:session1": mock_session1,
             "community:local:session2": mock_session2,
@@ -414,9 +415,11 @@ class TestCombinedSessionRegistryInitialization:
         existing_session = MagicMock()
         combined_registry._items["community:local:session1"] = existing_session
 
-        # Create new mock session managers
+        # Create new mock session managers with proper full_name attributes
         new_mock_session1 = MagicMock()
+        new_mock_session1.full_name = "community:local:session1"
         new_mock_session2 = MagicMock()
+        new_mock_session2.full_name = "community:local:session2"
         community_sessions = {
             "community:local:session1": new_mock_session1,  # Should overwrite existing
             "community:local:session2": new_mock_session2,  # Should be new


### PR DESCRIPTION
This pull request updates the initialization logic for community sessions in the combined registry and improves test coverage to ensure correct behavior. The main change is to use the session's `full_name` attribute as the key when storing sessions, which ensures proper encoding and prevents key mismatches. The tests are also updated to mock the `full_name` attribute, verifying that sessions are stored and overwritten correctly.

Initialization logic improvements:
* Changed the registry to store community sessions using each session's `full_name` as the key, ensuring consistent and properly encoded keys. Also, moved the `_initialized` flag to be set before updating enterprise sessions to align with dependency checks.

Test enhancements:
* Updated tests to mock the `full_name` attribute for community session objects, ensuring that keys are set and overwritten as expected in the registry. [[1]](diffhunk://#diff-ea101e092cbac24253d448bb970b40bed0b38b04746b4e14306a2e5cc146cd89L270-R273) [[2]](diffhunk://#diff-ea101e092cbac24253d448bb970b40bed0b38b04746b4e14306a2e5cc146cd89L417-R422)
* Removed unnecessary imports from the test file for clarity.