### PR TITLE
feat: better error messages on bad auth types

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,12 +164,11 @@ In addition to `"community"`, the `deephaven_mcp.json` file can optionally inclu
 
 *   `host` (string): Hostname or IP address of the [Deephaven Community Core](https://deephaven.io/community/) worker (e.g., `"localhost"`).
 *   `port` (integer): Port number for the worker connection (e.g., `10000`).
-*   `auth_type` (string): Authentication type. Supported values include:
-    *   `"token"`: For token-based authentication.
-    *   `"basic"`: For username/password authentication (use `auth_token` for `username:password` or see server docs for separate fields if supported).
-    *   `"anonymous"`: For no authentication.
-    *   `"io.deephaven.authentication.psk.PskAuthenticationHandler"`: For Pre-Shared Key (PSK) authentication - see [PSK Authentication](#psk-pre-shared-key-authentication) section below.
-*   `auth_token` (string): The authentication token if `auth_type` is `"token"`. For `"basic"` auth, this is typically the password, or `username:password` if the server expects it combined. For PSK auth, this is the pre-shared key value. Consult your [Deephaven server's authentication documentation](https://deephaven.io/core/docs/how-to-guides/authentication/auth-uname-pw/) for specifics.
+*   `auth_type` (string): Authentication type. Common values include:
+    *   `"Anonymous"`: For no authentication (default if omitted).
+    *   `"Basic"`: For username/password authentication (requires `auth_token` in `"username:password"` format).
+    *   Custom authenticator strings (e.g., `"io.deephaven.authentication.psk.PskAuthenticationHandler"` for Pre-Shared Key authentication).
+*   `auth_token` (string): The authentication token. For `"Basic"` auth, this must be in `"username:password"` format. For custom authenticators, this should conform to the specific requirements of that authenticator. Ignored when `auth_type` is `"Anonymous"`. Consult your [Deephaven server's authentication documentation](https://deephaven.io/core/docs/how-to-guides/authentication/auth-uname-pw/) for specifics.
 *   `auth_token_env_var` (string): Alternative to `auth_token` - specifies the name of an environment variable containing the authentication token (e.g., `"MY_AUTH_TOKEN"`). Mutually exclusive with `auth_token`.
 *   `never_timeout` (boolean): If `true`, the MCP server will attempt to configure the session to this worker to never time out. Server-side configurations may still override this.
 *   `session_type` (string): Specifies the type of session to create. Common values are `"groovy"` or `"python"`.
@@ -219,11 +218,11 @@ The `enterprise` key with nested `"systems"` in `deephaven_mcp.json` is a dictio
         "auth_token": "your-shared-secret-key",
         "session_type": "python"
       },
-      "secure_community_worker": {
+      "basic_auth_session": {
         "host": "secure.deephaven.example.com",
         "port": 10002,
-        "auth_type": "token",
-        "auth_token": "your-community-secret-api-token-here",
+        "auth_type": "Basic",
+        "auth_token": "username:password",
         "use_tls": true,
         "tls_root_certs": "/path/to/community_root.crt"
       }

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -296,12 +296,11 @@ All fields within a session's configuration object are optional. If a field is o
 
 *   `host` (string): Hostname or IP address of the Deephaven Community Core worker (e.g., `"localhost"`).
 *   `port` (integer): Port number for the worker connection (e.g., `10000`).
-*   `auth_type` (string): Authentication method. Supported values include:
-    *   `"token"`: For token-based authentication (e.g., bearer tokens). The actual token value is supplied via `auth_token` or `auth_token_env_var`.
-    *   `"basic"`: For username/password based HTTP Basic authentication. The password (or combined `username:password`) is supplied via `auth_token` or `auth_token_env_var`. Consult the Deephaven server's authentication guide for specifics.
-    *   `"anonymous"`: For connections requiring no authentication.
-    *   `"io.deephaven.authentication.psk.PskAuthenticationHandler"`: For Pre-Shared Key (PSK) authentication. Requires the full Java class name as shown. The pre-shared key value is supplied via `auth_token` or `auth_token_env_var`. See [PSK Authentication Configuration](#psk-authentication-configuration) below for detailed setup instructions.
-*   `auth_token` (string, optional): The direct authentication token or password. Use this OR `auth_token_env_var`, but not both. Required if `auth_type` is `"token"` or `"basic"` and `auth_token_env_var` is not specified.
+*   `auth_type` (string): Authentication method. Common values include:
+    *   `"Anonymous"`: For connections requiring no authentication (default if omitted).
+    *   `"Basic"`: For username/password authentication. The `auth_token` must be in `"username:password"` format.
+    *   Custom authenticator strings (e.g., `"io.deephaven.authentication.psk.PskAuthenticationHandler"` for Pre-Shared Key authentication). The full Java class name is required. See [PSK Authentication Configuration](#psk-authentication-configuration) below for detailed setup instructions.
+*   `auth_token` (string, optional): The authentication token. For `"Basic"` auth, this must be in `"username:password"` format. For custom authenticators, this should conform to the specific requirements of that authenticator. Ignored when `auth_type` is `"Anonymous"`. Use this OR `auth_token_env_var`, but not both.
 *   `auth_token_env_var` (string, optional): The name of an environment variable from which to read the authentication token. Use this OR `auth_token`, but not both. If specified, the token will be sourced from this environment variable.
 *   `never_timeout` (boolean): If `true`, the MCP server attempts to configure the session to this worker to prevent timeouts. Server-side settings might still enforce timeouts.
 *   `session_type` (string): Specifies the programming language for the session (e.g., `"python"`, `"groovy"`).
@@ -328,11 +327,11 @@ All fields within a session's configuration object are optional. If a field is o
         "auth_token": "your-shared-secret-key",
         "session_type": "python"
       },
-      "secure_remote_worker": {
+      "basic_auth_worker": {
         "host": "secure.deephaven.example.com",
         "port": 10002,
-        "auth_type": "token",
-        "auth_token_env_var": "MY_REMOTE_TOKEN_ENV_VAR",
+        "auth_type": "Basic",
+        "auth_token_env_var": "MY_BASIC_AUTH_ENV_VAR",
         "never_timeout": true,
         "session_type": "groovy",
         "use_tls": true,

--- a/src/deephaven_mcp/config/_community_session.py
+++ b/src/deephaven_mcp/config/_community_session.py
@@ -26,7 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 # Known auth_type values from Deephaven Python client documentation
 _KNOWN_AUTH_TYPES: set[str] = {
     "Anonymous",  # Default, no authentication required
-    "Basic",      # Requires username:password format in auth_token
+    "Basic",  # Requires username:password format in auth_token
     "io.deephaven.authentication.psk.PskAuthenticationHandler",  # Requires auth_token
 }
 """
@@ -132,6 +132,53 @@ def validate_community_sessions_config(
         validate_single_community_session_config(session_name, session_config_item)
 
 
+def _validate_field_types(session_name: str, config_item: dict[str, Any]) -> None:
+    """Validate field types for a community session configuration."""
+    for field_name, field_value in config_item.items():
+        if field_name not in _ALLOWED_COMMUNITY_SESSION_FIELDS:
+            raise CommunitySessionConfigurationError(
+                f"Unknown field '{field_name}' in community session config for {session_name}"
+            )
+
+        allowed_types = _ALLOWED_COMMUNITY_SESSION_FIELDS[field_name]
+        if isinstance(allowed_types, tuple):
+            if not isinstance(field_value, allowed_types):
+                expected_type_names = ", ".join(t.__name__ for t in allowed_types)
+                raise CommunitySessionConfigurationError(
+                    f"Field '{field_name}' in community session config for {session_name} "
+                    f"must be one of types ({expected_type_names}), got {type(field_value).__name__}"
+                )
+        elif not isinstance(field_value, allowed_types):
+            raise CommunitySessionConfigurationError(
+                f"Field '{field_name}' in community session config for {session_name} "
+                f"must be of type {allowed_types.__name__}, got {type(field_value).__name__}"
+            )
+
+
+def _validate_auth_configuration(
+    session_name: str, config_item: dict[str, Any]
+) -> None:
+    """Validate authentication-related configuration for a community session."""
+    # Check for mutual exclusivity of auth_token and auth_token_env_var
+    if "auth_token" in config_item and "auth_token_env_var" in config_item:
+        raise CommunitySessionConfigurationError(
+            f"In community session config for '{session_name}', both 'auth_token' and 'auth_token_env_var' are set. "
+            "Please use only one."
+        )
+
+    # Check auth_type value and log if it's not a known value
+    if "auth_type" in config_item:
+        auth_type_value = config_item["auth_type"]
+        if auth_type_value not in _KNOWN_AUTH_TYPES:
+            _LOGGER.warning(
+                "Community session config for '%s' uses auth_type='%s' which is not a commonly known value. "
+                "Known values are: %s. Custom authenticators are also valid - if this is intentional, you can ignore this warning.",
+                session_name,
+                auth_type_value,
+                ", ".join(sorted(_KNOWN_AUTH_TYPES)),
+            )
+
+
 def validate_single_community_session_config(
     session_name: str,
     config_item: dict[str, Any],
@@ -154,44 +201,8 @@ def validate_single_community_session_config(
             f"Community session config for {session_name} must be a dictionary, got {type(config_item)}"
         )
 
-    for field_name, field_value in config_item.items():
-        if field_name not in _ALLOWED_COMMUNITY_SESSION_FIELDS:
-            raise CommunitySessionConfigurationError(
-                f"Unknown field '{field_name}' in community session config for {session_name}"
-            )
-
-        allowed_types = _ALLOWED_COMMUNITY_SESSION_FIELDS[field_name]
-        if isinstance(allowed_types, tuple):
-            if not isinstance(field_value, allowed_types):
-                expected_type_names = ", ".join(t.__name__ for t in allowed_types)
-                raise CommunitySessionConfigurationError(
-                    f"Field '{field_name}' in community session config for {session_name} "
-                    f"must be one of types ({expected_type_names}), got {type(field_value).__name__}"
-                )
-        elif not isinstance(field_value, allowed_types):
-            raise CommunitySessionConfigurationError(
-                f"Field '{field_name}' in community session config for {session_name} "
-                f"must be of type {allowed_types.__name__}, got {type(field_value).__name__}"
-            )
-
-    # Check for mutual exclusivity of auth_token and auth_token_env_var
-    if "auth_token" in config_item and "auth_token_env_var" in config_item:
-        raise CommunitySessionConfigurationError(
-            f"In community session config for '{session_name}', both 'auth_token' and 'auth_token_env_var' are set. "
-            "Please use only one."
-        )
-
-    # Check auth_type value and log if it's not a known value
-    if "auth_type" in config_item:
-        auth_type_value = config_item["auth_type"]
-        if auth_type_value not in _KNOWN_AUTH_TYPES:
-            _LOGGER.warning(
-                "Community session config for '%s' uses auth_type='%s' which is not a commonly known value. "
-                "Known values are: %s. Custom authenticators are also valid - if this is intentional, you can ignore this warning.",
-                session_name,
-                auth_type_value,
-                ", ".join(sorted(_KNOWN_AUTH_TYPES))
-            )
+    _validate_field_types(session_name, config_item)
+    _validate_auth_configuration(session_name, config_item)
 
     for required_field in _REQUIRED_FIELDS:
         if required_field not in config_item:

--- a/tests/config/test_config__community_session.py
+++ b/tests/config/test_config__community_session.py
@@ -1,6 +1,7 @@
 """Tests for Deephaven MCP community session specific configuration logic."""
 
 from unittest.mock import patch
+import logging
 
 import pytest
 
@@ -324,3 +325,45 @@ def test_validate_community_sessions_invalid_item(mock_validate_single):
     assert mock_validate_single.call_count == 2
     mock_validate_single.assert_any_call("valid_session", {"host": "localhost"})
     mock_validate_single.assert_any_call("invalid_session", {"port": "not_an_int"})
+
+
+def test_validate_single_cs_auth_type_known_values_no_warning(caplog):
+    """Test that known auth_type values don't generate warnings."""
+    with caplog.at_level(logging.WARNING):
+        # Test known values
+        validate_single_community_session_config("test_session", {"auth_type": "Anonymous"})
+        validate_single_community_session_config("test_session", {"auth_type": "Basic"})
+        
+    # Should have no warnings
+    assert len(caplog.records) == 0
+
+
+def test_validate_single_cs_auth_type_unknown_value_warning(caplog):
+    """Test that unknown auth_type values generate appropriate warnings."""
+    with caplog.at_level(logging.WARNING):
+        # Test unknown value (common typo)
+        validate_single_community_session_config("test_session", {"auth_type": "anonymous"})
+        
+    # Should have exactly one warning
+    assert len(caplog.records) == 1
+    warning_message = caplog.records[0].message
+    assert "auth_type='anonymous'" in warning_message
+    assert "not a commonly known value" in warning_message
+    assert "Anonymous, Basic" in warning_message
+    assert "Custom authenticators are also valid" in warning_message
+
+
+def test_validate_single_cs_auth_type_custom_authenticator_warning(caplog):
+    """Test that custom authenticator strings generate warnings but are still valid."""
+    with caplog.at_level(logging.WARNING):
+        # Test custom authenticator (should warn but not fail)
+        validate_single_community_session_config("test_session", {
+            "auth_type": "com.example.custom.AuthenticationHandler"
+        })
+        
+    # Should have exactly one warning
+    assert len(caplog.records) == 1
+    warning_message = caplog.records[0].message
+    assert "com.example.custom.AuthenticationHandler" in warning_message
+    assert "not a commonly known value" in warning_message
+    assert "Custom authenticators are also valid" in warning_message

--- a/tests/config/test_config__community_session.py
+++ b/tests/config/test_config__community_session.py
@@ -1,7 +1,7 @@
 """Tests for Deephaven MCP community session specific configuration logic."""
 
-from unittest.mock import patch
 import logging
+from unittest.mock import patch
 
 import pytest
 
@@ -331,9 +331,11 @@ def test_validate_single_cs_auth_type_known_values_no_warning(caplog):
     """Test that known auth_type values don't generate warnings."""
     with caplog.at_level(logging.WARNING):
         # Test known values
-        validate_single_community_session_config("test_session", {"auth_type": "Anonymous"})
+        validate_single_community_session_config(
+            "test_session", {"auth_type": "Anonymous"}
+        )
         validate_single_community_session_config("test_session", {"auth_type": "Basic"})
-        
+
     # Should have no warnings
     assert len(caplog.records) == 0
 
@@ -342,8 +344,10 @@ def test_validate_single_cs_auth_type_unknown_value_warning(caplog):
     """Test that unknown auth_type values generate appropriate warnings."""
     with caplog.at_level(logging.WARNING):
         # Test unknown value (common typo)
-        validate_single_community_session_config("test_session", {"auth_type": "anonymous"})
-        
+        validate_single_community_session_config(
+            "test_session", {"auth_type": "anonymous"}
+        )
+
     # Should have exactly one warning
     assert len(caplog.records) == 1
     warning_message = caplog.records[0].message
@@ -357,10 +361,10 @@ def test_validate_single_cs_auth_type_custom_authenticator_warning(caplog):
     """Test that custom authenticator strings generate warnings but are still valid."""
     with caplog.at_level(logging.WARNING):
         # Test custom authenticator (should warn but not fail)
-        validate_single_community_session_config("test_session", {
-            "auth_type": "com.example.custom.AuthenticationHandler"
-        })
-        
+        validate_single_community_session_config(
+            "test_session", {"auth_type": "com.example.custom.AuthenticationHandler"}
+        )
+
     # Should have exactly one warning
     assert len(caplog.records) == 1
     warning_message = caplog.records[0].message


### PR DESCRIPTION
This pull request updates the documentation and validation logic for the `auth_type` field in Deephaven MCP community session configuration, improving clarity and error handling for authentication setup. It introduces a set of commonly known authentication types, adds warnings for unknown or custom values, and enhances tests to cover these scenarios.

**Documentation improvements:**

* Updated `README.md` and `docs/DEVELOPER_GUIDE.md` to clarify supported and recommended `auth_type` values, emphasizing `"Anonymous"` and `"Basic"` as common options, and explaining the requirements for custom authenticator strings. Example configurations now use `"Basic"` instead of `"token"` for basic authentication and specify the required token format. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L167-R171) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L222-R225) [[3]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092L299-R303) [[4]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092L331-R334)

**Validation logic enhancements:**

* Added a set of known `auth_type` values (`"Anonymous"`, `"Basic"`, and PSK handler) in `src/deephaven_mcp/config/_community_session.py` and updated validation to log a warning if an unknown or custom value is used, helping users catch typos or misconfigurations. [[1]](diffhunk://#diff-4ec53cf4e6252431d024de39ec9646e44429b6dc3ed2d08026907b5f4d4e0c3cR26-R37) [[2]](diffhunk://#diff-4ec53cf4e6252431d024de39ec9646e44429b6dc3ed2d08026907b5f4d4e0c3cR184-R195)

**Testing improvements:**

* Added new tests in `tests/config/test_config__community_session.py` to verify that known `auth_type` values do not trigger warnings, while unknown or custom values do, ensuring the new validation logic works as intended. [[1]](diffhunk://#diff-663b5d21f5c88a5d53a1196bf34d621de927117559d4612f197165fae3b1c5e1R328-R369) [[2]](diffhunk://#diff-663b5d21f5c88a5d53a1196bf34d621de927117559d4612f197165fae3b1c5e1R4)