### PR TITLE
feat: add MCP Apps widget view tool for inline Deephaven iframe rendering

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "aiohttp>=3.11.18",         # Async HTTP client (stress testing, SSE)
     "httpx>=0.24.0",            # HTTP client
     # MCP protocol and orchestration
-    "mcp[cli]>=1.12.0",          # CLI and fastmcp server
+    "mcp[cli]>=1.26.0",          # CLI and fastmcp server (>=1.26 for MCP Apps meta support)
     "mcp-proxy",                # SSE/Streamable-HTTP proxy support
     # Deephaven integration
     "pydeephaven>=0.39",      # Deephaven Python API

--- a/src/deephaven_mcp/client/_session.py
+++ b/src/deephaven_mcp/client/_session.py
@@ -975,6 +975,42 @@ class BaseSession(ClientObjectWrapper[T], Generic[T]):
             _LOGGER.error(f"[CoreSession:tables] Failed to list tables: {e}")
             raise QueryError(f"Failed to list tables: {e}") from e
 
+    async def widgets(self) -> list[dict[str, str | None]]:
+        """
+        Asynchronously retrieve the names and types of all exportable objects in the session.
+
+        Returns a list of dicts, each containing `name` and `type` keys, representing
+        every exportable object (tables, widgets, figures, etc.) currently bound in the
+        Deephaven global namespace.
+
+        Returns:
+            list[dict[str, str | None]]: List of dicts with ``name`` and ``type`` keys.
+
+        Raises:
+            DeephavenConnectionError: If a network or connection error occurs.
+            QueryError: If the operation fails due to a server-side error.
+        """
+        _LOGGER.debug("[CoreSession:widgets] Called")
+        try:
+
+            def _get_widgets() -> list[dict[str, str | None]]:
+                return [
+                    {"name": name, "type": obj.type}
+                    for name, obj in self.wrapped.exportable_objects.items()
+                ]
+
+            return await asyncio.to_thread(_get_widgets)
+        except ConnectionError as e:
+            _LOGGER.error(
+                f"[CoreSession:widgets] Connection error listing widgets: {e}"
+            )
+            raise DeephavenConnectionError(
+                f"Connection error listing widgets: {e}"
+            ) from e
+        except Exception as e:
+            _LOGGER.error(f"[CoreSession:widgets] Failed to list widgets: {e}")
+            raise QueryError(f"Failed to list widgets: {e}") from e
+
     async def is_alive(self) -> bool:
         """
         Asynchronously check if the session is still alive.

--- a/src/deephaven_mcp/config/_community_session.py
+++ b/src/deephaven_mcp/config/_community_session.py
@@ -75,6 +75,8 @@ _ALLOWED_COMMUNITY_SESSION_FIELDS: dict[str, type | tuple[type, ...]] = {
     "tls_root_certs": (str, types.NoneType),
     "client_cert_chain": (str, types.NoneType),
     "client_private_key": (str, types.NoneType),
+    "ui_url_base": str,
+    "widget_path": str,
 }
 """
 Dictionary of allowed community session configuration fields and their expected types.

--- a/src/deephaven_mcp/mcp_systems_server/_mcp.py
+++ b/src/deephaven_mcp/mcp_systems_server/_mcp.py
@@ -13,6 +13,7 @@ The actual MCP tools are defined in the _tools submodules:
 - _tools.script: Script execution and package management
 - _tools.catalog: Enterprise catalog operations
 - _tools.pq: Enterprise persistent query management
+- _tools.widget: Widget view as interactive MCP Apps
 - _tools.shared: Internal utilities
 
 All tools are automatically registered with the MCP server via decorators.
@@ -36,6 +37,7 @@ from deephaven_mcp.mcp_systems_server._tools import (  # noqa: F401
     session_enterprise as _session_enterprise,
 )
 from deephaven_mcp.mcp_systems_server._tools import table as _table  # noqa: F401
+from deephaven_mcp.mcp_systems_server._tools import widget as _widget  # noqa: F401
 from deephaven_mcp.mcp_systems_server._tools.mcp_server import mcp_server
 
 __all__ = [

--- a/src/deephaven_mcp/mcp_systems_server/_tools/mcp_server.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/mcp_server.py
@@ -89,6 +89,13 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, object]]:
         session_registry = CombinedSessionRegistry()
         await session_registry.initialize(config_manager)
 
+        # Update widget-view resource CSP with configured session origins
+        from deephaven_mcp.mcp_systems_server._tools.widget import (
+            update_widget_view_frame_domains,
+        )
+
+        await update_widget_view_frame_domains(config_manager)
+
         # lock for refresh to prevent concurrent refresh operations.
         refresh_lock = asyncio.Lock()
 
@@ -200,6 +207,14 @@ async def mcp_reload(context: Context) -> dict:
             await config_manager.clear_config_cache()
             await session_registry.close()
             await session_registry.initialize(config_manager)
+
+            # Refresh widget-view CSP frameDomains with reloaded config
+            from deephaven_mcp.mcp_systems_server._tools.widget import (
+                update_widget_view_frame_domains,
+            )
+
+            await update_widget_view_frame_domains(config_manager)
+
         _LOGGER.info(
             "[mcp_systems_server:mcp_reload] Success: Session configuration and session cache have been reloaded."
         )

