### PR TITLE
docs: add upgrade instructions and improve formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@
 
 - [Overview](#overview)
 - [🚀 Quick Start](#-quick-start)
+- [🔄 Quick Upgrade](#-quick-upgrade)
 - [Key Use Cases](#key-use-cases)
 - [Deephaven MCP Components](#deephaven-mcp-components)
 - [Architecture Diagrams](#architecture-diagrams)
 - [Prerequisites](#prerequisites)
 - [Installation & Initial Setup](#installation--initial-setup)
+- [Upgrading](#upgrading)
 - [Configuring `deephaven_mcp.json`](#configuring-deephaven_mcpjson)
 - [Environment Variables](#environment-variables)
 - [AI Tool Setup](#ai-tool-setup)
@@ -171,7 +173,7 @@ rm -rf .venv
 
 ### 2. Reinstall with the latest version
 
-Repeat the [Quick Start](#-quick-start) steps 1-3 above to reinstall with the latest version.
+Repeat the [🚀 Quick Start](#-quick-start) steps 1-3 above to reinstall with the latest version.
 
 For more upgrade options, see the detailed [Upgrading](#upgrading) section below.
 


### PR DESCRIPTION
This pull request updates the `README.md` to provide clearer instructions for upgrading the `deephaven-mcp` package. The changes make it easier for users to upgrade both in-place and by recreating their virtual environment, and clarify steps for both Community Core and Enterprise users.

Key documentation improvements:

* Added a "Quick Upgrade" section with step-by-step instructions for removing the old virtual environment and reinstalling the latest version of `deephaven-mcp`, making the upgrade process more accessible for existing users.
* Introduced a comprehensive "Upgrading" section detailing both the recommended (virtual environment recreation) and alternative (in-place upgrade) methods, including specific commands for Community Core and Enterprise users, and important notes for Enterprise environments.

Installation instruction enhancements:

* Clarified the installation commands for both Community Core and Enterprise systems by adding explicit code blocks for each case.