### PR TITLE
docs: Clarify private_key_path format and naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,9 +697,10 @@ The `session_creation` key enables dynamic creation of Deephaven Community Core 
       "saml_enterprise": {
         "connection_json_url": "https://enterprise.example.com:8000/iris/connection.json",
         // Private key authentication (commonly used with SAML/SSO setups)
-        // Your IT/security team typically provides the private key file
+        // Your IT/security team provides the private keypair file (Deephaven proprietary format)
+        // Typically named: priv-<keyname>.base64.txt
         "auth_type": "private_key",
-        "private_key_path": "/absolute/path/to/your/private_key.pem"  // Must be absolute!
+        "private_key_path": "/absolute/path/to/priv-mykeyname.base64.txt"  // Must be absolute!
       }
     }
   }
@@ -719,7 +720,7 @@ The `enterprise` key contains a `"systems"` dictionary mapping custom system nam
 | `username` | string | `auth_type` = `"password"` | Username for authentication |
 | `password` | string | `auth_type` = `"password"` | Password (use `password_env_var` instead for security) |
 | `password_env_var` | string | `auth_type` = `"password"` | Environment variable containing the password (recommended) |
-| `private_key_path` | string | `auth_type` = `"private_key"` | Absolute path to private key file |
+| `private_key_path` | string | `auth_type` = `"private_key"` | Absolute path to the Deephaven private keypair file (proprietary format, typically named `priv-<keyname>.base64.txt`; provided by your IT/security team) |
 | `connection_timeout` | integer \| float | Optional | Timeout in seconds for establishing connection to Enterprise system (default: 10.0) |
 | `session_creation` | object | Optional | Configuration for creating enterprise sessions. If omitted, session creation tools are unavailable |
 | `session_creation.max_concurrent_sessions` | integer | Optional | Maximum concurrent sessions (default: 5). Set to 0 to disable session creation |
@@ -888,7 +889,7 @@ Here's a complete example showing both Community and Enterprise configurations:
       "data_science_env": {
         "connection_json_url": "https://data-science.enterprise.example.com/iris/connection.json",
         "auth_type": "private_key",
-        "private_key_path": "/path/to/your/private_key.pem"  // From your IT team
+        "private_key_path": "/path/to/priv-mykeyname.base64.txt"  // Proprietary keypair file from your IT team
       }
     }
   }

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -809,7 +809,7 @@ If the `"enterprise"` key is present, it must be a dictionary. Each individual e
 - `connection_json_url` (string, **required**): The URL pointing to the `connection.json` file of the Deephaven Enterprise server. This file provides necessary connection details for the client. For standard HTTPS port 443, no port is needed (e.g., `"https://enterprise.example.com/iris/connection.json"`). For non-standard ports, include the port number explicitly (e.g., `"https://enterprise.example.com:8123/iris/connection.json"`)
 - `auth_type` (string, **required**): Specifies the authentication method to use. Must be one of the following values:
   - `"password"`: Authenticate using a username and password.
-  - `"private_key"`: Authenticate using a private key (e.g., for service accounts or specific SAML/OAuth setups requiring a private key).
+  - `"private_key"`: Authenticate using a Deephaven private keypair file (proprietary format, commonly used with SAML/SSO setups).
     Only configuration keys relevant to the selected `auth_type` (and the general `connection_json_url`) should be included. Extraneous keys will be ignored by the application but will generate a warning message in the logs, indicating which keys are unexpected for the chosen authentication method.
 
 - Conditional Authentication Fields (required based on `auth_type`):
@@ -818,7 +818,7 @@ If the `"enterprise"` key is present, it must be a dictionary. Each individual e
     - And either `password` (string): The password itself.
     - **OR** `password_env_var` (string): The name of an environment variable that holds the password. Using an environment variable is recommended. If the `password` field is used directly, its value will be redacted in application logs.
   - If `auth_type` is `"private_key"`:
