### PR TITLE
feat: document using uv tool for a simplified install

### DIFF
--- a/.github/workflows/tool-install.yml
+++ b/.github/workflows/tool-install.yml
@@ -75,4 +75,4 @@ jobs:
         run: uv tool install --python-preference managed mcp-proxy
 
       - name: Verify mcp-proxy is on PATH
-        run: mcp-proxy --help
+        run: command -v mcp-proxy

--- a/.github/workflows/tool-install.yml
+++ b/.github/workflows/tool-install.yml
@@ -55,19 +55,19 @@ jobs:
 
       - name: Add uv tool bin directory to PATH
         # `uv tool install` places executables in a per-user bin directory that is
-        # The docs server does not implement `--help` safely: invoking it can start the
-        # server and/or fail at import time if INKEEP_API_KEY is unset, so only verify
-        # that its installed script is discoverable on PATH.
         # not on PATH by default in GitHub Actions runners. Add it explicitly so
         # subsequent steps can invoke the installed entry points.
         run: echo "$(uv tool dir --bin)" >> "$GITHUB_PATH"
-          command -v dh-mcp-docs-server
+
       - name: Verify entry points are on PATH
-        # Confirms all three documented server commands land in ~/.local/bin (or platform equivalent)
+        # Confirms all three documented server commands land in ~/.local/bin (or platform equivalent).
+        # The docs server does not implement `--help` safely: invoking it can start the
+        # server and/or fail at import time if INKEEP_API_KEY is unset, so only verify
+        # that its installed script is discoverable on PATH.
         run: |
           dh-mcp-community-server --help
           dh-mcp-enterprise-server --help
-          dh-mcp-docs-server --help
+          command -v dh-mcp-docs-server
 
       - name: Install mcp-proxy as a separate tool
         # mcp-proxy is the Claude Desktop stdio↔HTTP bridge. It is not a deephaven-mcp

--- a/.github/workflows/tool-install.yml
+++ b/.github/workflows/tool-install.yml
@@ -55,10 +55,13 @@ jobs:
 
       - name: Add uv tool bin directory to PATH
         # `uv tool install` places executables in a per-user bin directory that is
+        # The docs server does not implement `--help` safely: invoking it can start the
+        # server and/or fail at import time if INKEEP_API_KEY is unset, so only verify
+        # that its installed script is discoverable on PATH.
         # not on PATH by default in GitHub Actions runners. Add it explicitly so
         # subsequent steps can invoke the installed entry points.
         run: echo "$(uv tool dir --bin)" >> "$GITHUB_PATH"
-
+          command -v dh-mcp-docs-server
       - name: Verify entry points are on PATH
         # Confirms all three documented server commands land in ~/.local/bin (or platform equivalent)
         run: |

--- a/.github/workflows/tool-install.yml
+++ b/.github/workflows/tool-install.yml
@@ -49,9 +49,24 @@ jobs:
           python -m build --wheel
 
       - name: Install as uv tool
-        # --find-links ensures the local wheel is preferred over PyPI for deephaven-mcp;
-        # all other dependencies are still resolved from PyPI normally.
-        run: uv tool install --python-preference managed "deephaven-mcp[community,enterprise]" --find-links dist/
+        # Install the locally-built wheel by file path so we are guaranteed to test
+        # the current branch's code, not whatever happens to be on PyPI. Using
+        # `--find-links dist/` is not sufficient: it only adds the directory as a
+        # candidate source, and setuptools_scm produces a `.devN` version on
+        # non-tag commits, which uv's default prerelease policy will skip in
+        # favor of a matching stable PyPI release. Passing the wheel path
+        # explicitly bypasses the resolver entirely for the deephaven-mcp
+        # distribution; transitive dependencies are still resolved from PyPI.
+        # `--python` ensures uv installs the tool against the matrix's Python
+        # version. Without it, `--python-preference managed` would silently pick
+        # the latest managed interpreter satisfying requires-python on every
+        # leg, collapsing the matrix to a single effective interpreter.
+        run: |
+          WHEEL=$(ls dist/deephaven_mcp-*.whl)
+          uv tool install \
+            --python-preference managed \
+            --python ${{ matrix.python-version }} \
+            "${WHEEL}[community,enterprise]"
 
       - name: Add uv tool bin directory to PATH
         # `uv tool install` places executables in a per-user bin directory that is
@@ -72,7 +87,9 @@ jobs:
       - name: Install mcp-proxy as a separate tool
         # mcp-proxy is the Claude Desktop stdio↔HTTP bridge. It is not a deephaven-mcp
         # dependency; users install it independently via `uv tool install --python-preference managed mcp-proxy`.
-        run: uv tool install --python-preference managed mcp-proxy
+        # `--python` pins the tool environment to the matrix interpreter for the
+        # same reason as the deephaven-mcp install above.
+        run: uv tool install --python-preference managed --python ${{ matrix.python-version }} mcp-proxy
 
       - name: Verify mcp-proxy is on PATH
         run: command -v mcp-proxy

