### PR TITLE
ci: Add mcp2 branch to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -2,9 +2,9 @@ name: black (Code Formatter)
 
 on:
   push:
-    branches: [main]
+    branches: [main, mcp2]
   pull_request:
-    branches: [main]
+    branches: [main, mcp2]
 
 jobs:
   black-check:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -3,9 +3,9 @@ name: Build and Publish Wheels
 on:
   workflow_dispatch:
   push:
-    branches: ["main"]
+    branches: ["main", "mcp2"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "mcp2"]
 
 jobs:
   build:

--- a/.github/workflows/docker-mcp-docs.yml
+++ b/.github/workflows/docker-mcp-docs.yml
@@ -72,9 +72,11 @@ on:
   push:
     branches:
       - main
+      - mcp2
   pull_request:
     branches:
       - main
+      - mcp2
   workflow_dispatch:
 
 env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,9 +2,9 @@ name: Integration Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "mcp2" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "mcp2" ]
   workflow_dispatch:  # Allow manual trigger
 
 jobs:

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -2,9 +2,9 @@ name: isort (Import Sorting)
 
 on:
   push:
-    branches: [main]
+    branches: [main, mcp2]
   pull_request:
-    branches: [main]
+    branches: [main, mcp2]
 
 jobs:
   isort-check:

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -2,9 +2,9 @@ name: markdownlint (Markdown Linter)
 
 on:
   push:
-    branches: [main]
+    branches: [main, mcp2]
   pull_request:
-    branches: [main]
+    branches: [main, mcp2]
 
 jobs:
   markdownlint-check:

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -2,9 +2,9 @@ name: mypy
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "mcp2" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "mcp2" ]
 
 jobs:
   mypy:

--- a/.github/workflows/pydocstyle.yml
+++ b/.github/workflows/pydocstyle.yml
@@ -2,9 +2,9 @@ name: pydocstyle
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "mcp2" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "mcp2" ]
 
 jobs:
   pydocstyle:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -2,9 +2,9 @@ name: ruff lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, mcp2]
   pull_request:
-    branches: [main]
+    branches: [main, mcp2]
 
 jobs:
   ruff-lint:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,9 +2,9 @@ name: Unit Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "mcp2" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "mcp2" ]
   workflow_dispatch:  # Allow manual trigger
 
 jobs:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to ensure all CI/CD checks and jobs run on both the `main` and `mcp2` branches. This change helps maintain consistency and code quality across both branches by enabling automated checks, tests, and builds whenever changes are pushed or pull requests are opened for either branch.

**Workflow configuration updates:**

* Enabled the following workflows to trigger on both `main` and `mcp2` branches for `push` and `pull_request` events:
  - `black.yml` (Python code formatting)
  - `isort.yml` (Import sorting)
  - `markdownlint.yml` (Markdown linting)
  - `ruff.yml` (Python linting)
  - `mypy.yml` (Type checking)
  - `pydocstyle.yml` (Docstring style checking)
  - `unit-tests.yml` (Unit tests)
  - `integration-tests.yml` (Integration tests)
  - `build-wheels.yml` (Build and publish Python wheels)
  - `docker-mcp-docs.yml` (Build and publish MCP docs Docker images)