### PR TITLE
docs: update path in MCP config example to use generic placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ Here's the standard `mcpServers` configuration for Deephaven. It works for both 
     "command": "/full/path/to/your/.venv/bin/dh-mcp-systems-server",
     "args": [],
     "env": {
-      "DH_MCP_CONFIG_FILE": "/full/path/to/deephaven-mcp/deephaven_mcp.json",
+      "DH_MCP_CONFIG_FILE": "/full/path/to/your/deephaven_mcp.json",
       "PYTHONLOGLEVEL": "INFO"
     }
   },


### PR DESCRIPTION
This pull request updates the documentation to clarify the recommended path for the `DH_MCP_CONFIG_FILE` environment variable in the `mcpServers` configuration example for Deephaven.

- Documentation update:
  * In the `README.md`, changed the example path for `DH_MCP_CONFIG_FILE` to use `/full/path/to/your/deephaven_mcp.json`, making it clear that users should reference their own config file location.
  
  Resolves #73