--- a/.github/workflows/tool-install.yml
+++ b/.github/workflows/tool-install.yml
@@ -1,0 +1,69 @@
+# Validates the end-user installation path documented in README.md.
+#
+# The README tells users to install via `uv tool install`, which places server
+# scripts directly on PATH in an isolated environment (no venv to manage).
+# mcp-proxy is intentionally NOT a deephaven-mcp dependency; it is a standalone
+# Claude Desktop bridge that users install separately with `uv tool install --python-preference managed mcp-proxy`.
+#
+# This workflow verifies both installs work correctly on the supported OS/Python
+# matrix so that README instructions stay accurate as dependencies evolve.
+
+name: Tool Install
+
+on:
+  push:
+    branches: [ "main", "mcp2" ]
+  pull_request:
+    branches: [ "main", "mcp2" ]
+  workflow_dispatch:
+
+jobs:
+  tool-install:
+    name: uv tool install (${{ matrix.os }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Full history needed for setuptools_scm version detection
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Build wheel
+        # Build from source so we test the current branch, not a PyPI release
+        run: |
+          pip install build wheel
+          python -m build --wheel
+
+      - name: Install as uv tool
+        # --find-links ensures the local wheel is preferred over PyPI for deephaven-mcp;
+        # all other dependencies are still resolved from PyPI normally.
+        run: uv tool install --python-preference managed "deephaven-mcp[community,enterprise]" --find-links dist/
+
+      - name: Verify entry points are on PATH
+        # Confirms all three documented server commands land in ~/.local/bin (or platform equivalent)
+        run: |
+          dh-mcp-community-server --help
+          dh-mcp-enterprise-server --help
+          dh-mcp-docs-server --help
+
+      - name: Install mcp-proxy as a separate tool
+        # mcp-proxy is the Claude Desktop stdio↔HTTP bridge. It is not a deephaven-mcp
+        # dependency; users install it independently via `uv tool install --python-preference managed mcp-proxy`.
+        run: uv tool install --python-preference managed mcp-proxy
+
+      - name: Verify mcp-proxy is on PATH
+        run: mcp-proxy --help

--- a/.github/workflows/tool-install.yml
+++ b/.github/workflows/tool-install.yml
@@ -53,6 +53,12 @@ jobs:
         # all other dependencies are still resolved from PyPI normally.
         run: uv tool install --python-preference managed "deephaven-mcp[community,enterprise]" --find-links dist/
 
+      - name: Add uv tool bin directory to PATH
+        # `uv tool install` places executables in a per-user bin directory that is
+        # not on PATH by default in GitHub Actions runners. Add it explicitly so
+        # subsequent steps can invoke the installed entry points.
+        run: echo "$(uv tool dir --bin)" >> "$GITHUB_PATH"
+
       - name: Verify entry points are on PATH
         # Confirms all three documented server commands land in ~/.local/bin (or platform equivalent)
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,10 +6,12 @@
         "deephaven",
         "ENOENT",
         "Inkeep",
+        "LOCALAPPDATA",
         "pyproject",
         "PYTHONLOGLEVEL",
         "streamable",
         "streamablehttp",
+        "uvx",
         "venv"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ To stop the server: `pkill -f dh-mcp-community-server`
 }
 ```
 
-> If your AI tool reports that `mcp-proxy` is not found, run `which mcp-proxy` in your terminal and use the full path as the `command` value.
+> If your AI tool reports that `mcp-proxy` is not found, locate it with `which mcp-proxy` (macOS/Linux) or `where mcp-proxy` / `Get-Command mcp-proxy` (Windows cmd.exe / PowerShell), and use the full path as the `command` value.
 
 **For other tools**, see the [detailed setup instructions](#setup-instructions-by-tool) below.
 
@@ -303,7 +303,7 @@ To stop the server: `pkill -f dh-mcp-enterprise-server`
 }
 ```
 
-> If your AI tool reports that `mcp-proxy` is not found, run `which mcp-proxy` in your terminal and use the full path as the `command` value.
+> If your AI tool reports that `mcp-proxy` is not found, locate it with `which mcp-proxy` (macOS/Linux) or `where mcp-proxy` / `Get-Command mcp-proxy` (Windows cmd.exe / PowerShell), and use the full path as the `command` value.
 
 **For other tools**, see the [detailed setup instructions](#setup-instructions-by-tool) below.
 
@@ -1171,7 +1171,7 @@ Open **Claude Desktop** → **Settings** → **Developer** → **Edit Config** a
 }
 ```
 
-> If your AI tool reports that `mcp-proxy` is not found, run `which mcp-proxy` in your terminal and use the full path as the `command` value.
+> If your AI tool reports that `mcp-proxy` is not found, locate it with `which mcp-proxy` (macOS/Linux) or `where mcp-proxy` / `Get-Command mcp-proxy` (Windows cmd.exe / PowerShell), and use the full path as the `command` value.
 
 **Additional Resources:**
 
@@ -1275,7 +1275,7 @@ Before diving into detailed troubleshooting, try these common solutions:
 
 | Error | Where You'll See This | Solution |
 |-------|----------------------|----------|
-| `spawn mcp-proxy ENOENT` | AI tool logs | Run `uv tool install --python-preference managed mcp-proxy` first; if the tool still can't find it, run `which mcp-proxy` and use the full path as the `command` |
+| `spawn mcp-proxy ENOENT` | AI tool logs | Run `uv tool install --python-preference managed mcp-proxy` first; if the tool still can't find it, locate it with `which mcp-proxy` (macOS/Linux) or `where mcp-proxy` / `Get-Command mcp-proxy` (Windows) and use the full path as the `command` |
 | `Connection failed` | MCP server logs | Check internet connection and server URLs |
 | `Config not found` | MCP server startup | Verify full path to config file passed via `--config` or `DH_MCP_CONFIG_FILE` |
 | `Permission denied` | Command execution | Ensure executable has proper permissions; run `chmod +x` on the `mcp-proxy` path |
@@ -1343,7 +1343,7 @@ Before diving into detailed troubleshooting, try these common solutions:
   - **Platform-Specific Issues:** Some packages may require platform-specific compilation
 
 - **Python Version Compatibility:**
-  - Deephaven MCP requires Python 3.11 or higher
+  - Deephaven MCP requires Python 3.12 or higher
   - Check your Python version: `python --version`
   - Ensure your virtual environment uses the correct Python version
 

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ graph TD
 
 ## Prerequisites
 
-- **[`uv`](https://docs.astral.sh/uv/) (Recommended)**: Used for `uv tool install`, which puts the server commands on your PATH with no venv to manage. Install it via `pip install uv` or the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/). Once installed, `uv` places its bin directory on your PATH automatically.
+- **[`uv`](https://docs.astral.sh/uv/) (Recommended)**: Used for `uv tool install`, which puts the server commands on your PATH with no venv to manage. Install it via `pip install uv` or the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/). After installing tools, you may need to run `uv tool update-shell` and open a new terminal so the uv tool bin directory is on your `PATH` (this directory — typically `~/.local/bin` on macOS/Linux or `%LOCALAPPDATA%\uv\bin\` on Windows — is not on the default shell `PATH` everywhere).
 - **Python**: Version 3.12 or higher. uv downloads its own managed Python automatically via `--python-preference managed` — no separate Python installation required. ([Download Python](https://www.python.org/downloads/) only needed for non-uv workflows)
 - **Docker (Optional)**: Required for Docker-based community session creation. ([Download Docker](https://www.docker.com/get-started/))
 - **Access to Deephaven systems:** To use the MCP servers, you will need one or more of the following:

--- a/README.md
+++ b/README.md
@@ -1326,26 +1326,27 @@ Before diving into detailed troubleshooting, try these common solutions:
 
 - **`command not found` for [`uv`](docs/UV.md) (in LLM tool logs):**
   - Ensure [`uv`](docs/UV.md) is installed and its installation directory is in your system's `PATH` environment variable, accessible by the LLM tool.
-- **`command not found` for `dh-mcp-enterprise-server` or `dh-mcp-community-server`:**
-  - Ensure the package is installed in your virtual environment with `uv pip install "deephaven-mcp[community,enterprise]"`
-  - If running directly, verify the venv is activated or use the full path to the executable.
+- **`command not found` for `dh-mcp-enterprise-server`, `dh-mcp-community-server`, or `dh-mcp-docs-server`:**
+  - **If you used `uv tool install` (recommended):** Reinstall (or upgrade) with `uv tool install --python-preference managed "deephaven-mcp[community,enterprise]"` (or `uv tool upgrade deephaven-mcp`). Then make sure the uv tool bin directory is on your `PATH` — run `uv tool update-shell` and open a new shell, or locate the binary with `which dh-mcp-community-server` (macOS/Linux) or `where dh-mcp-community-server` / `Get-Command dh-mcp-community-server` (Windows).
+  - **If you used a virtual environment (alternative install):** Ensure the package is installed in the venv with `uv pip install "deephaven-mcp[community,enterprise]"`, and either activate the venv or use the full path to the executable (e.g. `.venv/bin/dh-mcp-community-server`).
 
-### Virtual Environment and Dependency Issues
+### Installation and Dependency Issues
 
-- **Virtual Environment Not Activated:**
-  - Symptoms: `Module not found` errors, `command not found` for installed packages
-  - Solution: Activate your virtual environment before running commands
-  - Verify: Check that your prompt shows the environment name in parentheses
+- **`Module not found: deephaven_mcp` / commands missing after install:**
+  - **`uv tool install` users:** Reinstall with `uv tool install --python-preference managed "deephaven-mcp[community,enterprise]"`. The tool install is self-contained — there is no user-managed venv to activate.
+  - **Virtual environment users:** Make sure the venv is activated (your shell prompt should show its name) before running commands, or invoke commands via `uv run ...` / the full `.venv/bin/...` path.
 
 - **Dependency Installation Problems:**
-  - **Missing Dependencies:** Reinstall with the correct extras: `uv pip install "deephaven-mcp[community,enterprise]"`
-  - **Version Conflicts:** Check for conflicting package versions in your environment
-  - **Platform-Specific Issues:** Some packages may require platform-specific compilation
+  - **Missing Dependencies (`uv tool install` users):** Re-run `uv tool install --python-preference managed "deephaven-mcp[community,enterprise]"` to refresh the isolated tool environment, or `uv tool upgrade deephaven-mcp` to pick up a newer release.
+  - **Missing Dependencies (venv users):** Reinstall with the correct extras: `uv pip install "deephaven-mcp[community,enterprise]"`.
+  - **Version Conflicts:** `uv tool install` runs in an isolated environment, so cross-package conflicts are rare; for venv installs, check for conflicting package versions in your environment.
+  - **Platform-Specific Issues:** Some packages may require platform-specific compilation.
 
 - **Python Version Compatibility:**
-  - Deephaven MCP requires Python 3.12 or higher
-  - Check your Python version: `python --version`
-  - Ensure your virtual environment uses the correct Python version
+  - Deephaven MCP requires Python 3.12 or higher.
+  - Check your Python version: `python --version`.
+  - **`uv tool install` users:** Pass `--python-preference managed` (as the documented commands do) to let uv manage a compatible interpreter automatically; if you previously installed with a different Python, reinstall the tool.
+  - **Virtual environment users:** Ensure your venv uses Python 3.12+ (e.g. `uv venv .venv -p 3.12`).
 
 ### Server and Environment Issues
 

--- a/README.md
+++ b/README.md
@@ -74,54 +74,29 @@ Choose the quickstart for your Deephaven deployment type:
 
 **Get up and running in 5 minutes!** This quickstart assumes you have a local Deephaven Community Core instance running on `localhost:10000`. If you don't have one, [download and start Deephaven Community Core](https://deephaven.io/core/docs/getting-started/quickstart/) first.
 
-#### 1. Create Virtual Environment
+#### 1. Install Deephaven MCP
 
-**Using `uv` (recommended):**
-
-Pick a suitable project directory for your venv.
+Install with [`uv`](https://docs.astral.sh/uv/) (see [Prerequisites](#prerequisites) if you don't have it yet):
 
 ```bash
-name_of_your_venv=".venv"
-uv venv $name_of_your_venv -p 3.11
+uv tool install --python-preference managed "deephaven-mcp[community,enterprise]"
 ```
 
-**Using standard `venv`:**
+This places three commands on your PATH — `dh-mcp-community-server`, `dh-mcp-enterprise-server`, and `dh-mcp-docs-server` — with no venv to manage.
 
-```bash
-python3.11 -m venv .venv
-```
+> **What `--python-preference managed` does**: tells uv to download and use its own Python (stored in `~/.local/share/uv/python/`) rather than any Python on your system. The tool environment is unaffected if your system Python is upgraded, moved, or removed. uv picks the latest Python version compatible with `requires-python` in the package.
+>
+> **Where tools are installed**: Scripts land in `~/.local/bin/` (macOS/Linux) or `%LOCALAPPDATA%\uv\bin\` (Windows). The tool environment itself lives under `~/.local/share/uv/tools/deephaven-mcp/` — run `uv tool dir` to find the root.
+>
+> **Optional extras**: `[community]` adds Python-based session creation; `[enterprise]` adds DHE connectivity. Both together is the recommended default. For more details, see [Installation & Initial Setup](#installation--initial-setup).
+>
+> **For stdio-only AI tools** (e.g. Claude Desktop): also install `mcp-proxy`, which bridges stdio transport to the HTTP servers:
+>
+> ```bash
+> uv tool install --python-preference managed mcp-proxy
+> ```
 
-> Replace `3.11` / `python3.11` with any supported Python version (3.11 or higher).
-
-#### 2. Install Deephaven MCP
-
-For most users, installing with both Community + Enterprise support is the best default. The Deephaven MCP docs server is hosted by Deephaven and requires no installation.
-
-**Using `uv` (recommended):**
-
-```bash
-uv pip install "deephaven-mcp[community,enterprise]"
-```
-
-**Using standard `pip`:**
-
-```bash
-.venv/bin/pip install "deephaven-mcp[community,enterprise]"
-```
-
-**Optional extras:**
-
-| Extra | Use when |
-|-------|----------|
-| `[community]` | You want to create Community Core sessions using the Python launch method (no Docker required) |
-| `[enterprise]` | You need to connect to Deephaven Enterprise (Core+) systems |
-| `[test]` | You want to run the test suite |
-| `[lint]` | You only need code quality tools (linting, formatting, type checking) |
-| `[dev]` | You're developing/contributing to this project (includes everything) |
-
-> For more details and additional installation methods, see [Installation & Initial Setup](#installation--initial-setup).
-
-#### 3. Create Configuration File
+#### 2. Create Configuration File
 
 For the Community server, create a file (e.g., `dhc.json`) anywhere on your system:
 
@@ -159,7 +134,7 @@ For the Community server, create a file (e.g., `dhc.json`) anywhere on your syst
 
 > **Dynamic Sessions**: The `session_creation` section enables on-demand [Community Core](https://deephaven.io/community/) session creation. Requirements: `deephaven-server` (installed in any Python venv) for the python method, or [Docker](https://www.docker.com/get-started/) for the docker method. See [Community Session Creation Configuration](#community-session-creation-configuration) for details.
 
-#### 4. Start the Community Server and Configure Your AI Tool
+#### 3. Start the Community Server and Configure Your AI Tool
 
 Start the Community MCP server in the background (logs go to `dh-mcp-community.log`):
 
@@ -177,20 +152,22 @@ To stop the server: `pkill -f dh-mcp-community-server`
 {
   "mcpServers": {
     "deephaven-community": {
-      "command": "/full/path/to/your/.venv/bin/mcp-proxy",
+      "command": "mcp-proxy",
       "args": ["--transport=streamablehttp", "http://127.0.0.1:8003/mcp"]
     },
     "deephaven-docs": {
-      "command": "/full/path/to/your/.venv/bin/mcp-proxy",
+      "command": "mcp-proxy",
       "args": ["--transport=streamablehttp", "https://deephaven-mcp-docs-prod.dhc-demo.deephaven.io/mcp"]
     }
   }
 }
 ```
 
+> If your AI tool reports that `mcp-proxy` is not found, run `which mcp-proxy` in your terminal and use the full path as the `command` value.
+
 **For other tools**, see the [detailed setup instructions](#setup-instructions-by-tool) below.
 
-#### 5. Try It Out
+#### 4. Try It Out
 
 Restart your AI tool (or IDE) after starting the servers.
 
@@ -210,42 +187,27 @@ Confirm the setup is working by asking:
 
 **Get up and running in 5 minutes!** This quickstart assumes you have a Deephaven Enterprise system accessible at a known URL. Contact your Deephaven administrator for the `connection.json` URL and your credentials.
 
-#### 1. Create Virtual Environment
+#### 1. Install Deephaven MCP
 
-**Using `uv` (recommended):**
-
-Pick a suitable project directory for your venv.
+Install with [`uv`](https://docs.astral.sh/uv/) (see [Prerequisites](#prerequisites) if you don't have it yet):
 
 ```bash
-name_of_your_venv=".venv"
-uv venv $name_of_your_venv -p 3.11
+uv tool install --python-preference managed "deephaven-mcp[enterprise]"
 ```
 
-**Using standard `venv`:**
+This places `dh-mcp-enterprise-server` (and `dh-mcp-community-server`, `dh-mcp-docs-server`) on your PATH with no venv to manage.
 
-```bash
-python3.11 -m venv .venv
-```
+> **Installing both server types?** Use `"deephaven-mcp[community,enterprise]"` instead.
+>
+> **Where tools are installed**: Scripts land in `~/.local/bin/` (macOS/Linux) or `%LOCALAPPDATA%\uv\bin\` (Windows). The tool environment lives under `~/.local/share/uv/tools/deephaven-mcp/` — run `uv tool dir` to find the root.
+>
+> **For stdio-only AI tools** (e.g. Claude Desktop): also install `mcp-proxy`, which bridges stdio transport to the HTTP servers:
+>
+> ```bash
+> uv tool install --python-preference managed mcp-proxy
+> ```
 
-> Replace `3.11` / `python3.11` with any supported Python version (3.11 or higher).
-
-#### 2. Install Deephaven MCP
-
-**Using `uv` (recommended):**
-
-```bash
-uv pip install "deephaven-mcp[enterprise]"
-```
-
-**Using standard `pip`:**
-
-```bash
-.venv/bin/pip install "deephaven-mcp[enterprise]"
-```
-
-> Installing `[community,enterprise]` is also fine if you need both server types.
-
-#### 3. Create Configuration File
+#### 2. Create Configuration File
 
 Create a config file (e.g., `dhe.json`) for your enterprise system. Each enterprise server instance manages **one** DHE system.
 
@@ -310,7 +272,7 @@ The enterprise server must be deployed behind TLS — the headers above
 carry secrets in cleartext on the wire. Consult your MCP client's
 documentation for how to inject custom HTTP headers on every request.
 
-#### 4. Start the Enterprise Server and Configure Your AI Tool
+#### 3. Start the Enterprise Server and Configure Your AI Tool
 
 Start the Enterprise MCP server in the background (logs go to `dh-mcp-enterprise-prod.log`):
 
@@ -330,20 +292,22 @@ To stop the server: `pkill -f dh-mcp-enterprise-server`
 {
   "mcpServers": {
     "deephaven-enterprise": {
-      "command": "/full/path/to/your/.venv/bin/mcp-proxy",
+      "command": "mcp-proxy",
       "args": ["--transport=streamablehttp", "http://127.0.0.1:8002/mcp"]
     },
     "deephaven-docs": {
-      "command": "/full/path/to/your/.venv/bin/mcp-proxy",
+      "command": "mcp-proxy",
       "args": ["--transport=streamablehttp", "https://deephaven-mcp-docs-prod.dhc-demo.deephaven.io/mcp"]
     }
   }
 }
 ```
 
+> If your AI tool reports that `mcp-proxy` is not found, run `which mcp-proxy` in your terminal and use the full path as the `command` value.
+
 **For other tools**, see the [detailed setup instructions](#setup-instructions-by-tool) below.
 
-#### 5. Try It Out
+#### 4. Try It Out
 
 Restart your AI tool (or IDE) after starting the server.
 
@@ -363,25 +327,21 @@ Confirm the setup is working by asking:
 
 **Already have `deephaven-mcp` installed?** Here's how to upgrade:
 
-**Using `uv`:**
+**Using `uv tool` (recommended):**
 
 ```bash
-uv pip install --upgrade deephaven-mcp
+uv tool upgrade deephaven-mcp
 ```
 
-**Using standard `pip`:**
+**Using `uv pip` (venv-based install):**
 
 ```bash
-.venv/bin/pip install --upgrade deephaven-mcp
-```
-
-**To upgrade with optional dependencies:**
-
-```bash
-# uv
 uv pip install --upgrade "deephaven-mcp[community,enterprise]"
+```
 
-# pip
+**Using standard `pip` (venv-based install):**
+
+```bash
 .venv/bin/pip install --upgrade "deephaven-mcp[community,enterprise]"
 ```
 
@@ -540,14 +500,12 @@ graph TD
 
 ## Prerequisites
 
-- **Python**: Version 3.11 or higher. ([Download Python](https://www.python.org/downloads/))
+- **[`uv`](https://docs.astral.sh/uv/) (Recommended)**: Used for `uv tool install`, which puts the server commands on your PATH with no venv to manage. Install it via `pip install uv` or the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/). Once installed, `uv` places its bin directory on your PATH automatically.
+- **Python**: Version 3.12 or higher. uv downloads its own managed Python automatically via `--python-preference managed` — no separate Python installation required. ([Download Python](https://www.python.org/downloads/) only needed for non-uv workflows)
 - **Docker (Optional)**: Required for Docker-based community session creation. ([Download Docker](https://www.docker.com/get-started/))
 - **Access to Deephaven systems:** To use the MCP servers, you will need one or more of the following:
   - **[Deephaven Community Core](https://deephaven.io/community/) instance(s):** For development and personal use.
   - **[Deephaven Enterprise](https://deephaven.io/enterprise/) system(s):** For enterprise-level features and capabilities.
-- **Choose your Python environment setup method:**
-  - **Option A: [`uv`](https://docs.astral.sh/uv/) (Recommended)**: A very fast Python package installer and resolver. If you don't have it, you can install it via `pip install uv` or see the [uv installation guide](https://github.com/astral-sh/uv#installation).
-  - **Option B: Standard Python `venv` and `pip`**: Uses Python's built-in [virtual environment (`venv`)](https://docs.python.org/3/library/venv.html) tools and [`pip`](https://pip.pypa.io/en/stable/getting-started/).
 - **Configuration Files**: Each integration requires proper configuration files (specific locations detailed in each integration section)
 
 ---
@@ -560,54 +518,68 @@ The recommended way to install `deephaven-mcp` is from [PyPI](https://pypi.org/p
 
 ### Installation Methods
 
-#### Using `uv` (Fast, Recommended)
+#### Using `uv tool install` (Recommended)
 
-[`uv`](https://github.com/astral-sh/uv) is a high-performance Python package manager. For detailed [`uv`](https://github.com/astral-sh/uv) workflows and project-specific setup, see the [`uv` documentation](docs/UV.md).
+[`uv`](https://github.com/astral-sh/uv) is a high-performance Python package manager. `uv tool install` places the server commands directly on your PATH in an isolated, managed environment — no venv to create or activate.
 
-**Install uv:**
+**Install uv** (if you don't have it):
 
 ```sh
 pip install uv
 ```
 
-**Create environment and install:**
+Or see the [uv installation guide](https://docs.astral.sh/uv/getting-started/installation/) for other options.
+
+**Install deephaven-mcp as a tool:**
 
 ```sh
-# Create virtual environment with Python 3.11+, in a chosen project directory
-name_of_your_venv=".venv"
-uv venv $name_of_your_venv -p 3.11
-
-# Install deephaven-mcp (choose your extras)
-uv pip install deephaven-mcp                           # Basic
-uv pip install "deephaven-mcp[community]"              # + Python session creation
-uv pip install "deephaven-mcp[enterprise]"             # + Enterprise support
-uv pip install "deephaven-mcp[community,enterprise]"   # Both
+uv tool install --python-preference managed "deephaven-mcp[community,enterprise]"
 ```
 
-#### Using Standard `pip` and `venv`
+After this command, `dh-mcp-community-server`, `dh-mcp-enterprise-server`, and `dh-mcp-docs-server` are available on your PATH.
 
-**Create environment and install:**
+**Where tools are installed:**
 
-```sh
-# Create virtual environment
-python3.11 -m venv .venv
+| Platform | Scripts (on PATH) | Tool environment |
+|----------|-------------------|-----------------|
+| macOS/Linux | `~/.local/bin/` | `~/.local/share/uv/tools/deephaven-mcp/` |
+| Windows | `%LOCALAPPDATA%\uv\bin\` | `%APPDATA%\uv\tools\deephaven-mcp\` |
 
-# Install deephaven-mcp (choose your extras)
-.venv/bin/pip install deephaven-mcp                           # Basic
-.venv/bin/pip install "deephaven-mcp[community]"              # + Python session creation
-.venv/bin/pip install "deephaven-mcp[enterprise]"             # + Enterprise support
-.venv/bin/pip install "deephaven-mcp[community,enterprise]"   # Both
-```
+Run `uv tool dir` to find the tool environment root on your system.
 
-**Optional Dependency Reference:**
+**Choose your extras:**
 
 | Extra | Provides |
 |-------|----------|
 | `[community]` | Python-based Community Core session creation (no Docker) |
 | `[enterprise]` | Deephaven Enterprise (Core+) system connectivity |
+| `[community,enterprise]` | Both (recommended default) |
 | `[test]` | Testing framework and utilities |
 | `[lint]` | Code quality tools (linting, formatting, type checking) |
 | `[dev]` | Full development environment (all of the above) |
+
+For detailed [`uv`](https://github.com/astral-sh/uv) workflows and project-specific setup, see the [`uv` documentation](docs/UV.md).
+
+#### Alternative: Using `uv pip` or standard `pip` with a venv
+
+If you prefer a manual venv (for example, when developing or testing):
+
+```sh
+# Create virtual environment with Python 3.12+
+uv venv .venv -p 3.12
+
+# Install deephaven-mcp
+uv pip install "deephaven-mcp[community,enterprise]"
+```
+
+Or with standard pip:
+
+```sh
+python3.12 -m venv .venv
+.venv/bin/pip install "deephaven-mcp[community,enterprise]"
+```
+
+When using a venv, use the full path to executables (e.g., `.venv/bin/dh-mcp-community-server`).
 
 ---
 
@@ -1180,22 +1152,26 @@ tail -f dh-mcp-enterprise-prod.log
 
 #### Claude Desktop
 
-Claude Desktop only supports stdio transport. Use `mcp-proxy` (included in your venv) as a bridge to the HTTP servers. Open **Claude Desktop** → **Settings** → **Developer** → **Edit Config**:
+Claude Desktop uses stdio transport and requires `mcp-proxy` as a bridge to the HTTP servers. Make sure you have run `uv tool install --python-preference managed mcp-proxy` first (see the install step in [Quick Start](#quick-start)).
+
+Open **Claude Desktop** → **Settings** → **Developer** → **Edit Config** and add:
 
 ```json
 {
   "mcpServers": {
     "deephaven-community": {
-      "command": "/full/path/to/your/.venv/bin/mcp-proxy",
+      "command": "mcp-proxy",
       "args": ["--transport=streamablehttp", "http://127.0.0.1:8003/mcp"]
     },
     "deephaven-docs": {
-      "command": "/full/path/to/your/.venv/bin/mcp-proxy",
+      "command": "mcp-proxy",
       "args": ["--transport=streamablehttp", "https://deephaven-mcp-docs-prod.dhc-demo.deephaven.io/mcp"]
     }
   }
 }
 ```
+
+> If your AI tool reports that `mcp-proxy` is not found, run `which mcp-proxy` in your terminal and use the full path as the `command` value.
 
 **Additional Resources:**
 
@@ -1299,13 +1275,13 @@ Before diving into detailed troubleshooting, try these common solutions:
 
 | Error | Where You'll See This | Solution |
 |-------|----------------------|----------|
-| `spawn uv ENOENT` | IDE/AI assistant logs | Use full path to [`uv`](docs/UV.md) |
+| `spawn mcp-proxy ENOENT` | AI tool logs | Run `uv tool install --python-preference managed mcp-proxy` first; if the tool still can't find it, run `which mcp-proxy` and use the full path as the `command` |
 | `Connection failed` | MCP server logs | Check internet connection and server URLs |
 | `Config not found` | MCP server startup | Verify full path to config file passed via `--config` or `DH_MCP_CONFIG_FILE` |
-| `Permission denied` | Command execution | Ensure [`uv`](docs/UV.md) executable has proper permissions |
-| `Python version error` | Virtual environment | Verify supported Python version is installed and accessible |
+| `Permission denied` | Command execution | Ensure executable has proper permissions; run `chmod +x` on the `mcp-proxy` path |
+| `Python version error` | uv tool install | Deephaven MCP requires Python 3.12+; use `uv tool install --python-preference managed ...` |
 | `JSON parse error` | IDE/AI assistant logs | Fix JSON syntax errors in configuration files |
-| `Module not found: deephaven_mcp` | MCP server logs | Ensure virtual environment is activated and dependencies installed |
+| `Module not found: deephaven_mcp` | MCP server logs | Re-run `uv tool install --python-preference managed "deephaven-mcp[community,enterprise]"` |
 | `Invalid session_id format` | MCP tool responses | Community: `community:config:{name}` or `community:dynamic:{name}`; Enterprise: `enterprise:{system_name}:{name}` |
 
 ### JSON Configuration Issues

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -2842,18 +2842,18 @@ Claude Desktop is very useful for debugging and interactively exploring MCP serv
 2. **Navigate to `Settings > Developer > Edit Config`.**
 3. **Edit the `claude_desktop_config.json` file.**
 4. **Add your MCP server under the `mcpServers` section.**
-   - All three servers (Community, Enterprise, Docs) are HTTP-only. Start them first, then configure Claude Desktop using `mcp-proxy` (included in your venv) as a stdio bridge (Claude Desktop does not support HTTP transport natively).
+   - All three servers (Community, Enterprise, Docs) are HTTP-only. Start them first, then configure Claude Desktop using `mcp-proxy` as a stdio bridge (Claude Desktop does not support HTTP transport natively). `mcp-proxy` is **not** a dependency of this project; install it separately with `uv tool install --python-preference managed mcp-proxy`.
    - Example configuration:
 
      ```json
      {
        "mcpServers": {
          "mcp-community": {
-           "command": "/full/path/to/your/.venv/bin/mcp-proxy",
+           "command": "mcp-proxy",
            "args": ["--transport=streamablehttp", "http://127.0.0.1:8003/mcp"]
          },
          "mcp-docs": {
-           "command": "/full/path/to/your/.venv/bin/mcp-proxy",
+           "command": "mcp-proxy",
            "args": ["--transport=streamablehttp", "http://127.0.0.1:8001/mcp"]
          }
        }
@@ -2886,7 +2886,7 @@ For troubleshooting Claude Desktop MCP integration, log files are located at:
 
 ### mcp-proxy
 
-[mcp-proxy](https://github.com/modelcontextprotocol/mcp-proxy) enables MCP clients that only support stdio to connect to servers using HTTP-based transports (streamable-http or SSE). This is useful for clients that do not natively support streamable-http. The `mcp-proxy` utility is included as a dependency in this project.
+[mcp-proxy](https://github.com/modelcontextprotocol/mcp-proxy) enables MCP clients that only support stdio to connect to servers using HTTP-based transports (streamable-http or SSE). This is useful for clients that do not natively support streamable-http. `mcp-proxy` is **not** a dependency of this project; install it separately with `uv tool install --python-preference managed mcp-proxy` (this places `mcp-proxy` on your PATH).
 
 **Use Cases:**
 
@@ -2907,7 +2907,7 @@ For troubleshooting Claude Desktop MCP integration, log files are located at:
    {
      "mcpServers": {
        "deephaven-community": {
-         "command": "/full/path/to/your/.venv/bin/mcp-proxy",
+         "command": "mcp-proxy",
          "args": ["--transport=streamablehttp", "http://127.0.0.1:8003/mcp"]
        }
      }
@@ -2930,7 +2930,7 @@ For troubleshooting Claude Desktop MCP integration, log files are located at:
    {
      "mcpServers": {
        "deephaven-docs": {
-         "command": "/full/path/to/your/.venv/bin/mcp-proxy",
+         "command": "mcp-proxy",
          "args": ["--transport=streamablehttp", "http://127.0.0.1:8001/mcp"]
        }
      }

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -11,7 +11,7 @@ This repository houses the Python-based [Model Context Protocol (MCP)](https://m
 1. **Deephaven MCP Servers**: Provide tools for interacting with Deephaven Community Core and Enterprise instances via separate server processes.
 2. **Deephaven MCP Docs Server**: Provides conversational Q&A about Deephaven documentation.
 
-> **Requirements**: [Python](https://www.python.org/) 3.11 or later is required to run these servers.
+> **Requirements**: [Python](https://www.python.org/) 3.12 or later is required to run these servers.
 
 ---
 
@@ -253,11 +253,11 @@ Before using the Deephaven MCP servers, ensure you have the following prerequisi
 
 ### Required for All Users
 
-**Python 3.11 or Later**
+**Python 3.12 or Later**
 
-- **Requirement**: [Python](https://www.python.org/) 3.11+ is required to run both MCP servers
+- **Requirement**: [Python](https://www.python.org/) 3.12+ is required to run both MCP servers
 - **Installation**: Download from [python.org](https://www.python.org/downloads/) or use your system's package manager
-- **Verification**: Run `python --version` to confirm Python 3.11 or later is installed
+- **Verification**: Run `python --version` to confirm Python 3.12 or later is installed
 
 **Configuration File**
 
@@ -311,7 +311,7 @@ Choose **one** of the following launch methods for dynamically creating Deephave
 
 **Development Tools**
 
-- **Required**: Git, Python 3.11+, virtual environment tool (`venv` or `uv`)
+- **Required**: Git, Python 3.12+, virtual environment tool (`venv` or `uv`)
 - **Recommended**: [`uv`](https://github.com/astral-sh/uv) for faster package management
 - **Installation**: See [UV.md](UV.md) for project-specific uv setup and workflows, or the [uv installation guide](https://github.com/astral-sh/uv#installation) for general installation
 
@@ -358,7 +358,7 @@ pip install -e ".[dev]"
 
 Before proceeding with the Quick Start Guide, verify your setup:
 
-- ✅ Python 3.11+ installed: `python --version`
+- ✅ Python 3.12+ installed: `python --version`
 - ✅ Configuration file created (for Systems Server): `deephaven_mcp.json`
 - ✅ Environment variable set (for Systems Server): `export DH_MCP_CONFIG_FILE=/path/to/deephaven_mcp.json`
 - ✅ Inkeep API key set (for Docs Server): `export INKEEP_API_KEY=your-key`
@@ -3009,7 +3009,7 @@ Both servers expose their tools through FastMCP, following the Model Context Pro
 2. **Create a virtual environment**:
 
    ```sh
-   uv venv .venv -p 3.11 # Or your desired Python version e.g., 3.12, 3.13
+   uv venv .venv -p 3.12 # Or a later Python version, e.g. 3.13
    ```
 
 3. **Install dependencies with uv (editable mode for development)**:

--- a/docs/UV.md
+++ b/docs/UV.md
@@ -256,9 +256,9 @@ Example GitHub Actions step for using `uv`:
 
 ```yaml
 - name: Set up Python
-  uses: actions/setup-python@v4
+  uses: actions/setup-python@v5
   with:
-    python-version: '3.10'
+    python-version: '3.12'
 - name: Install uv
   run: pip install uv
 - name: Install dependencies

--- a/docs/UV.md
+++ b/docs/UV.md
@@ -10,6 +10,7 @@
 
 - [Using `uv` in deephaven-mcp](#using-uv-in-deephaven-mcp)
   - [Table of Contents](#table-of-contents)
+  - [End-User Install (`uv tool install`)](#end-user-install-uv-tool-install)
   - [Why use `uv`?](#why-use-uv)
   - [Installing `uv`](#installing-uv)
     - [Creating a Virtual Environment with `uv`](#creating-a-virtual-environment-with-uv)
@@ -27,6 +28,28 @@
   - [Troubleshooting](#troubleshooting)
   - [Tips \& Troubleshooting](#tips--troubleshooting)
   - [Further Reading](#further-reading)
+
+---
+
+## End-User Install (`uv tool install`)
+
+For end users (not contributors), the recommended installation method is `uv tool install`. This places `dh-mcp-community-server`, `dh-mcp-enterprise-server`, and `dh-mcp-docs-server` on your PATH in an isolated managed environment — no venv to create or activate.
+
+```sh
+uv tool install --python-preference managed "deephaven-mcp[community,enterprise]"
+```
+
+- `--python-preference managed` tells uv to download and use its own Python (stored in `~/.local/share/uv/python/`) rather than any system Python. The tool environment is unaffected if your system Python is upgraded, moved, or removed. uv picks the latest compatible version per `requires-python` in the package.
+- Scripts land in `~/.local/bin/` (macOS/Linux) or `%LOCALAPPDATA%\uv\bin\` (Windows).
+- The tool environment lives under `~/.local/share/uv/tools/deephaven-mcp/`. Run `uv tool dir` to find the root.
+
+**To upgrade:**
+
+```sh
+uv tool upgrade deephaven-mcp
+```
+
+The rest of this document covers developer and contributor workflows that use a local venv.
 
 ---
 
@@ -94,16 +117,22 @@ This will install all dependencies to exactly match your lock file(s) for reprod
 
 ### 3. Running Servers and Scripts
 
-**Systems Server (SSE):**
+**Community Server:**
 
 ```sh
-DH_MCP_CONFIG_FILE=deephaven_mcp.json uv run dh-mcp-systems --transport sse
+DH_MCP_CONFIG_FILE=dhc.json uv run dh-mcp-community-server --port 8003
 ```
 
-**Docs Server (SSE):**
+**Enterprise Server:**
 
 ```sh
-INKEEP_API_KEY=your-inkeep-api-key uv run dh-mcp-docs --transport sse
+DH_MCP_CONFIG_FILE=dhe.json uv run dh-mcp-enterprise-server --port 8002
+```
+
+**Docs Server:**
+
+```sh
+uv run dh-mcp-docs-server
 ```
 
 **Run a test server:**

--- a/docs/UV.md
+++ b/docs/UV.md
@@ -77,13 +77,13 @@ Once [`uv`](https://github.com/astral-sh/uv) is installed, it's highly recommend
 
 1. **Create a virtual environment (e.g., named `.venv`) with a specific Python version:**
 
-    Use the `-p` option to specify your desired Python interpreter (e.g., Python 3.11, 3.12, 3.13, or a full path to an executable):
+    Use the `-p` option to specify your desired Python interpreter (e.g., Python 3.12, 3.13, or a full path to an executable). Deephaven MCP requires Python 3.12 or higher:
 
     ```sh
-    uv venv .venv -p 3.11
+    uv venv .venv -p 3.12
     ```
 
-    Replace `3.11` with your target Python version or path.
+    Replace `3.12` with your target Python version (3.12+) or path.
 
 2. **Activate the virtual environment (optional):**
 
@@ -132,7 +132,7 @@ DH_MCP_CONFIG_FILE=dhe.json uv run dh-mcp-enterprise-server --port 8002
 **Docs Server:**
 
 ```sh
-uv run dh-mcp-docs-server
+INKEEP_API_KEY=your-inkeep-api-key uv run dh-mcp-docs-server
 ```
 
 **Run a test server:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "httpx>=0.24.0",            # HTTP client
     # MCP protocol and orchestration
     "mcp[cli]>=1.12.0",          # CLI and fastmcp server
-    "mcp-proxy",                # SSE/Streamable-HTTP proxy support
     # Deephaven integration
     "pydeephaven>=0.39",      # Deephaven Python API
     "numba>=0.63.1",          # Force Python 3.12+ compatible numba (see https://github.com/deephaven/deephaven-mcp/issues/145)


### PR DESCRIPTION
- Added `.github/workflows/tool-install.yml` to verify end-user installation path via `uv tool install`
- Workflow validates installation on ubuntu-latest and macos-latest with Python 3.12 and 3.13
- Tests that all three server entry points (community, enterprise, docs) are accessible on PATH after installation
- Verifies mcp-proxy can be installed separately as documented in README
- Builds wheel from source to test current branch rather than Py