### PR TITLE
chore: fix windsurf pytest rule

### DIFF
--- a/.windsurf/rules.yaml
+++ b/.windsurf/rules.yaml
@@ -1,8 +1,0 @@
-# Windsurf file-based rule: Use 'uv run pytest' for unit tests
-unit_test:
-  runner: "uv run pytest"
-  files:
-    - "tests/**/*.py"
-    - "src/**/*.py"
-  description: |
-    Always use 'uv run pytest' instead of 'pytest' directly for running unit tests in this repository. This ensures the correct environment and dependencies are used.

--- a/.windsurf/rules/pytest.md
+++ b/.windsurf/rules/pytest.md
@@ -1,0 +1,6 @@
+---
+trigger: always_on
+---
+
+# Unit test guidelines
+- Always use 'uv run pytest' instead of 'pytest' directly for running unit tests in this repository. This ensures the correct environment and dependencies are used.


### PR DESCRIPTION
This pull request updates the documentation and configuration for running unit tests to clarify and reinforce the use of `uv run pytest` instead of running `pytest` directly.

Test guidelines and configuration updates:

* Removed the file-based Windsurf rule in `.windsurf/rules.yaml` that enforced using `uv run pytest` for unit tests.
* Added a new always-on Markdown guideline in `.windsurf/rules/pytest.md` instructing developers to use `uv run pytest` for running unit tests, ensuring the correct environment and dependencies are used.