-    - `private_key_path` (string, **required**): The absolute file system path to the private key file (e.g., a `.pem` file).
+    - `private_key_path` (string, **required**): The absolute file system path to the Deephaven private keypair file (proprietary format, typically named `priv-<keyname>.base64.txt`; provided by your IT/security team — this is **not** a standard PEM file).
 
 - Optional Connection Settings:
   - `connection_timeout` (integer | float, **optional, default: 10.0**): Timeout in seconds for establishing connection to the Enterprise system.
@@ -876,7 +876,7 @@ If the `"enterprise"` key is present, it must be a dictionary. Each individual e
       "analytics_private_key_auth": {
         "connection_json_url": "https://analytics.dept.com/iris/connection.json",
         "auth_type": "private_key",
-        "private_key_path": "/secure/keys/analytics_service_account.pem",
+        "private_key_path": "/secure/keys/priv-analytics.base64.txt",  // Proprietary keypair file from your IT team
         "session_creation": {
           "max_concurrent_sessions": 5,  // Higher limit for production
           "defaults": {

--- a/src/deephaven_mcp/client/_session_factory.py
+++ b/src/deephaven_mcp/client/_session_factory.py
@@ -432,7 +432,7 @@ class CorePlusSessionFactory(
 
         - For 'private_key' authentication:
             * 'private_key_path': The path to the Deephaven private keypair file (proprietary format,
-              typically named priv-<keyname>.base64.txt; provided by your IT/security team)
+              typically named `priv-<keyname>.base64.txt`; provided by your IT/security team)
 
         - For 'saml' authentication:
             * No additional fields required, but SAML must be configured on server

--- a/src/deephaven_mcp/client/_session_factory.py
+++ b/src/deephaven_mcp/client/_session_factory.py
@@ -431,7 +431,8 @@ class CorePlusSessionFactory(
             * Optional 'effective_user': User to operate as after authentication
 
         - For 'private_key' authentication:
-            * 'private_key_path': The path to the private key file
+            * 'private_key_path': The path to the Deephaven private keypair file (proprietary format,
+              typically named priv-<keyname>.base64.txt; provided by your IT/security team)
 
         - For 'saml' authentication:
             * No additional fields required, but SAML must be configured on server
@@ -1482,11 +1483,13 @@ class CorePlusSessionFactory(
             ```python
             import io
 
-            # Read key from somewhere else (e.g., environment variable, secrets manager)
-            key_data = "-----BEGIN RSA PRIVATE KEY-----\n..."
+            # Read keypair data from somewhere else (e.g., secrets manager)
+            # The content is in Deephaven's proprietary base64 keypair format,
+            # the same format found in priv-<keyname>.base64.txt files.
+            key_data = "<base64-encoded-keypair-content>"
             key_io = io.StringIO(key_data)
 
-            # Authenticate using the in-memory key
+            # Authenticate using the in-memory keypair data
             await factory.private_key(key_io)
             ```
 

--- a/src/deephaven_mcp/client/_session_factory.py
+++ b/src/deephaven_mcp/client/_session_factory.py
@@ -492,7 +492,7 @@ class CorePlusSessionFactory(
                 config = {
                     "connection_json_url": "https://example.deephaven.io/iris/connection.json",
                     "auth_type": "private_key",
-                    "private_key_path": "/path/to/private_key.pem"
+                    "private_key_path": "/path/to/priv-mykeyname.base64.txt"
                 }
 
                 # Create and authenticate in one step
@@ -1472,7 +1472,7 @@ class CorePlusSessionFactory(
                 factory = await CorePlusSessionFactory.from_url("https://myserver.example.com/iris/connection.json")
 
                 # Authenticate using a private key file
-                await factory.private_key("/path/to/private_key.pem")
+                await factory.private_key("/path/to/priv-mykeyname.base64.txt")
 
                 # Use the authenticated session factory
                 session = await factory.connect_to_new_worker()

--- a/src/deephaven_mcp/client/_session_factory.py
+++ b/src/deephaven_mcp/client/_session_factory.py
@@ -1472,7 +1472,7 @@ class CorePlusSessionFactory(
                 # Create the session factory
                 factory = await CorePlusSessionFactory.from_url("https://myserver.example.com/iris/connection.json")
 
-                # Authenticate using a private key file
+                # Authenticate using a private keypair file
                 await factory.private_key("/path/to/priv-mykeyname.base64.txt")
 
                 # Use the authenticated session factory

--- a/src/deephaven_mcp/config/__init__.py
+++ b/src/deephaven_mcp/config/__init__.py
@@ -114,7 +114,7 @@ It may contain the following top-level keys:
                         - `password_env_var` (str, optional): Environment variable for the password.
                           (Note: `password` and `password_env_var` are mutually exclusive.)
                     * "private_key":
-                        - `private_key_path` (str, required): The path to the private key file.
+                        - `private_key_path` (str, required): The path to the Deephaven private keypair file (proprietary format, typically named `priv-<keyname>.base64.txt`; provided by your IT/security team - this is not a standard PEM file).
                 - `session_creation` (dict, optional): Configuration for creating enterprise sessions.
                     * `max_concurrent_sessions` (int, optional): Maximum concurrent sessions (default: 5). Set to 0 to disable session creation.
                     * `defaults` (dict, optional): Default parameters for session creation:
@@ -1020,7 +1020,7 @@ def validate_config(config: dict[str, Any]) -> dict[str, Any]:
                               - 'password_env_var' (str, optional): Environment variable for the password.
                                 (Note: `password` and `password_env_var` are mutually exclusive.)
                           * "private_key":
-                              - 'private_key_path' (str, required): The path to the private key file.
+                              - 'private_key_path' (str, required): The path to the Deephaven private keypair file (proprietary format, typically named `priv-<keyname>.base64.txt`; provided by your IT/security team - this is not a standard PEM file).
 
     Validation Rules:
       - Only known keys are allowed at each level of nesting.

--- a/src/deephaven_mcp/config/_enterprise_system.py
+++ b/src/deephaven_mcp/config/_enterprise_system.py
@@ -171,7 +171,7 @@ def validate_enterprise_systems_config(enterprise_systems_map: Any | None) -> No
 
         'private_key' auth_type:
             - private_key_path (str): Path to the Deephaven private keypair file (proprietary format,
-              typically named priv-<keyname>.base64.txt; provided by your IT/security team)
+              typically named `priv-<keyname>.base64.txt`; provided by your IT/security team)
 
     Optional Fields (per system):
         - connection_timeout (int | float): Timeout in seconds for initial connection (default: 10.0)

--- a/src/deephaven_mcp/config/_enterprise_system.py
+++ b/src/deephaven_mcp/config/_enterprise_system.py
@@ -211,7 +211,7 @@ def validate_enterprise_systems_config(enterprise_systems_map: Any | None) -> No
             "development": {
                 "connection_json_url": "https://dev.deephaven.io/iris/connection.json",
                 "auth_type": "private_key",
-                "private_key_path": "/opt/deephaven/keys/dev.pem"
+                "private_key_path": "/opt/deephaven/keys/priv-dev.base64.txt"
             }
         }
 

--- a/src/deephaven_mcp/config/_enterprise_system.py
+++ b/src/deephaven_mcp/config/_enterprise_system.py
@@ -170,7 +170,8 @@ def validate_enterprise_systems_config(enterprise_systems_map: Any | None) -> No
             - password (str) XOR password_env_var (str): Mutually exclusive credential options
 
         'private_key' auth_type:
-            - private_key_path (str): Path to private key file
+            - private_key_path (str): Path to the Deephaven private keypair file (proprietary format,
+              typically named priv-<keyname>.base64.txt; provided by your IT/security team)
 
     Optional Fields (per system):
         - connection_timeout (int | float): Timeout in seconds for initial connection (default: 10.0)


### PR DESCRIPTION
- [x] Updated README and docs to clarify `private_key_path` format
- [x] Updated config module docstrings
- [x] Updated `_session_factory.py` examples and descriptions
- [x] Updated `_enterprise_system.py` docstring
- [x] Fixed angle brackets in filenames to use backtick wrapping
- [x] Updated StringIO example to use Deephaven keypair format
- [x] Updated comment "private key file" → "private keypair file" at line 1475 for consistency