--- a/src/deephaven_mcp/mcp_systems_server/_tools/widget.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/widget.py
@@ -1,0 +1,571 @@
+"""
+Widget View MCP Tools - Open Deephaven Widgets as Interactive MCP Apps.
+
+Provides MCP tools and resources for rendering Deephaven widgets (tables, charts,
+dashboards, etc.) as interactive UI views inside MCP Apps-capable chat clients.
+
+Tools:
+- session_widget_view: Open a Deephaven widget in an interactive inline iframe
+
+Resources:
+- ui://deephaven-mcp/widget-view: HTML view resource for rendering Deephaven widget iframes
+"""
+
+import logging
+import os
+from typing import Any
+from urllib.parse import quote, urlparse
+
+from mcp.server.fastmcp import Context
+
+from deephaven_mcp.config import ConfigManager, get_config_section
+from deephaven_mcp.resource_manager import (
+    CombinedSessionRegistry,
+    CommunitySessionManager,
+    DynamicCommunitySessionManager,
+    EnterpriseSessionManager,
+)
+
+from .mcp_server import mcp_server
+
+_LOGGER = logging.getLogger(__name__)
+
+VIEW_URI = "ui://deephaven-mcp/widget-view"
+
+
+def _build_community_base_url(mgr: CommunitySessionManager) -> str:
+    """Build the base HTTP(S) URL for a community session.
+
+    For dynamic sessions, uses the pre-built ``connection_url``.
+    For static (config-based) sessions, constructs the URL from the
+    ``server`` field if present, otherwise from ``host``, ``port``, and
+    ``use_tls`` config fields.
+
+    Args:
+        mgr: A community session manager.
+
+    Returns:
+        The base URL, e.g. ``"http://localhost:10000"``.
+    """
+    if isinstance(mgr, DynamicCommunitySessionManager):
+        return mgr.connection_url
+
+    # Static session – prefer pre-built "server" URL, fall back to host/port
+    server = mgr._config.get("server")
+    if server:
+        return str(server)
+
+    host = mgr._config.get("host", "localhost")
+    port = mgr._config.get("port", 10000)
+    use_tls = mgr._config.get("use_tls", False)
+    scheme = "https" if use_tls else "http"
+    return f"{scheme}://{host}:{port}"
+
+
+def _get_community_psk_token(
+    mgr: CommunitySessionManager,
+    credential_retrieval_mode: str,
+) -> str | None:
+    """Return the PSK auth token for a community session if allowed.
+
+    Respects the ``security.community.credential_retrieval_mode`` setting:
+    - ``"none"``: never return a token
+    - ``"dynamic_only"``: only for dynamic sessions
+    - ``"static_only"``: only for static (config-based) sessions
+    - ``"all"``: always return a token when available
+
+    Returns ``None`` when no token should be included.
+    """
+    is_dynamic = isinstance(mgr, DynamicCommunitySessionManager)
+    is_static = not is_dynamic
+
+    if credential_retrieval_mode == "none":
+        return None
+    if credential_retrieval_mode == "dynamic_only" and is_static:
+        return None
+    if credential_retrieval_mode == "static_only" and is_dynamic:
+        return None
+
+    # Retrieve auth_type and token
+    if isinstance(mgr, DynamicCommunitySessionManager):
+        auth_type = mgr.launched_session.auth_type.upper()
+        token = mgr.launched_session.auth_token or ""
+    else:
+        auth_type = mgr._config.get("auth_type", "Anonymous").upper()
+        token = mgr._config.get("auth_token", "")
+        if not token:
+            # Try resolving from environment variable
+            env_var = mgr._config.get("auth_token_env_var", "")
+            if env_var:
+                token = os.getenv(env_var, "")
+
+    if auth_type == "PSK" and token:
+        return token
+    return None
+
+
+def _build_community_widget_url(
+    mgr: CommunitySessionManager,
+    widget_name: str,
+    credential_retrieval_mode: str,
+) -> str:
+    """Build a full Deephaven Community iframe widget URL.
+
+    URL format: ``http[s]://host:port/iframe/widget/?name=<widget_name>[&psk=<token>]``
+    """
+    base = _build_community_base_url(mgr)
+    url = f"{base}/iframe/widget/?name={quote(widget_name, safe='')}"
+    token = _get_community_psk_token(mgr, credential_retrieval_mode)
+    if token:
+        url += f"&psk={quote(token, safe='')}"
+    return url
+
+
+def _build_enterprise_widget_url(
+    connection_json_url: str,
+    pq_name: str,
+    widget_name: str,
+) -> str:
+    """Build a Deephaven Enterprise iframe widget URL.
+
+    URL format: ``https://host[:port]/iriside/embed/widget/<pq_name>/<widget_name>``
+
+    The base URL is derived from ``connection_json_url`` by stripping the path
+    (e.g. ``/iris/connection.json``).
+    """
+    parsed = urlparse(connection_json_url)
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    return f"{base}/iriside/embed/widget/{quote(pq_name, safe='')}/{quote(widget_name, safe='')}"
+
+
+# ---------------------------------------------------------------------------
+# MCP App Resource
+# ---------------------------------------------------------------------------
+
+# View HTML served as a ui:// resource for MCP Apps-capable hosts.
+# The View creates an iframe pointing at the Deephaven widget URL
+# received via the tool result.
+_WIDGET_VIEW_HTML = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark">
+  <title>Deephaven Widget</title>
+  <style>
+    :root {
+      --font-sans: system-ui, -apple-system, sans-serif;
+      --color-text-primary: light-dark(#171717, #fafafa);
+      --color-text-secondary: light-dark(#666, #999);
+      --color-background-primary: light-dark(#ffffff, #171717);
+      --color-border-primary: light-dark(#e0e0e0, #333);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; overflow: hidden; background: transparent; }
+    body {
+      font-family: var(--font-sans);
+      color: var(--color-text-primary);
+      display: flex;
+      flex-direction: column;
+    }
+    .container { flex: 1; display: flex; flex-direction: column; min-height: 400px; }
+    .container.fullscreen { min-height: 100vh; }
+    iframe {
+      flex: 1;
+      width: 100%;
+      border: 1px solid var(--color-border-primary);
+      border-radius: 6px;
+      background: var(--color-background-primary);
+    }
+    .container.fullscreen iframe { border-radius: 0; border: none; }
+    .status {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 400px;
+      color: var(--color-text-secondary);
+      font-size: 14px;
+    }
+    .error { color: #e53e3e; }
+    .toolbar {
+      position: absolute; top: 8px; right: 8px;
+      display: flex; gap: 4px;
+      opacity: 0; transition: opacity 0.2s; z-index: 10;
+    }
+    .container:hover .toolbar { opacity: 0.8; }
+    .toolbar:hover { opacity: 1; }
+    .controlBtn {
+      width: 32px; height: 32px;
+      border: none; border-radius: 6px;
+      background: rgba(0, 0, 0, 0.5); color: white; cursor: pointer;
+      display: flex; align-items: center; justify-content: center;
+      transition: background 0.2s; font-size: 14px;
+    }
+    .controlBtn:hover { background: rgba(0, 0, 0, 0.8); }
+    .controlBtn svg { width: 16px; height: 16px; }
+    .fullscreenBtn { display: none; }
+    .fullscreenBtn.available { display: flex; }
+    .fullscreenBtn .collapseIcon { display: none; }
+    .container.fullscreen .fullscreenBtn .expandIcon { display: none; }
+    .container.fullscreen .fullscreenBtn .collapseIcon { display: block; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module">
+    import { App, applyDocumentTheme, applyHostStyleVariables }
+      from "https://unpkg.com/@modelcontextprotocol/ext-apps@0.4.1/app-with-deps";
+
+    const root = document.getElementById("root");
+
+    // State
+    let displayMode = "inline";
+    let fullscreenAvailable = false;
+
+    const app = new App({ name: "Deephaven Widget Viewer", version: "1.0.0" });
+
+    // --- rendering helpers ---
+    function renderLoading() {
+      root.innerHTML = '<div class="container"><div class="status">Loading widget\u2026</div></div>';
+    }
+
+    function renderError(msg) {
+      root.innerHTML = '<div class="container"><div class="status error">' + escapeHtml(msg) + '</div></div>';
+    }
+
+    function escapeHtml(s) {
+      const d = document.createElement("div");
+      d.textContent = s;
+      return d.innerHTML;
+    }
+
+    function renderWidget(url) {
+      const isFS = displayMode === "fullscreen";
+      root.innerHTML = "";
+
+      const container = document.createElement("div");
+      container.className = "container" + (isFS ? " fullscreen" : "");
+      container.style.position = "relative";
+
+      // Toolbar
+      const toolbar = document.createElement("div");
+      toolbar.className = "toolbar";
+
+      // Fullscreen button
+      const fsBtn = document.createElement("button");
+      fsBtn.className = "controlBtn fullscreenBtn" + (fullscreenAvailable ? " available" : "");
+      fsBtn.title = "Toggle fullscreen";
+      fsBtn.innerHTML =
+        '<svg class="expandIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">' +
+          '<path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3"/>' +
+        '</svg>' +
+        '<svg class="collapseIcon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">' +
+          '<path d="M8 3v3a2 2 0 0 1-2 2H3m18 0h-3a2 2 0 0 1-2-2V3m0 18v-3a2 2 0 0 1 2-2h3M3 16h3a2 2 0 0 1 2 2v3"/>' +
+        '</svg>';
+      fsBtn.addEventListener("click", toggleFullscreen);
+      toolbar.appendChild(fsBtn);
+      container.appendChild(toolbar);
+
+      // Iframe
+      const iframe = document.createElement("iframe");
+      iframe.src = url;
+      iframe.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms allow-popups");
+      iframe.setAttribute("allow", "clipboard-write");
+      container.appendChild(iframe);
+
+      root.appendChild(container);
+    }
+
+    // Current widget URL for re-rendering
+    let currentWidgetUrl = null;
+
+    async function toggleFullscreen() {
+      const newMode = displayMode === "fullscreen" ? "inline" : "fullscreen";
+      try {
+        const result = await app.requestDisplayMode({ mode: newMode });
+        displayMode = result.mode;
+      } catch (_) {}
+      if (currentWidgetUrl) renderWidget(currentWidgetUrl);
+    }
+
+    // --- host context ---
+    function applyHostContext(ctx) {
+      if (ctx.theme) applyDocumentTheme(ctx.theme);
+      if (ctx.styles && ctx.styles.variables) applyHostStyleVariables(ctx.styles.variables);
+      if (ctx.availableDisplayModes && ctx.availableDisplayModes.includes("fullscreen")) {
+        fullscreenAvailable = true;
+        const btn = document.querySelector(".fullscreenBtn");
+        if (btn) btn.classList.add("available");
+      }
+      if (ctx.displayMode) {
+        displayMode = ctx.displayMode;
+        if (currentWidgetUrl) renderWidget(currentWidgetUrl);
+      }
+    }
+
+    app.onhostcontextchanged = applyHostContext;
+
+    // --- tool result handling ---
+    app.ontoolresult = (result) => {
+      try {
+        const textBlock = result.content && result.content.find(c => c.type === "text");
+        if (!textBlock) { renderError("No result data received"); return; }
+        const data = JSON.parse(textBlock.text);
+        if (!data.success) { renderError(data.error || "Tool returned an error"); return; }
+        if (!data.widget_url) { renderError("No widget URL in result"); return; }
+        currentWidgetUrl = data.widget_url;
+        renderWidget(currentWidgetUrl);
+      } catch (e) {
+        renderError("Failed to process tool result: " + e.message);
+      }
+    };
+
+    app.onteardown = async () => {
+      currentWidgetUrl = null;
+      root.innerHTML = "";
+      return {};
+    };
+
+    // --- initialise ---
+    renderLoading();
+    await app.connect();
+    const ctx = app.getHostContext();
+    if (ctx) applyHostContext(ctx);
+  </script>
+</body>
+</html>"""
+
+
+@mcp_server.resource(
+    VIEW_URI,
+    mime_type="text/html;profile=mcp-app",
+    meta={
+        "ui": {
+            "csp": {
+                "resourceDomains": ["https://unpkg.com"],
+                "frameDomains": ["http://*", "https://*"],
+            },
+            "prefersBorder": False,
+        }
+    },
+)
+def widget_view_resource() -> str:
+    """Deephaven widget viewer — renders a Deephaven table, chart, or widget in an iframe."""
+    return _WIDGET_VIEW_HTML
+
+
+# ---------------------------------------------------------------------------
+# MCP Tool
+# ---------------------------------------------------------------------------
+
+
+@mcp_server.tool(
+    meta={
+        "ui": {"resourceUri": VIEW_URI},
+        "ui/resourceUri": VIEW_URI,  # legacy format for older hosts
+    },
+)
+async def session_widget_view(
+    context: Context,
+    session_id: str,
+    widget_name: str,
+    pq_name: str | None = None,
+) -> dict[str, Any]:
+    """Open a Deephaven widget (table, chart, dashboard, etc.) as an interactive view.
+
+    Generates a URL to embed the specified widget from a Deephaven session in an
+    inline iframe.  MCP Apps-capable hosts (Claude, ChatGPT, VS Code, etc.) will
+    render the widget directly in the conversation.
+
+    **Terminology Note:**
+    - ``session_id``: A fully qualified session identifier in format
+      ``"community:config:<name>"``, ``"community:dynamic:<name>"``, or
+      ``"enterprise:<system>:<session>"``.
+    - ``widget_name``: The variable name assigned to a table, chart, or other
+      exportable widget in the Deephaven session.
+    - ``pq_name``: (Enterprise only) The name of the Persistent Query or
+      Code Studio containing the widget.
+
+    **AI Agent Usage:**
+    Use this tool after creating a table or chart via ``session_script_run`` to
+    display it visually.  For example, after running a script that creates a
+    variable ``my_table``, call this tool with ``widget_name="my_table"`` to
+    render it inline.
+
+    For Community sessions, ``pq_name`` is ignored.  For Enterprise sessions,
+    ``pq_name`` is required and should be the Persistent Query or Code Studio
+    name that contains the widget.
+
+    Args:
+        session_id: Fully qualified session identifier
+            (e.g. ``"community:config:local_test"``).
+        widget_name: Name of the widget variable to display
+            (e.g. ``"my_table"``).
+        pq_name: (Enterprise only) Name of the Persistent Query or Code Studio.
+            Required for Enterprise sessions; ignored for Community sessions.
+
+    Returns:
+        A dict with these fields:
+
+        Success Response::
+
+            {
+                "success": True,
+                "widget_url": "http://localhost:10000/iframe/widget/?name=my_table",
+                "session_id": "community:config:local_test",
+                "widget_name": "my_table"
+            }
+
+        Error Response::
+
+            {
+                "success": False,
+                "error": "Session 'community:config:xyz' not found: ...",
+                "isError": True
+            }
+
+    Example Success Response (Community)::
+
+        {
+            "success": true,
+            "widget_url": "http://localhost:10000/iframe/widget/?name=sin_table&psk=my_token",
+            "session_id": "community:config:local_test",
+            "widget_name": "sin_table"
+        }
+
+    Example Success Response (Enterprise)::
+
+        {
+            "success": true,
+            "widget_url": "https://dh-enterprise.example.com/iriside/embed/widget/MyQuery/revenue_chart",
+            "session_id": "enterprise:prod:MyQuery",
+            "widget_name": "revenue_chart"
+        }
+
+    Error Scenarios:
+        - Session not found in registry
+        - Enterprise session missing required ``pq_name`` parameter
+        - Enterprise system configuration missing ``connection_json_url``
+    """
+    _LOGGER.info(
+        f"[mcp_systems_server:session_widget_view] Invoked for session_id={session_id!r}, "
+        f"widget_name={widget_name!r}, pq_name={pq_name!r}"
+    )
+
+    try:
+        # Retrieve session registry and config from context
+        session_registry: CombinedSessionRegistry = (
+            context.request_context.lifespan_context["session_registry"]
+        )
+        config_manager: ConfigManager = context.request_context.lifespan_context[
+            "config_manager"
+        ]
+
+        # Look up the session manager
+        try:
+            mgr = await session_registry.get(session_id)
+        except Exception as e:
+            return {
+                "success": False,
+                "error": f"Session '{session_id}' not found: {e}",
+                "isError": True,
+            }
+
+        # --- Community sessions ---
+        if isinstance(mgr, CommunitySessionManager):
+            # Get credential retrieval mode for PSK gating
+            config = await config_manager.get_config()
+            security_config = config.get("security", {})
+            security_community = security_config.get("community", {})
+            credential_retrieval_mode = security_community.get(
+                "credential_retrieval_mode", "none"
+            )
+
+            widget_url = _build_community_widget_url(
+                mgr, widget_name, credential_retrieval_mode
+            )
+
+            _LOGGER.info(
+                f"[mcp_systems_server:session_widget_view] Built community widget URL for "
+                f"session_id={session_id!r}, widget_name={widget_name!r}"
+            )
+
+            return {
+                "success": True,
+                "widget_url": widget_url,
+                "session_id": session_id,
+                "widget_name": widget_name,
+            }
+
+        # --- Enterprise sessions ---
+        if isinstance(mgr, EnterpriseSessionManager):
+            if not pq_name:
+                return {
+                    "success": False,
+                    "error": (
+                        "Enterprise sessions require the 'pq_name' parameter — "
+                        "the name of the Persistent Query or Code Studio that "
+                        "contains the widget."
+                    ),
+                    "isError": True,
+                }
+
+            # Derive the system name from the manager's source
+            system_name = mgr.source
+
+            # Get the enterprise system config to find connection_json_url
+            try:
+                enterprise_systems = get_config_section(
+                    await config_manager.get_config(),
+                    ["enterprise", "systems"],
+                )
+            except KeyError:
+                enterprise_systems = {}
+
+            system_config = enterprise_systems.get(system_name, {})
+            connection_json_url = system_config.get("connection_json_url", "")
+
+            if not connection_json_url:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Enterprise system '{system_name}' does not have a "
+                        f"'connection_json_url' configured. Cannot build widget URL."
+                    ),
+                    "isError": True,
+                }
+
+            widget_url = _build_enterprise_widget_url(
+                connection_json_url, pq_name, widget_name
+            )
+
+            _LOGGER.info(
+                f"[mcp_systems_server:session_widget_view] Built enterprise widget URL for "
+                f"session_id={session_id!r}, pq_name={pq_name!r}, widget_name={widget_name!r}"
+            )
+
+            return {
+                "success": True,
+                "widget_url": widget_url,
+                "session_id": session_id,
+                "widget_name": widget_name,
+            }
+
+        # --- Unknown session type ---
+        return {
+            "success": False,
+            "error": (
+                f"Session '{session_id}' has an unsupported manager type "
+                f"({type(mgr).__name__}). Widget view is supported for "
+                f"Community and Enterprise sessions."
+            ),
+            "isError": True,
+        }
+
+    except Exception as e:
+        _LOGGER.error(
+            f"[mcp_systems_server:session_widget_view] Failed: {e!r}",
+            exc_info=True,
+        )
+        return {"success": False, "error": str(e), "isError": True}

--- a/src/deephaven_mcp/mcp_systems_server/_tools/widget.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/widget.py
@@ -27,6 +27,7 @@ from deephaven_mcp.resource_manager import (
 )
 
 from .mcp_server import mcp_server
+from .shared import _get_session_from_context
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -655,6 +656,94 @@ async def session_widget_view(
     except Exception as e:
         _LOGGER.error(
             f"[mcp_systems_server:session_widget_view] Failed: {e!r}",
+            exc_info=True,
+        )
+        return {"success": False, "error": str(e), "isError": True}
+
+
+@mcp_server.tool()
+async def session_widgets_list(context: Context, session_id: str) -> dict:
+    """
+    MCP Tool: Retrieve the names and types of all exportable objects in a Deephaven session.
+
+    Returns a list of widgets (tables, figures, plots, custom objects, etc.) with their
+    names and types.  This is the widget-level equivalent of ``session_tables_list`` but
+    includes *all* exportable objects, not only tables.
+
+    Terminology Note:
+    - 'Session' and 'worker' are interchangeable terms - both refer to a running Deephaven instance
+    - 'Deephaven Community' and 'Deephaven Core' are interchangeable names for the same product
+    - 'Deephaven Enterprise', 'Deephaven Core+', and 'Deephaven CorePlus' are interchangeable names for the same product
+    - 'DHC' is shorthand for Deephaven Community (also called 'Core')
+    - 'DHE' is shorthand for Deephaven Enterprise (also called 'Core+')
+
+    AI Agent Usage:
+    - Use this for discovering all exportable objects in a session (tables, figures, widgets, etc.)
+    - Complements session_tables_list which only returns table names
+    - Use before session_widget_view to find available widget names to display
+    - Each widget entry includes its ``name`` and ``type`` (e.g. ``"Table"``, ``"Figure"``, etc.)
+    - Always check 'success' field before accessing 'widgets'
+
+    Args:
+        context (Context): The MCP context object, required by MCP protocol but not actively used.
+        session_id (str): ID of the Deephaven session to query. Must match an existing active session.
+
+    Returns:
+        dict: Structured result object with the following keys:
+            - 'success' (bool): Always present. True if widgets were retrieved successfully.
+            - 'session_id' (str, optional): The session ID if successful.
+            - 'widgets' (list[dict], optional): List of dicts with 'name' and 'type' keys if successful.
+            - 'count' (int, optional): Number of widgets found if successful.
+            - 'error' (str, optional): Human-readable error message if retrieval failed.
+            - 'isError' (bool, optional): Present and True only when success=False.
+
+    Example Successful Response:
+        {
+            'success': True,
+            'session_id': 'community:localhost:10000',
+            'widgets': [
+                {'name': 'trades', 'type': 'Table'},
+                {'name': 'my_plot', 'type': 'Figure'},
+                {'name': 'dashboard', 'type': 'PartitionedTable'}
+            ],
+            'count': 3
+        }
+
+    Example Error Response:
+        {
+            'success': False,
+            'error': 'Session not found: community:localhost:10000',
+            'isError': True
+        }
+    """
+    _LOGGER.info(
+        f"[mcp_systems_server:session_widgets_list] Invoked: session_id={session_id!r}"
+    )
+
+    try:
+        session = await _get_session_from_context(
+            "session_widgets_list", context, session_id
+        )
+
+        _LOGGER.debug(
+            f"[mcp_systems_server:session_widgets_list] Retrieving widgets from session '{session_id}'"
+        )
+        widgets = await session.widgets()
+
+        _LOGGER.info(
+            f"[mcp_systems_server:session_widgets_list] Success: Retrieved {len(widgets)} widget(s) from session '{session_id}'"
+        )
+
+        return {
+            "success": True,
+            "session_id": session_id,
+            "widgets": widgets,
+            "count": len(widgets),
+        }
+
+    except Exception as e:
+        _LOGGER.error(
+            f"[mcp_systems_server:session_widgets_list] Failed for session: '{session_id}', error: {e!r}",
             exc_info=True,
         )
         return {"success": False, "error": str(e), "isError": True}

--- a/src/deephaven_mcp/mcp_systems_server/_tools/widget.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/widget.py
@@ -344,7 +344,12 @@ _WIDGET_VIEW_HTML = """\
         "ui": {
             "csp": {
                 "resourceDomains": ["https://unpkg.com"],
-                "frameDomains": ["http://*", "https://*"],
+                "frameDomains": [
+                    "http://*",
+                    "https://*",
+                    "http://localhost:*",
+                    "http://127.0.0.1:*",
+                ],
             },
             "prefersBorder": False,
         }

--- a/src/deephaven_mcp/mcp_systems_server/_tools/widget.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/widget.py
@@ -38,9 +38,10 @@ def _build_community_base_url(mgr: CommunitySessionManager) -> str:
     """Build the base HTTP(S) URL for a community session.
 
     For dynamic sessions, uses the pre-built ``connection_url``.
-    For static (config-based) sessions, constructs the URL from the
-    ``server`` field if present, otherwise from ``host``, ``port``, and
-    ``use_tls`` config fields.
+    For static (config-based) sessions, if ``ui_url_base`` is present in the
+    config it is returned directly — this lets developers point at a local
+    Web UI dev server.  Otherwise the URL is constructed from the ``server``
+    field or from ``host``, ``port``, and ``use_tls``.
 
     Args:
         mgr: A community session manager.
@@ -51,7 +52,12 @@ def _build_community_base_url(mgr: CommunitySessionManager) -> str:
     if isinstance(mgr, DynamicCommunitySessionManager):
         return mgr.connection_url
 
-    # Static session – prefer pre-built "server" URL, fall back to host/port
+    # Static session – honour explicit ui_url_base override first
+    ui_url_base = mgr._config.get("ui_url_base")
+    if ui_url_base:
+        return str(ui_url_base)
+
+    # Prefer pre-built "server" URL, fall back to host/port
     server = mgr._config.get("server")
     if server:
         return str(server)
@@ -112,10 +118,17 @@ def _build_community_widget_url(
 ) -> str:
     """Build a full Deephaven Community iframe widget URL.
 
-    URL format: ``http[s]://host:port/iframe/widget/?name=<widget_name>[&psk=<token>]``
+    URL format: ``http[s]://host:port/<widget_path>?name=<widget_name>[&psk=<token>]``
+
+    The path defaults to ``/iframe/widget/`` but can be overridden via the
+    ``widget_path`` config key on static sessions.
     """
     base = _build_community_base_url(mgr)
-    url = f"{base}/iframe/widget/?name={quote(widget_name, safe='')}"
+    if isinstance(mgr, DynamicCommunitySessionManager):
+        widget_path = "/iframe/widget/"
+    else:
+        widget_path = mgr._config.get("widget_path", "/iframe/widget/")
+    url = f"{base}{widget_path}?name={quote(widget_name, safe='')}"
     token = _get_community_psk_token(mgr, credential_retrieval_mode)
     if token:
         url += f"&psk={quote(token, safe='')}"

--- a/src/deephaven_mcp/mcp_systems_server/_tools/widget.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/widget.py
@@ -18,7 +18,7 @@ from urllib.parse import quote, urlparse
 
 from mcp.server.fastmcp import Context
 
-from deephaven_mcp.config import ConfigManager, get_config_section
+from deephaven_mcp.config import ConfigManager, get_all_config_names, get_config_section
 from deephaven_mcp.resource_manager import (
     CombinedSessionRegistry,
     CommunitySessionManager,
@@ -337,6 +337,95 @@ _WIDGET_VIEW_HTML = """\
 </html>"""
 
 
+def _compute_frame_domains_from_config(config: dict[str, Any]) -> list[str]:
+    """Compute CSP ``frameDomains`` from the Deephaven MCP configuration.
+
+    Extracts the scheme + host + port origin for every configured community
+    session and enterprise system so that the widget-view resource advertises
+    only the domains that the server can actually reach.
+
+    If dynamic session creation (``community.session_creation``) is enabled,
+    ``http://localhost:*`` and ``http://127.0.0.1:*`` are included as
+    catch-alls since dynamic sessions use ephemeral ports on localhost.
+
+    Returns:
+        A deduplicated, sorted list of origin strings
+        (e.g. ``["http://localhost:10000", "https://dh.example.com"]``).
+    """
+    origins: set[str] = set()
+
+    # --- Community static sessions ---
+    session_names = get_all_config_names(config, ["community", "sessions"])
+    for name in session_names:
+        try:
+            sess = get_config_section(config, ["community", "sessions", name])
+        except KeyError:
+            continue
+
+        server_url = sess.get("server")
+        if server_url:
+            parsed = urlparse(str(server_url))
+            origins.add(f"{parsed.scheme}://{parsed.netloc}")
+        else:
+            host = sess.get("host", "localhost")
+            port = sess.get("port", 10000)
+            use_tls = sess.get("use_tls", False)
+            scheme = "https" if use_tls else "http"
+            origins.add(f"{scheme}://{host}:{port}")
+
+    # --- Community dynamic session creation ---
+    try:
+        get_config_section(config, ["community", "session_creation"])
+        # Dynamic sessions run on localhost with ephemeral ports
+        origins.add("http://localhost:*")
+        origins.add("http://127.0.0.1:*")
+    except KeyError:
+        pass
+
+    # --- Enterprise systems ---
+    system_names = get_all_config_names(config, ["enterprise", "systems"])
+    for name in system_names:
+        try:
+            sys_cfg = get_config_section(config, ["enterprise", "systems", name])
+        except KeyError:
+            continue
+
+        conn_url = sys_cfg.get("connection_json_url", "")
+        if conn_url:
+            parsed = urlparse(conn_url)
+            origins.add(f"{parsed.scheme}://{parsed.netloc}")
+
+    return sorted(origins)
+
+
+async def update_widget_view_frame_domains(config_manager: ConfigManager) -> None:
+    """Update the widget-view resource CSP ``frameDomains`` from the live config.
+
+    Called during server lifespan startup (and on config reload) to replace
+    the initial empty ``frameDomains`` list with origins derived from the
+    configured community sessions and enterprise systems.
+
+    Args:
+        config_manager: The active :class:`ConfigManager` instance.
+    """
+    config = await config_manager.get_config()
+    domains = _compute_frame_domains_from_config(config)
+
+    resource = mcp_server._resource_manager._resources.get(VIEW_URI)
+    if resource is None:
+        _LOGGER.warning(
+            "[widget] Cannot update frameDomains: resource %r not registered.",
+            VIEW_URI,
+        )
+        return
+
+    resource.meta["ui"]["csp"]["frameDomains"] = domains
+    _LOGGER.info(
+        "[widget] Updated frameDomains to %s",
+        domains,
+    )
+
+
 @mcp_server.resource(
     VIEW_URI,
     mime_type="text/html;profile=mcp-app",
@@ -344,12 +433,7 @@ _WIDGET_VIEW_HTML = """\
         "ui": {
             "csp": {
                 "resourceDomains": ["https://unpkg.com"],
-                "frameDomains": [
-                    "http://*",
-                    "https://*",
-                    "http://localhost:*",
-                    "http://127.0.0.1:*",
-                ],
+                "frameDomains": [],
             },
             "prefersBorder": False,
         }

--- a/tests/mcp_systems_server/_tools/test_widget.py
+++ b/tests/mcp_systems_server/_tools/test_widget.py
@@ -51,7 +51,25 @@ class TestBuildCommunityBaseUrl:
         mgr._config = {}
         assert _build_community_base_url(mgr) == "http://localhost:10000"
 
-    def test_dynamic_uses_connection_url(self):
+    def test_ui_url_base_override(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {
+            "server": "http://localhost:10000",
+            "ui_url_base": "http://localhost:4000",
+        }
+        assert _build_community_base_url(mgr) == "http://localhost:4000"
+
+    def test_ui_url_base_takes_precedence_over_server(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {
+            "server": "http://localhost:10000",
+            "host": "other",
+            "port": 9999,
+            "ui_url_base": "http://localhost:4000",
+        }
+        assert _build_community_base_url(mgr) == "http://localhost:4000"
+
+    def test_dynamic_ignores_ui_url_base(self):
         mgr = MagicMock(spec=DynamicCommunitySessionManager)
         mgr.connection_url = "http://dynamic-host:12345"
         assert _build_community_base_url(mgr) == "http://dynamic-host:12345"
@@ -156,6 +174,55 @@ class TestBuildCommunityWidgetUrl:
         mgr._config = {"server": "http://localhost:10000"}
         url = _build_community_widget_url(mgr, "my table&special", "none")
         assert "name=my%20table%26special" in url
+
+    def test_ui_url_base_override_from_config(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {
+            "server": "http://localhost:10000",
+            "auth_type": "Anonymous",
+            "ui_url_base": "http://localhost:4000",
+        }
+        url = _build_community_widget_url(mgr, "my_table", "none")
+        assert url == "http://localhost:4000/iframe/widget/?name=my_table"
+
+    def test_ui_url_base_override_with_psk(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {
+            "server": "http://localhost:10000",
+            "auth_type": "PSK",
+            "auth_token": "abc123",
+            "ui_url_base": "http://localhost:4000",
+        }
+        url = _build_community_widget_url(mgr, "my_table", "all")
+        assert url.startswith("http://localhost:4000/iframe/widget/")
+        assert "&psk=abc123" in url
+
+    def test_no_ui_url_base_uses_server(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {"server": "http://localhost:10000", "auth_type": "Anonymous"}
+        url = _build_community_widget_url(mgr, "my_table", "none")
+        assert url == "http://localhost:10000/iframe/widget/?name=my_table"
+
+    def test_custom_widget_path(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {
+            "server": "http://localhost:10000",
+            "auth_type": "Anonymous",
+            "widget_path": "/custom/path/",
+        }
+        url = _build_community_widget_url(mgr, "my_table", "none")
+        assert url == "http://localhost:10000/custom/path/?name=my_table"
+
+    def test_custom_widget_path_with_ui_url_base(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {
+            "server": "http://localhost:10000",
+            "auth_type": "Anonymous",
+            "ui_url_base": "http://localhost:4000",
+            "widget_path": "/custom/path/",
+        }
+        url = _build_community_widget_url(mgr, "my_table", "none")
+        assert url == "http://localhost:4000/custom/path/?name=my_table"
 
 
 # ---------------------------------------------------------------------------
@@ -355,6 +422,30 @@ class TestSessionWidgetViewCommunity:
         assert result["success"] is True
         assert result["widget_url"] == (
             "http://dynamic:11111/iframe/widget/?name=chart"
+        )
+
+    @pytest.mark.asyncio
+    async def test_community_with_ui_url_base_override(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {
+            "server": "http://localhost:10000",
+            "auth_type": "Anonymous",
+            "ui_url_base": "http://localhost:4000",
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.get = AsyncMock(return_value=mgr)
+        context = _make_context(config_dict={}, session_registry=mock_registry)
+
+        result = await session_widget_view(
+            context,
+            session_id="community:config:local",
+            widget_name="my_table",
+        )
+
+        assert result["success"] is True
+        assert result["widget_url"] == (
+            "http://localhost:4000/iframe/widget/?name=my_table"
         )
 
 

--- a/tests/mcp_systems_server/_tools/test_widget.py
+++ b/tests/mcp_systems_server/_tools/test_widget.py
@@ -1,0 +1,478 @@
+"""Tests for the session_widget_view tool and URL construction helpers."""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from conftest import MockContext, create_mock_instance_tracker
+
+from deephaven_mcp._exceptions import RegistryItemNotFoundError
+from deephaven_mcp.mcp_systems_server._tools.widget import (
+    VIEW_URI,
+    _build_community_base_url,
+    _build_community_widget_url,
+    _build_enterprise_widget_url,
+    _get_community_psk_token,
+    session_widget_view,
+    widget_view_resource,
+)
+from deephaven_mcp.resource_manager import (
+    CommunitySessionManager,
+    DynamicCommunitySessionManager,
+    EnterpriseSessionManager,
+)
+
+# ---------------------------------------------------------------------------
+# Helper: _build_community_base_url
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCommunityBaseUrl:
+    """Tests for _build_community_base_url."""
+
+    def test_static_with_server_field(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {"server": "http://myhost:9999"}
+        assert _build_community_base_url(mgr) == "http://myhost:9999"
+
+    def test_static_with_host_port(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {"host": "example.com", "port": 8080, "use_tls": False}
+        assert _build_community_base_url(mgr) == "http://example.com:8080"
+
+    def test_static_with_tls(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {"host": "secure.example.com", "port": 443, "use_tls": True}
+        assert _build_community_base_url(mgr) == "https://secure.example.com:443"
+
+    def test_static_defaults(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {}
+        assert _build_community_base_url(mgr) == "http://localhost:10000"
+
+    def test_dynamic_uses_connection_url(self):
+        mgr = MagicMock(spec=DynamicCommunitySessionManager)
+        mgr.connection_url = "http://dynamic-host:12345"
+        assert _build_community_base_url(mgr) == "http://dynamic-host:12345"
+
+
+# ---------------------------------------------------------------------------
+# Helper: _get_community_psk_token
+# ---------------------------------------------------------------------------
+
+
+class TestGetCommunityPskToken:
+    """Tests for _get_community_psk_token."""
+
+    def test_none_mode_never_returns_token(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {"auth_type": "PSK", "auth_token": "secret"}
+        assert _get_community_psk_token(mgr, "none") is None
+
+    def test_dynamic_only_blocks_static(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {"auth_type": "PSK", "auth_token": "secret"}
+        assert _get_community_psk_token(mgr, "dynamic_only") is None
+
+    def test_static_only_blocks_dynamic(self):
+        mgr = MagicMock(spec=DynamicCommunitySessionManager)
+        mgr.launched_session = MagicMock()
+        mgr.launched_session.auth_type = "psk"
+        mgr.launched_session.auth_token = "secret"
+        assert _get_community_psk_token(mgr, "static_only") is None
+
+    def test_all_mode_returns_static_psk(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {"auth_type": "PSK", "auth_token": "my_psk"}
+        assert _get_community_psk_token(mgr, "all") == "my_psk"
+
+    def test_all_mode_returns_dynamic_psk(self):
+        mgr = MagicMock(spec=DynamicCommunitySessionManager)
+        mgr.launched_session = MagicMock()
+        mgr.launched_session.auth_type = "psk"
+        mgr.launched_session.auth_token = "dynamic_psk"
+        assert _get_community_psk_token(mgr, "all") == "dynamic_psk"
+
+    def test_dynamic_only_allows_dynamic(self):
+        mgr = MagicMock(spec=DynamicCommunitySessionManager)
+        mgr.launched_session = MagicMock()
+        mgr.launched_session.auth_type = "psk"
+        mgr.launched_session.auth_token = "dynamic_token"
+        assert _get_community_psk_token(mgr, "dynamic_only") == "dynamic_token"
+
+    def test_static_only_allows_static(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {"auth_type": "Psk", "auth_token": "static_token"}
+        assert _get_community_psk_token(mgr, "static_only") == "static_token"
+
+    def test_anonymous_auth_returns_none(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {"auth_type": "Anonymous", "auth_token": ""}
+        assert _get_community_psk_token(mgr, "all") is None
+
+    def test_psk_empty_token_returns_none(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {"auth_type": "PSK", "auth_token": ""}
+        assert _get_community_psk_token(mgr, "all") is None
+
+    def test_static_env_var_fallback(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {
+            "auth_type": "PSK",
+            "auth_token": "",
+            "auth_token_env_var": "MY_PSK_ENV",
+        }
+        with patch.dict(os.environ, {"MY_PSK_ENV": "env_psk_value"}):
+            assert _get_community_psk_token(mgr, "all") == "env_psk_value"
+
+
+# ---------------------------------------------------------------------------
+# Helper: _build_community_widget_url
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCommunityWidgetUrl:
+    """Tests for _build_community_widget_url."""
+
+    def test_anonymous_no_psk(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {"server": "http://localhost:10000", "auth_type": "Anonymous"}
+        url = _build_community_widget_url(mgr, "my_table", "none")
+        assert url == "http://localhost:10000/iframe/widget/?name=my_table"
+
+    def test_with_psk(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {
+            "server": "http://localhost:10000",
+            "auth_type": "PSK",
+            "auth_token": "abc123",
+        }
+        url = _build_community_widget_url(mgr, "my_table", "all")
+        assert url == "http://localhost:10000/iframe/widget/?name=my_table&psk=abc123"
+
+    def test_widget_name_url_encoded(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {"server": "http://localhost:10000"}
+        url = _build_community_widget_url(mgr, "my table&special", "none")
+        assert "name=my%20table%26special" in url
+
+
+# ---------------------------------------------------------------------------
+# Helper: _build_enterprise_widget_url
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEnterpriseWidgetUrl:
+    """Tests for _build_enterprise_widget_url."""
+
+    def test_basic_url(self):
+        url = _build_enterprise_widget_url(
+            "https://enterprise.example.com/iris/connection.json",
+            "MyQuery",
+            "revenue_chart",
+        )
+        assert (
+            url
+            == "https://enterprise.example.com/iriside/embed/widget/MyQuery/revenue_chart"
+        )
+
+    def test_url_with_port(self):
+        url = _build_enterprise_widget_url(
+            "https://enterprise.example.com:8443/iris/connection.json",
+            "Analytics",
+            "dashboard",
+        )
+        assert (
+            url
+            == "https://enterprise.example.com:8443/iriside/embed/widget/Analytics/dashboard"
+        )
+
+    def test_special_characters_encoded(self):
+        url = _build_enterprise_widget_url(
+            "https://host.example.com/iris/connection.json",
+            "My Query",
+            "my chart",
+        )
+        assert "/iriside/embed/widget/My%20Query/my%20chart" in url
+
+
+# ---------------------------------------------------------------------------
+# Resource: widget_view_resource
+# ---------------------------------------------------------------------------
+
+
+class TestWidgetViewResource:
+    """Tests for the widget_view_resource MCP resource."""
+
+    def test_returns_html_string(self):
+        html = widget_view_resource()
+        assert isinstance(html, str)
+        assert "<!DOCTYPE html>" in html
+
+    def test_html_contains_iframe_logic(self):
+        html = widget_view_resource()
+        assert "iframe" in html.lower()
+
+    def test_html_contains_mcp_apps_import(self):
+        html = widget_view_resource()
+        assert "@modelcontextprotocol/ext-apps" in html
+
+    def test_html_contains_app_connect(self):
+        html = widget_view_resource()
+        assert "app.connect()" in html
+
+
+# ---------------------------------------------------------------------------
+# Tool: session_widget_view
+# ---------------------------------------------------------------------------
+
+
+def _make_context(config_dict=None, session_registry=None):
+    """Create a MockContext with config_manager and session_registry."""
+    mock_config_manager = MagicMock()
+    mock_config_manager.get_config = AsyncMock(return_value=config_dict or {})
+    if session_registry is None:
+        session_registry = MagicMock()
+        session_registry.get = AsyncMock(
+            side_effect=RegistryItemNotFoundError("not found")
+        )
+    return MockContext(
+        {
+            "config_manager": mock_config_manager,
+            "session_registry": session_registry,
+            "instance_tracker": create_mock_instance_tracker(),
+        }
+    )
+
+
+class TestSessionWidgetViewCommunity:
+    """Tests for session_widget_view with community sessions."""
+
+    @pytest.mark.asyncio
+    async def test_community_anonymous(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {
+            "server": "http://localhost:10000",
+            "auth_type": "Anonymous",
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.get = AsyncMock(return_value=mgr)
+        context = _make_context(config_dict={}, session_registry=mock_registry)
+
+        result = await session_widget_view(
+            context,
+            session_id="community:config:local",
+            widget_name="my_table",
+        )
+
+        assert result["success"] is True
+        assert result["widget_url"] == (
+            "http://localhost:10000/iframe/widget/?name=my_table"
+        )
+        assert result["session_id"] == "community:config:local"
+        assert result["widget_name"] == "my_table"
+
+    @pytest.mark.asyncio
+    async def test_community_with_psk_all_mode(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {
+            "server": "http://localhost:10000",
+            "auth_type": "PSK",
+            "auth_token": "my_token",
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.get = AsyncMock(return_value=mgr)
+
+        config_dict = {
+            "security": {
+                "community": {
+                    "credential_retrieval_mode": "all",
+                }
+            }
+        }
+        context = _make_context(config_dict=config_dict, session_registry=mock_registry)
+
+        result = await session_widget_view(
+            context,
+            session_id="community:config:local",
+            widget_name="t",
+        )
+
+        assert result["success"] is True
+        assert "&psk=my_token" in result["widget_url"]
+
+    @pytest.mark.asyncio
+    async def test_community_psk_suppressed_by_none_mode(self):
+        mgr = MagicMock(spec=CommunitySessionManager)
+        mgr._config = {
+            "server": "http://localhost:10000",
+            "auth_type": "PSK",
+            "auth_token": "my_token",
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.get = AsyncMock(return_value=mgr)
+
+        config_dict = {
+            "security": {
+                "community": {
+                    "credential_retrieval_mode": "none",
+                }
+            }
+        }
+        context = _make_context(config_dict=config_dict, session_registry=mock_registry)
+
+        result = await session_widget_view(
+            context,
+            session_id="community:config:local",
+            widget_name="t",
+        )
+
+        assert result["success"] is True
+        assert "psk=" not in result["widget_url"]
+
+    @pytest.mark.asyncio
+    async def test_community_dynamic(self):
+        mgr = MagicMock(spec=DynamicCommunitySessionManager)
+        mgr.connection_url = "http://dynamic:11111"
+        mgr.launched_session = MagicMock()
+        mgr.launched_session.auth_type = "anonymous"
+        mgr.launched_session.auth_token = ""
+
+        mock_registry = MagicMock()
+        mock_registry.get = AsyncMock(return_value=mgr)
+        context = _make_context(config_dict={}, session_registry=mock_registry)
+
+        result = await session_widget_view(
+            context,
+            session_id="community:dynamic:dyn1",
+            widget_name="chart",
+        )
+
+        assert result["success"] is True
+        assert result["widget_url"] == (
+            "http://dynamic:11111/iframe/widget/?name=chart"
+        )
+
+
+class TestSessionWidgetViewEnterprise:
+    """Tests for session_widget_view with enterprise sessions."""
+
+    @pytest.mark.asyncio
+    async def test_enterprise_success(self):
+        mgr = MagicMock(spec=EnterpriseSessionManager)
+        mgr.source = "prod_system"
+        mgr.name = "MyPQ"
+
+        mock_registry = MagicMock()
+        mock_registry.get = AsyncMock(return_value=mgr)
+
+        config_dict = {
+            "enterprise": {
+                "systems": {
+                    "prod_system": {
+                        "connection_json_url": "https://dh.example.com/iris/connection.json",
+                    }
+                }
+            }
+        }
+        context = _make_context(config_dict=config_dict, session_registry=mock_registry)
+
+        result = await session_widget_view(
+            context,
+            session_id="enterprise:prod_system:MyPQ",
+            widget_name="revenue_chart",
+            pq_name="MyPQ",
+        )
+
+        assert result["success"] is True
+        assert result["widget_url"] == (
+            "https://dh.example.com/iriside/embed/widget/MyPQ/revenue_chart"
+        )
+        assert result["session_id"] == "enterprise:prod_system:MyPQ"
+        assert result["widget_name"] == "revenue_chart"
+
+    @pytest.mark.asyncio
+    async def test_enterprise_missing_pq_name(self):
+        mgr = MagicMock(spec=EnterpriseSessionManager)
+        mgr.source = "prod"
+
+        mock_registry = MagicMock()
+        mock_registry.get = AsyncMock(return_value=mgr)
+        context = _make_context(session_registry=mock_registry)
+
+        result = await session_widget_view(
+            context,
+            session_id="enterprise:prod:MyPQ",
+            widget_name="chart",
+        )
+
+        assert result["success"] is False
+        assert "pq_name" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_enterprise_missing_connection_json_url(self):
+        mgr = MagicMock(spec=EnterpriseSessionManager)
+        mgr.source = "prod"
+
+        mock_registry = MagicMock()
+        mock_registry.get = AsyncMock(return_value=mgr)
+
+        config_dict = {
+            "enterprise": {
+                "systems": {
+                    "prod": {},
+                }
+            }
+        }
+        context = _make_context(config_dict=config_dict, session_registry=mock_registry)
+
+        result = await session_widget_view(
+            context,
+            session_id="enterprise:prod:MyPQ",
+            widget_name="chart",
+            pq_name="MyPQ",
+        )
+
+        assert result["success"] is False
+        assert "connection_json_url" in result["error"]
+
+
+class TestSessionWidgetViewErrors:
+    """Tests for session_widget_view error cases."""
+
+    @pytest.mark.asyncio
+    async def test_session_not_found(self):
+        mock_registry = MagicMock()
+        mock_registry.get = AsyncMock(
+            side_effect=RegistryItemNotFoundError("no such session")
+        )
+        context = _make_context(session_registry=mock_registry)
+
+        result = await session_widget_view(
+            context,
+            session_id="community:config:nonexistent",
+            widget_name="t",
+        )
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unsupported_manager_type(self):
+        mgr = MagicMock()
+        # Plain MagicMock is neither CommunitySessionManager nor EnterpriseSessionManager
+        mock_registry = MagicMock()
+        mock_registry.get = AsyncMock(return_value=mgr)
+        context = _make_context(session_registry=mock_registry)
+
+        result = await session_widget_view(
+            context,
+            session_id="unknown:something:else",
+            widget_name="t",
+        )
+
+        assert result["success"] is False
+        assert "unsupported" in result["error"].lower()

--- a/tests/mcp_systems_server/_tools/test_widget.py
+++ b/tests/mcp_systems_server/_tools/test_widget.py
@@ -14,6 +14,7 @@ from deephaven_mcp.mcp_systems_server._tools.widget import (
     _build_enterprise_widget_url,
     _get_community_psk_token,
     session_widget_view,
+    session_widgets_list,
     widget_view_resource,
 )
 from deephaven_mcp.resource_manager import (
@@ -476,3 +477,144 @@ class TestSessionWidgetViewErrors:
 
         assert result["success"] is False
         assert "unsupported" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Tool: session_widgets_list
+# ---------------------------------------------------------------------------
+
+
+class TestSessionWidgetsList:
+    """Tests for session_widgets_list."""
+
+    @pytest.mark.asyncio
+    async def test_success_multiple_widgets(self):
+        """Test session_widgets_list returns multiple widgets with types."""
+
+        class DummySession:
+            async def widgets(self):
+                return [
+                    {"name": "trades", "type": "Table"},
+                    {"name": "my_plot", "type": "Figure"},
+                    {"name": "dashboard", "type": "PartitionedTable"},
+                ]
+
+        mock_session_manager = MagicMock()
+        mock_session_manager.get = AsyncMock(return_value=DummySession())
+
+        session_registry = MagicMock()
+        session_registry.get = AsyncMock(return_value=mock_session_manager)
+
+        context = MockContext({"session_registry": session_registry})
+        result = await session_widgets_list(context, session_id="test-session")
+
+        session_registry.get.assert_awaited_once_with("test-session")
+        mock_session_manager.get.assert_awaited_once()
+
+        assert result["success"] is True
+        assert result["session_id"] == "test-session"
+        assert result["count"] == 3
+        assert result["widgets"] == [
+            {"name": "trades", "type": "Table"},
+            {"name": "my_plot", "type": "Figure"},
+            {"name": "dashboard", "type": "PartitionedTable"},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_success_empty_session(self):
+        """Test session_widgets_list with no widgets."""
+
+        class DummySession:
+            async def widgets(self):
+                return []
+
+        mock_session_manager = MagicMock()
+        mock_session_manager.get = AsyncMock(return_value=DummySession())
+
+        session_registry = MagicMock()
+        session_registry.get = AsyncMock(return_value=mock_session_manager)
+
+        context = MockContext({"session_registry": session_registry})
+        result = await session_widgets_list(context, session_id="empty-session")
+
+        assert result["success"] is True
+        assert result["session_id"] == "empty-session"
+        assert result["widgets"] == []
+        assert result["count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_invalid_session_id(self):
+        """Test session_widgets_list with invalid session_id."""
+        session_registry = MagicMock()
+        session_registry.get = AsyncMock(
+            side_effect=Exception("Session not found: invalid-session")
+        )
+
+        context = MockContext({"session_registry": session_registry})
+        result = await session_widgets_list(context, session_id="invalid-session")
+
+        assert result["success"] is False
+        assert result["isError"] is True
+        assert "Session not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_session_connection_failure(self):
+        """Test session_widgets_list when session connection fails."""
+        mock_session_manager = MagicMock()
+        mock_session_manager.get = AsyncMock(side_effect=Exception("Connection failed"))
+
+        session_registry = MagicMock()
+        session_registry.get = AsyncMock(return_value=mock_session_manager)
+
+        context = MockContext({"session_registry": session_registry})
+        result = await session_widgets_list(context, session_id="test-session")
+
+        assert result["success"] is False
+        assert result["isError"] is True
+        assert "Connection failed" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_widgets_method_failure(self):
+        """Test session_widgets_list when session.widgets() raises."""
+
+        class DummySession:
+            async def widgets(self):
+                raise Exception("Failed to retrieve widget list")
+
+        mock_session_manager = MagicMock()
+        mock_session_manager.get = AsyncMock(return_value=DummySession())
+
+        session_registry = MagicMock()
+        session_registry.get = AsyncMock(return_value=mock_session_manager)
+
+        context = MockContext({"session_registry": session_registry})
+        result = await session_widgets_list(context, session_id="test-session")
+
+        assert result["success"] is False
+        assert result["isError"] is True
+        assert "Failed to retrieve widget list" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_tables_only_session(self):
+        """Test session_widgets_list with only tables (no other widget types)."""
+
+        class DummySession:
+            async def widgets(self):
+                return [
+                    {"name": "table1", "type": "Table"},
+                    {"name": "table2", "type": "Table"},
+                ]
+
+        mock_session_manager = MagicMock()
+        mock_session_manager.get = AsyncMock(return_value=DummySession())
+
+        session_registry = MagicMock()
+        session_registry.get = AsyncMock(return_value=mock_session_manager)
+
+        context = MockContext({"session_registry": session_registry})
+        result = await session_widgets_list(context, session_id="community:local:test")
+
+        assert result["success"] is True
+        assert result["session_id"] == "community:local:test"
+        assert result["count"] == 2
+        assert all(w["type"] == "Table" for w in result["widgets"])


### PR DESCRIPTION
Add session_widget_view tool and ui://deephaven-mcp/widget-view resource that render Deephaven widgets (tables, charts, dashboards) as interactive iframes inside MCP Apps-capable chat clients.
- Support Community sessions with optional PSK auth (respects credential_retrieval_mode security config)
- Support Enterprise sessions via /iriside/embed/widget/ URL pattern
- Serve HTML view resource using @modelcontextprotocol/ext-apps SDK
- Bump mcp[cli] dependency from >=1.12.0 to >=1.26.0 for meta support
- Tested by asking Copilot to display plots/deephaven.ui components, or tables with the widget view.