### PR TITLE
feat: Post CLI cleanup

### DIFF
--- a/.agents/skills/_documentation-roles/SKILL.md
+++ b/.agents/skills/_documentation-roles/SKILL.md
@@ -12,14 +12,22 @@ Every top-level markdown file in this repository has a single, intentional role.
 
 | File | Reader | In scope | Out of scope |
 | --- | --- | --- | --- |
-| `README.md` | end user (not developer) | Get a user installed, configured, and connected to their AI tool with minimum friction. Quick start, install (including extras), upgrade path, AI-tool setup, capability list, troubleshooting, architecture overview. | Detailed schema reference, internal mechanics, contributor workflows. |
+| `README.md` | end user (not developer) | Get a user installed, configured, and connected to their AI tool with minimum friction. Quick start, install (including extras), upgrade path, AI-tool setup, capability list (one line per tool), troubleshooting, architecture overview. | Detailed schema reference, per-tool reference detail, internal mechanics, contributor workflows. |
 | `docs/CONFIGURATION.md` | operator | Configuration *files and directories* — schema, fields, defaults, templating syntax. | Install options (uv extras, pip), security narrative, developer workflows. |
 | `docs/ENV.md` | operator | Environment variables consumed by the server processes. | Templating syntax (lives in `CONFIGURATION.md`), uv. |
 | `docs/SECURITY.md` | operator deploying the server | **Short, self-contained** guide. A reader must be able to stand up a secure deployment without leaving the page. Trust model, hardening checklist, authentication, transport security, secret handling, rotation. | Anything that requires bouncing to `DEVELOPER_GUIDE.md` to act on. |
 | `docs/UV.md` | developer new to `uv` | Generic `uv` crash course. | Project-specific commands, project env vars, project tests, project install lines. |
 | `docs/CLI.md` | operator + AI agent using the local `dh-mcp` CLI | Full `dh-mcp` reference: command surface (noun-verb tree), global flags, env-var bindings, exit codes, `error_code` registry, output modes (`human` / `json` / `yaml`), examples, shell completion, `dh-mcp introspect` agent self-discovery. | Server-side configuration (lives in `CONFIGURATION.md`); developer/contributor mechanics (lives in `DEVELOPER_GUIDE.md`); environment variables consumed by the server processes (those live in `ENV.md`; CLI-specific env vars stay here). |
-| `docs/DEVELOPER_GUIDE.md` | contributor | Everything a developer working *on* the project needs. Catch-all. | (No restrictions.) |
+| `docs/DEVELOPER_GUIDE.md` | contributor | Everything a developer working *on* the project needs. Catch-all. | Per-tool reference (parameters, returns, examples) — see [Tool reference is owned by code](#tool-reference-is-owned-by-code). |
 | `AGENTS.md` | AI agent | Agent process rules. Not human documentation; **no TOC**. | Anything intended for humans. |
+
+## Tool reference is owned by code
+
+MCP tool reference — each tool's parameters, return shape, and examples — has one source of truth: the tool's **docstring**. It is sent to AI agents over MCP and surfaced live by `dh-mcp tool show <name>`, so it cannot drift from the installed code. **No markdown document hand-maintains this content** — a hand-kept copy drifts the moment a signature changes (the prior guide had accumulated fabricated and missing parameters).
+
+- **README** (*Available MCP Tools*) — the one-line-per-tool capability list (name + purpose), nothing deeper.
+- **Every other doc** — links to `dh-mcp tool show` / the `_tools/` source; it never reproduces a tool's parameters or returns.
+- **Adding or removing a tool** — the docstring is the reference; README's one-liner is the only doc that changes. See `mcp-tool-add`.
 
 ## Editing rules
 

--- a/.agents/skills/mcp-tool-add/SKILL.md
+++ b/.agents/skills/mcp-tool-add/SKILL.md
@@ -14,7 +14,7 @@ Apply the `_mcp-module-organization` skill for module placement and the `pydocs-
 5. **Add helpers** with a leading underscore. Place them in the same module unless used by 3+ modules, in which case promote to `_tools/shared.py`.
 6. **Add logging.** Apply the `_logging-standards` skill: log entry, success, and the failure path for the tool in its canonical message format; never log secrets.
 7. **Add tests.** A new tool gets its own test cases covering the happy path, error paths, and any session-id parsing. Apply the `tests-improve` skill for coverage targets.
-8. **Update docs.** `docs/CONFIGURATION.md` and `docs/DEVELOPER_GUIDE.md` if the tool changes the user-visible surface.
+8. **Update the capability list.** Add the tool to the *Available MCP Tools* list in `README.md` (one line: name + one-line purpose). The docstring from step 3 is the tool's reference — no other doc needs a per-tool entry. Update `docs/CONFIGURATION.md` only if the tool adds a configuration field.
 9. **Run** `run-precommit` and `tests-run-file` on the changed test files, then `tests-run` for a full-suite check.
 
 ## Anti-patterns

--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ in the PQ id (form `<system>:<serial>`).
 - `session_script_run(session_id, ...)` - Execute Python/Groovy scripts
 - `session_pip_list(session_id)` - Query installed packages
 
-> For detailed tool documentation with parameters and examples, see the [Developer & Contributor Guide](docs/DEVELOPER_GUIDE.md).
+> For each tool's full parameters, return shape, and examples, run `dh-mcp tool show <name>` (or `dh-mcp tool list` to enumerate them) — see [`docs/CLI.md`](docs/CLI.md). The authoritative detail is each tool's source docstring, which is also what the command surfaces live.
 
 ---
 
@@ -970,7 +970,7 @@ Before diving into detailed troubleshooting, try these common solutions:
 
 **Log File Locations:**
 
-- **Claude Desktop (macOS):** `~/Library/Logs/Claude/mcp-server-*.log`
+- **Claude Desktop:** macOS `~/Library/Logs/Claude/`, Windows `%APPDATA%\Claude\logs\` — `mcp.log` holds general MCP connection logging; `mcp-server-<name>.log` holds each server's stderr.
 - **VS Code/Copilot:** Check VS Code's Output panel and Developer Console
 - **Cursor IDE:** Check the IDE's log panel and developer tools
 - **Windsurf IDE:** Check the IDE's integrated terminal and log outputs

--- a/config-samples/ai/config/README.md
+++ b/config-samples/ai/config/README.md
@@ -38,6 +38,7 @@ best-effort).
 ## Files in This Example
 
 - `server.json` — PSK material for the HTTP transport.
+- `cli.json` — `dh-mcp` CLI defaults (output format, daemon control, request timeouts); all defaults shown.
 - `community/settings.json` — community-wide settings + session_creation defaults.
 - `community/sessions/local_dev.json` — a static community session.
 - `enterprise/settings.json` — enterprise-wide settings (timeouts; may be `{}` to take defaults).

--- a/config-samples/ai/config/cli.json
+++ b/config-samples/ai/config/cli.json
@@ -1,0 +1,17 @@
+{
+  "output": {
+    "format": "human"
+  },
+  "daemon": {
+    "auto_start": true,
+    "timeouts": {
+      "startup_deadline_seconds": 30,
+      "kill_after_seconds": 10
+    }
+  },
+  "request": {
+    "timeouts": {
+      "default_seconds": 60
+    }
+  }
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -251,6 +251,32 @@ dh-mcp tool show sessions_list
 dh-mcp tool call sessions_list --arg type=community
 ```
 
+### `dh-mcp session`
+
+| Verb                   | Purpose                                                                                       |
+|------------------------|-----------------------------------------------------------------------------------------------|
+| `credentials <id>`     | Prints one Community session's browser-login credentials (`auth_type`, `auth_token`, `connection_url`, `connection_url_with_auth`). |
+
+`dh-mcp session credentials` is an ergonomic wrapper over the
+`session_community_credentials` MCP tool. Unlike `dh-mcp daemon`,
+which redacts secrets, its output contains a **plaintext auth token
+by design** so you can open the session in a browser. Retrieval is
+gated by `security.credential_retrieval_mode` in
+`community/settings.json`, which defaults to `none`; when retrieval
+is disabled — or the session is missing or not a Community session —
+the command exits `3` with the tool's explanation. Returns:
+
+- `0` — success.
+- `2` — client-side failure (connection, timeout, daemon, ...).
+- `3` — the credentials tool reported an error (`tool_returned_error`).
+
+Examples:
+
+```bash
+dh-mcp session credentials community:community:my-session
+dh-mcp -o json session credentials community:community:my-session
+```
+
 ### `dh-mcp config`
 
 | Verb        | Purpose                                                                                       |

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -359,7 +359,7 @@ Where:
 - `source`: For community sessions, always the literal `"community"` (the umbrella system name; the static-vs-dynamic distinction lives on the manager's `origin` field, not in the id). For enterprise sessions, the server's configured `system_name` (e.g. `"prod"`, `"staging"`).
 - `session_name`: The specific session name within that source
 
-For enterprise sessions, `source` equals the server's configured `system_name`, Embedding it in the session ID lets the one multiplexed server host multiple enterprise systems without ID collisions; a tool call validates that the `system_name` component names a configured system and errors clearly otherwise.
+For enterprise sessions, `source` equals the server's configured `system_name`. Embedding it in the session ID lets the multiplexed server host multiple enterprise systems without ID collisions; tool calls validate the `system_name` component and error clearly otherwise.
 
 **Examples**:
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -948,7 +948,7 @@ deephaven-mcp/
 - Provides LLM-powered documentation Q&A capabilities
 - Integrates with the Inkeep LLM API (OpenAI-compatible endpoint) for conversational assistance
 - HTTP-only (streamable-http transport)
-- Rate-limits its own outbound Inkeep API calls; the server does not rate-limit inbound requests (front it with a gateway — see [`docs/SECURITY.md`](SECURITY.md))
+- Does not rate-limit inbound requests; protect it with an API gateway / ingress rate limiting (see [`docs/SECURITY.md`](SECURITY.md)).
 
 **Resource Manager (`resource_manager/`)**:
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,6 +1,4 @@
-# Deephaven MCP
-
-> **You are reading the [Developer & Contributor Guide](DEVELOPER_GUIDE.md) for Deephaven MCP.**
+# Deephaven MCP — Developer & Contributor Guide
 
 > **Project repository:** [https://github.com/deephaven/deephaven-mcp](https://github.com/deephaven/deephaven-mcp)
 
@@ -8,7 +6,7 @@
 
 This repository houses the Python-based [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers for Deephaven:
 
-1. **Deephaven MCP Servers**: Provide tools for interacting with Deephaven Community Core and Enterprise instances via separate server processes.
+1. **Deephaven MCP Systems Server**: A single multiplexed server providing tools for interacting with Deephaven Community Core and Enterprise instances.
 2. **Deephaven MCP Docs Server**: Provides conversational Q&A about Deephaven documentation.
 
 > **Requirements**: [Python](https://www.python.org/) 3.12 or later is required to run these servers.
@@ -17,87 +15,42 @@ This repository houses the Python-based [Model Context Protocol (MCP)](https://m
 
 ## Table of Contents
 
-- [Deephaven MCP](#deephaven-mcp)
+- [Deephaven MCP — Developer & Contributor Guide](#deephaven-mcp--developer--contributor-guide)
   - [Table of Contents](#table-of-contents)
   - [Introduction](#introduction)
     - [About This Project](#about-this-project)
     - [Key Features](#key-features)
     - [System Architecture](#system-architecture)
   - [Prerequisites](#prerequisites)
-    - [Required for All Users](#required-for-all-users)
-    - [Systems Server Prerequisites](#systems-server-prerequisites)
-    - [Docs Server Prerequisites (Only If Using Docs Server)](#docs-server-prerequisites-only-if-using-docs-server)
     - [Development Prerequisites (Contributors Only)](#development-prerequisites-contributors-only)
-  - [Optional Dependencies](#optional-dependencies)
-    - [Quick Verification Checklist](#quick-verification-checklist)
   - [Quick Start Guide](#quick-start-guide)
-    - [Systems Server Quick Start](#systems-server-quick-start)
-    - [Docs Server Quick Start](#docs-server-quick-start)
   - [Command Line Entry Points](#command-line-entry-points)
   - [HTTP Transport Security](#http-transport-security)
-    - [PSK gating](#psk-gating)
     - [Loopback-only enforcement](#loopback-only-enforcement)
     - [Health-check endpoint](#health-check-endpoint)
   - [MCP Server Implementations](#mcp-server-implementations)
-    - [Community Server](#community-server)
-      - [Community Server Overview](#community-server-overview)
-        - [Configuration Directory Tree](#configuration-directory-tree)
-          - [Environment Variables](#environment-variables)
-          - [File Structure Overview](#file-structure-overview)
-      - [Systems Sessions Configuration](#systems-sessions-configuration)
-    - [Security Configuration](#security-configuration)
-      - [Community Session Credential Retrieval](#community-session-credential-retrieval)
-      - [Community Session Creation Configuration](#community-session-creation-configuration)
-      - [Enterprise Server Configuration](#enterprise-server-configuration)
-        - [Enterprise Auth Model](#enterprise-auth-model)
-      - [Running the Systems Server](#running-the-systems-server)
-        - [Systems Server CLI Arguments](#systems-server-cli-arguments)
-      - [Using the Systems Server](#using-the-systems-server)
-      - [Session ID Format and Terminology](#session-id-format-and-terminology)
-      - [Community Server Tools](#community-server-tools)
-      - [Error Handling](#error-handling)
-      - [MCP Tools](#mcp-tools)
-    - [System Tools](#system-tools)
-      - [`list_systems`](#list_systems)
-      - [`enterprise_systems_status`](#enterprise_systems_status)
-      - [Enterprise Session Tools](#enterprise-session-tools)
-        - [`session_enterprise_create`](#session_enterprise_create)
-        - [`session_enterprise_delete`](#session_enterprise_delete)
-      - [Persistent Query (PQ) Management Tools](#persistent-query-pq-management-tools)
-        - [`pq_name_to_id`](#pq_name_to_id)
-        - [`pq_list`](#pq_list)
-        - [`pq_details`](#pq_details)
-        - [`pq_create`](#pq_create)
-        - [`pq_delete`](#pq_delete)
-        - [`pq_modify`](#pq_modify)
-        - [`pq_start`](#pq_start)
-        - [`pq_stop`](#pq_stop)
-        - [`pq_restart`](#pq_restart)
-      - [Community Session Tools](#community-session-tools)
-        - [`session_community_create`](#session_community_create)
-        - [`session_community_delete`](#session_community_delete)
-        - [`session_community_credentials`](#session_community_credentials)
-      - [General Session Tools](#general-session-tools)
-        - [`sessions_list`](#sessions_list)
-        - [`session_details`](#session_details)
-        - [`catalog_tables_list`](#catalog_tables_list)
-        - [`catalog_namespaces_list`](#catalog_namespaces_list)
-        - [`catalog_tables_schema`](#catalog_tables_schema)
-        - [`catalog_table_sample`](#catalog_table_sample)
-    - [Session Data Tools](#session-data-tools)
-      - [`session_tables_schema`](#session_tables_schema)
-        - [`session_script_run`](#session_script_run)
-        - [`session_pip_list`](#session_pip_list)
-        - [`session_table_data`](#session_table_data)
-        - [`session_tables_list`](#session_tables_list)
-      - [Community Server Test Components](#community-server-test-components)
-        - [Community Test Server](#community-test-server)
-        - [Community Server Test Client](#community-server-test-client)
+    - [Systems Server](#systems-server)
+      - [Community sessions](#community-sessions)
+      - [Community session security and creation](#community-session-security-and-creation)
+        - [Dynamic session launch prerequisites](#dynamic-session-launch-prerequisites)
+        - [Retrieving session credentials](#retrieving-session-credentials)
+      - [Enterprise systems](#enterprise-systems)
+        - [Enterprise session registry internals](#enterprise-session-registry-internals)
+      - [Running the systems server](#running-the-systems-server)
+        - [CLI arguments](#cli-arguments)
+      - [Using the systems server](#using-the-systems-server)
+    - [Concepts and conventions](#concepts-and-conventions)
+      - [Session ID format and terminology](#session-id-format-and-terminology)
+      - [Response envelope](#response-envelope)
+      - [Tool reference](#tool-reference)
+      - [Persistent Query (PQ) concepts](#persistent-query-pq-concepts)
+    - [Test components](#test-components)
+      - [Test server](#test-server)
+      - [Smoke-test client](#smoke-test-client)
     - [Docs Server](#docs-server)
       - [Docs Server Overview](#docs-server-overview)
       - [Docs Server Configuration](#docs-server-configuration)
         - [Docs Server Environment Variables](#docs-server-environment-variables)
-        - [Example Configuration](#example-configuration)
       - [Running the Docs Server](#running-the-docs-server)
         - [Docs Server CLI Arguments](#docs-server-cli-arguments)
       - [Docs Server Tools](#docs-server-tools)
@@ -107,22 +60,19 @@ This repository houses the Python-based [Model Context Protocol (MCP)](https://m
         - [Docs Test Client](#docs-test-client)
   - [Integration Methods](#integration-methods)
     - [MCP Inspector](#mcp-inspector)
-      - [MCP Inspector with Community Server](#mcp-inspector-with-community-server)
+      - [MCP Inspector with the systems server](#mcp-inspector-with-the-systems-server)
       - [MCP Inspector with Docs Server](#mcp-inspector-with-docs-server)
     - [Claude Desktop](#claude-desktop)
-      - [Configuration](#configuration)
-      - [Claude Desktop Log Locations](#claude-desktop-log-locations)
     - [mcp-proxy](#mcp-proxy)
-      - [mcp-proxy with Community Server](#mcp-proxy-with-community-server)
-      - [mcp-proxy with Docs Server](#mcp-proxy-with-docs-server)
     - [Programmatic API](#programmatic-api)
-      - [Community Server Example](#community-server-example)
+      - [Systems Server Example](#systems-server-example)
       - [Docs Server Example](#docs-server-example)
   - [Development](#development)
     - [Development Workflow](#development-workflow)
+    - [Contributing workflow](#contributing-workflow)
     - [Advanced Development Techniques](#advanced-development-techniques)
     - [Development Commands](#development-commands)
-      - [Code Quality \& Pre-commit Checks](#code-quality--pre-commit-checks)
+      - [Code Quality & Pre-commit Checks](#code-quality--pre-commit-checks)
     - [Project Structure](#project-structure)
       - [Key Module Details](#key-module-details)
       - [Script References](#script-references)
@@ -132,8 +82,8 @@ This repository houses the Python-based [Model Context Protocol (MCP)](https://m
     - [Performance Testing](#performance-testing)
       - [MCP Docs Server Stress Testing](#mcp-docs-server-stress-testing)
       - [HTTP Transport Stress Testing](#http-transport-stress-testing)
-      - [Usage Example](#usage-example)
-      - [Arguments](#arguments)
+        - [Usage example](#usage-example)
+        - [Arguments](#arguments)
   - [Testing](#testing)
     - [Unit Tests](#unit-tests)
     - [Integration Tests](#integration-tests)
@@ -142,14 +92,13 @@ This repository houses the Python-based [Model Context Protocol (MCP)](https://m
       - [Running Specific Test Classes](#running-specific-test-classes)
       - [Troubleshooting Integration Tests](#troubleshooting-integration-tests)
   - [Troubleshooting](#troubleshooting)
-    - [Common Issues](#common-issues)
-    - [Common Errors \& Solutions](#common-errors--solutions)
+    - [Development-specific issues](#development-specific-issues)
   - [Resources](#resources)
     - [Documentation](#documentation)
     - [Deephaven API Reference](#deephaven-api-reference)
-    - [Tools \& Related Projects](#tools--related-projects)
+    - [Tools & Related Projects](#tools--related-projects)
     - [Contributing](#contributing)
-    - [Community \& Support](#community--support)
+    - [Community & Support](#community--support)
   - [License](#license)
 
 ---
@@ -235,69 +184,13 @@ graph TD
 
 **Transport:**
 
-The Docs Server uses **streamable-http exclusively**. Clients without native streamable-http support can use [mcp-proxy](#mcp-proxy-with-docs-server) to bridge stdio to streamable-http. (The systems server, by contrast, supports both stdio and streamable-HTTP natively.)
+The Docs Server uses **streamable-http exclusively**. Clients without native streamable-http support can use [mcp-proxy](#mcp-proxy) to bridge stdio to streamable-http. (The systems server, by contrast, supports both stdio and streamable-HTTP natively.)
 
 The MCP Docs Server processes natural language questions about Deephaven documentation using LLM capabilities via the Inkeep API.
 
 ## Prerequisites
 
-Before using the Deephaven MCP servers, ensure you have the following prerequisites installed and configured:
-
-### Required for All Users
-
-**Python 3.12 or Later**
-
-- **Requirement**: [Python](https://www.python.org/) 3.12+ is required to run both MCP servers
-- **Installation**: Download from [python.org](https://www.python.org/downloads/) or use your system's package manager
-- **Verification**: Run `python --version` to confirm Python 3.12 or later is installed
-
-**Configuration File**
-
-- **Requirement**: A directory tree of JSON5 configuration files (not a single file) for the Systems Server
-- **Location**: Default `~/.deephaven/ai/config/` (POSIX) or `%APPDATA%/Deephaven/ai/config/` (Windows). Override with the `DH_MCP_DATA_DIR` env var or the `--config-dir` CLI flag.
-- **Details**: See [Configuration Directory Tree](#configuration-directory-tree) for the layout summary, [`docs/CONFIGURATION.md`](CONFIGURATION.md) for the authoritative schema reference, and [`config-samples/ai/config/`](../config-samples/ai/config/) for a sample tree.
-
-### Systems Server Prerequisites
-
-**For Static Community Sessions**
-
-- **Requirement**: Access to running Deephaven Community Core instance(s)
-- **Configuration**: Connection details (host, port, auth) specified in per-session JSON files under `community/sessions/`
-- **More Info**: See [Systems Sessions Configuration](#systems-sessions-configuration)
-
-**For Dynamic Community Sessions (Optional)**
-
-Choose **one** of the following launch methods for dynamically creating Deephaven sessions:
-
-- **Docker Launch Method**:
-  - **Requirement**: [Docker](https://www.docker.com/get-started/) installed and running
-  - **Installation**: No additional Python packages required beyond base `deephaven-mcp`
-  - **Verification**: Run `docker ps` to confirm Docker daemon is accessible
-  - **Best For**: Production, isolated environments, cross-platform consistency
-
-- **Python Launch Method**:
-  - **Requirement**: `deephaven-server` Python package
-  - **Installation**: `pip install deephaven-server` (in MCP venv or a custom venv)
-  - **Verification**: Run `deephaven server --help` to confirm the command is available
-  - **Best For**: Development environments, faster startup, no Docker dependency
-  - **Custom Venv**: Use the `python.venv_path` config setting to specify a different Python environment
-
-**For Enterprise Systems (Optional)**
-
-- **Requirement**: Deephaven Enterprise (Core+) system(s) with accessible connection.json URL
-- **Installation**: `pip install "deephaven-mcp[enterprise]"` (installs `deephaven-coreplus-client` from PyPI)
-- **Configuration**: Each Enterprise system gets one file at `enterprise/systems/<system_name>.json` under your configuration directory.
-- **More Info**: See [Enterprise Server Configuration](#enterprise-server-configuration) and [Development Workflow](#development-workflow)
-
-### Docs Server Prerequisites (Only If Using Docs Server)
-
-> **Note**: These prerequisites are only required if you plan to use the MCP Docs Server. Most users only need the Systems Servers (Community or Enterprise) and can skip this section.
-
-**Inkeep API Key**
-
-- **Requirement**: Valid API key from [Inkeep](https://inkeep.com/) for documentation Q&A
-- **Configuration**: Set via `INKEEP_API_KEY` environment variable (required)
-- **Obtaining**: Contact Inkeep or visit [inkeep.com](https://inkeep.com/) to obtain an API key
+End-user prerequisites — Python 3.12+, the configuration directory, Docker for docker-launched sessions, and the Inkeep key for a self-hosted docs server — are covered in the [README Prerequisites](../README.md#prerequisites) and [Configuration](../README.md#configuration) sections. Only contributor-specific prerequisites follow.
 
 ### Development Prerequisites (Contributors Only)
 
@@ -315,155 +208,9 @@ Choose **one** of the following launch methods for dynamically creating Deephave
   - `deephaven-server` package installed (for python integration tests)
 - **More Info**: See [Testing](#testing) section
 
-## Optional Dependencies
-
-The `deephaven-mcp` package provides optional dependency groups (extras) to tailor the installation to your specific needs:
-
-| Extra | Purpose | Install Command |
-|-------|---------|-----------------|
-| `[community]` | Python-based Community Core session creation (no Docker required) | `pip install "deephaven-mcp[community]"` |
-| `[enterprise]` | Connect to Deephaven Enterprise (Core+) systems | `pip install "deephaven-mcp[enterprise]"` |
-| `[test]` | Run unit and integration tests | `pip install "deephaven-mcp[test]"` |
-| `[lint]` | Code quality tools (linting, formatting, type checking) | `pip install "deephaven-mcp[lint]"` |
-| `[dev]` | Full development environment with all features | `pip install "deephaven-mcp[dev]"` |
-
-**Common Installation Patterns:**
-
-```bash
-# Basic installation (connect to existing instances)
-pip install deephaven-mcp
-
-# With python session creation for Community Core
-pip install "deephaven-mcp[community]"
-
-# With Enterprise support
-pip install "deephaven-mcp[enterprise]"
-
-# Both Community + Enterprise
-pip install "deephaven-mcp[community,enterprise]"
-
-# Full development environment (includes all features)
-pip install -e ".[dev]"
-```
-
-### Quick Verification Checklist
-
-Before proceeding with the Quick Start Guide, verify your setup:
-
-- ✅ Python 3.12+ installed: `python --version`
-- ✅ Configuration directory populated (for Systems Server): see [`config-samples/ai/config/`](../config-samples/ai/config/)
-- ✅ Environment variable set when overriding the default location: `export DH_MCP_DATA_DIR=/path/to/your/data-root`
-- ✅ Inkeep API key set (for Docs Server): `export INKEEP_API_KEY=your-key`
-- ✅ Docker running (for docker launch method): `docker ps`
-- ✅ OR deephaven-server installed (for python launch method): `deephaven server --help`
-
 ## Quick Start Guide
 
-### Systems Server Quick Start
-
-1. **Set up the configuration directory:**
-   `dh-mcp-systems-server` reads a directory tree of small JSON files
-   (default `~/.deephaven/ai/config/`). Create at least one community
-   session file:
-
-   ```json5
-   // ~/.deephaven/ai/config/community/sessions/local_session.json
-   {
-     "session_name": "local_session",  // must match the filename stem
-     "host": "localhost",              // Deephaven server address
-     "port": 10000                     // Default Deephaven port
-   }
-   ```
-
-   See [`config-samples/ai/config/`](../config-samples/ai/config/) for a complete
-   sample tree (community sessions, enterprise systems, and
-   `server.json` for the HTTP-transport PSK).
-
-   > **Dynamic Community Session Creation (Optional):** To enable
-   > on-demand creation of Deephaven Community sessions, add a
-   > `session_creation` block to `~/.deephaven/ai/config/community/settings.json`.
-   > Choose your launch method:
-   >
-   > - **Docker (default):** Requires Docker installed and running. No additional Python packages needed.
-   >
-   >   ```json
-   >   {
-   >     "session_creation": {
-   >       "max_concurrent_sessions": 5,
-   >       "defaults": {"launch_method": "docker"}
-   >     }
-   >   }
-   >   ```
-   >
-   > - **Python:** Faster startup, no Docker needed. Install `deephaven-server` in your Python environment.
-   >
-   >   ```json5
-   >   {
-   >     "session_creation": {
-   >       "max_concurrent_sessions": 5,
-   >       "defaults": {
-   >         "launch_method": "python",
-   >         "python": { "venv_path": null }  // null uses MCP venv, or specify "/path/to/custom/venv"
-   >       }
-   >     }
-   >   }
-   >   ```
-   >
-   > See [Community Session Creation Configuration](#community-session-creation-configuration) for all options.
-
-2. **Start a test Deephaven server in one terminal:**
-
-   ```sh
-   # For anonymous authentication (no MCP auth needed)
-   uv run scripts/run_deephaven_test_server.py --table-group simple
-
-   # OR for PSK authentication (if your MCP config uses auth tokens)
-   uv run scripts/run_deephaven_test_server.py --table-group simple --auth-token Deephaven123
-   ```
-
-   > This script is located at [`../scripts/run_deephaven_test_server.py`](../scripts/run_deephaven_test_server.py) and creates a local Deephaven server with test data. Use the `--auth-token` parameter if your MCP configuration requires PSK authentication.
-
-3. **Run the Systems Server (HTTP transport, for the Inspector):**
-
-   ```sh
-   # server.json must declare a PSK; here we read it from $DH_MCP_PSK
-   export DH_MCP_PSK='your-shared-secret'
-   uv run dh-mcp-systems-server --transport http --port 8000
-   ```
-
-   For desktop AI clients, drop the `--transport http` flag and let
-   the client launch the server as a stdio subprocess instead.
-
-4. **Test with the MCP Inspector:**
-
-   ```sh
-   npx @modelcontextprotocol/inspector@latest
-   ```
-
-   Connect to `http://127.0.0.1:8000/mcp` in the Inspector UI and add
-   the request header `X-Deephaven-PSK: your-shared-secret`.
-
-### Docs Server Quick Start
-
-1. **Set up Inkeep API key:**
-
-   ```sh
-   export INKEEP_API_KEY=your-inkeep-api-key  # Get from https://inkeep.com
-   ```
-
-2. **Run the Docs Server:**
-
-   ```sh
-   uv run dh-mcp-docs-server
-   ```
-
-3. **Test with the MCP Inspector:**
-
-   ```sh
-   npx @modelcontextprotocol/inspector@latest
-   ```
-
-   Connect to `http://localhost:8001/mcp` in the Inspector UI and test the `docs_chat` tool.
+End-user quick starts (stdio and HTTP, per deployment type) live in the README: [Community Core Quick Start](../README.md#community-core-quick-start) and [Enterprise Quick Start](../README.md#enterprise-quick-start). To build and run the servers from a checkout, see [Development](#development); to spin up a local Deephaven server with demo tables, see [test server](#test-server).
 
 ## Command Line Entry Points
 
@@ -479,328 +226,50 @@ These commands are automatically available in your PATH after installing the pac
 
 ## HTTP Transport Security
 
-> **See also: [`docs/SECURITY.md`](SECURITY.md)** for the project's
-> security model and hardening checklist. The section below is the
-> deep operator reference for the multiplexed `dh-mcp-systems-server`'s
-> HTTP transport.
-
-`dh-mcp-systems-server` supports two transports:
-
-- **`stdio`** (default) — the AI client launches the server as a
-  subprocess; auth comes from the fact that only that client can
-  write to the pipe.
-- **`http`** (streamable-HTTP) — a long-lived HTTP service that
-  binds **only** to loopback and is gated by a Pre-Shared Key.
-  Production deployments terminate TLS at a reverse proxy on the same
-  host and forward to `127.0.0.1:<port>`; the server itself never
-  uses TLS.
-
-### PSK gating
-
-When started with `--transport http`, the server requires `server.json`
-(in the configuration directory) to declare a `psk` value. Use
-`"${env:NAME}"` templating inside the value if you want to source the
-secret from an environment variable. Every request must
-then carry the `X-Deephaven-PSK` HTTP header with that value. The
-middleware enforces this with a constant-time comparison
-(`hmac.compare_digest`); requests with a missing or mismatched header
-are rejected with HTTP `401`.
-
-```json5
-// $DH_MCP_DATA_DIR/config/server.json
-{
-  "psk": "${env:DH_MCP_PSK}"   // server reads $DH_MCP_PSK at startup
-}
-```
+> **See also: [`docs/SECURITY.md`](SECURITY.md)** for the project's security model, hardening checklist, and the inbound-auth specification — PSK gating, the `X-Deephaven-PSK` header, the 16-character minimum, the `401` body, the loopback trust boundary, and the TLS-terminating-reverse-proxy pattern. The notes below cover only the implementation details a contributor needs.
 
 ### Loopback-only enforcement
 
-The server validates `--host` at startup using
-[`socket.getaddrinfo`](https://docs.python.org/3/library/socket.html#socket.getaddrinfo)
-and refuses to bind to any address that is not exclusively loopback.
-Accepted values are `127.0.0.1`, `::1`, `localhost` (case-insensitive),
-and any hostname whose resolution yields only loopback addresses.
-Unresolvable hosts are also refused so the safe default is to fail
-closed.
-
-If you need to expose the server beyond loopback, terminate TLS at a
-reverse proxy on the same host:
-
-```nginx
-# nginx fragment (TLS terminating in front of the systems server)
-upstream deephaven_mcp { server 127.0.0.1:8000; }
-server {
-    listen 443 ssl http2;
-    ssl_certificate     /etc/ssl/certs/example.crt;
-    ssl_certificate_key /etc/ssl/private/example.key;
-    location /mcp {
-        proxy_pass         http://deephaven_mcp;
-        proxy_http_version 1.1;
-        proxy_set_header   X-Deephaven-PSK $http_x_deephaven_psk;
-    }
-}
-```
+The server validates `--host` at startup with [`socket.getaddrinfo`](https://docs.python.org/3/library/socket.html#socket.getaddrinfo) and refuses any address that is not exclusively loopback (`127.0.0.1`, `::1`, `localhost`, or a hostname resolving only to loopback). Unresolvable hosts are refused too, so the default is to fail closed.
 
 ### Health-check endpoint
 
-The systems server exposes a `/health` endpoint that returns `200 OK`
-with JSON body `{"status": "ok"}`. The endpoint is designed for
-liveness/readiness probes from load balancers and orchestrator agents
-(Kubernetes, Cloud Run, AWS ALB, etc.). `/health` is registered via
-`@server.custom_route("/health", methods=["GET"])` and is added to
-`PSKMiddleware`'s `bypass_paths`, so external probes do not need to
-share the PSK.
-
-The **docs server** (`dh-mcp-docs-server`) registers `/health` the
-same way and mounts no auth middleware at all, so the bypass is moot
-there.
-
-No other path is bypassed; in particular `/healthz` is **not** an
-alias and is rejected normally.
+`/health` returns `200` with body `{"status": "ok"}` for liveness/readiness probes. It is registered via `@server.custom_route("/health", methods=["GET"])` and added to `PSKMiddleware`'s `bypass_paths`, so probes need no PSK. The docs server registers `/health` the same way and mounts no auth middleware at all. No other path is bypassed — `/healthz` is **not** an alias and is rejected normally.
 
 ## MCP Server Implementations
 
-### Community Server
+### Systems Server
 
-> **Note:** This describes the community-side capabilities exposed by the unified `dh-mcp-systems-server`. There is no longer a separate Community server process — community sessions and enterprise systems are multiplexed inside the single systems server.
+`dh-mcp-systems-server` is one multiplexed process that hosts every configured Community session and Enterprise system. Its community and enterprise facets are described below, followed by cross-cutting concepts and dev tooling.
 
-#### Community Server Overview
+#### Community sessions
 
-The Deephaven MCP Community Server is an [MCP](https://github.com/modelcontextprotocol/spec)-compatible server (built with [FastMCP](https://github.com/modelcontextprotocol/python-sdk)) that provides tools for interacting with Deephaven Community Core instances.
+The community side of `dh-mcp-systems-server` provides tools for interacting with Deephaven Community Core instances, built on [FastMCP](https://github.com/modelcontextprotocol/python-sdk). Key architectural features:
 
-Key architectural features include:
+- **Session caching** — reuses [PyDeephaven](https://github.com/deephaven/deephaven-core/tree/main/py) connections where possible and manages session lifecycles.
+- **Concurrent-access safety** — [asyncio](https://docs.python.org/3/library/asyncio.html) locks guard session-management operations.
+- **Automatic cleanup** — sessions are terminated and cleaned up on server shutdown.
+- **On-demand creation** — worker sessions are created only when needed, then cached.
+- **Async-first** — built on asyncio for non-blocking, high-concurrency operation.
 
-- **Efficient Session Management**: Implements a sophisticated session caching system using [PyDeephaven](https://github.com/deephaven/deephaven-core/tree/main/py) that automatically reuses existing connections when possible and manages session lifecycles.
-- **Concurrent Access Safety**: Uses [asyncio](https://docs.python.org/3/library/asyncio.html) Lock mechanisms to ensure thread-safe operations during session management.
-- **Automatic Resource Cleanup**: Gracefully handles session termination and cleanup during server shutdown or reload operations.
-- **On-Demand Session Creation**: Sessions to worker nodes are created only when needed and cached for future use.
-- **Async-First Design**: Built around [asyncio](https://docs.python.org/3/library/asyncio.html) for high-concurrency performance and non-blocking operations.
-- **Configurable Session Behavior**: Supports worker configuration options such as `never_timeout` to control session persistence and lifecycle management.
+The on-disk configuration tree, every file's schema, the `${env:}` / `${file:}` templating engine, the environment variables, and the `auth.credentials` discriminated union are specified once in [`docs/CONFIGURATION.md`](CONFIGURATION.md) (and [`docs/ENV.md`](ENV.md) for process-level env vars). Copy-paste-ready samples live in [`config-samples/ai/config/`](../config-samples/ai/config/).
 
-##### Configuration Directory Tree
+#### Community session security and creation
 
-The multiplexed `dh-mcp-systems-server` reads a *directory tree* of small JSON5 files (not a single configuration file). The default location is `~/.deephaven/ai/config/` on POSIX or `%APPDATA%/Deephaven/ai/config/` on Windows; override with the `DH_MCP_DATA_DIR` env var or the `--config-dir` CLI flag.
+The optional `security.credential_retrieval_mode` knob in `community/settings.json` (enum `none` / `dynamic_only` / `static_only` / `all`, default `none`) controls whether the `session_community_credentials` tool may return plaintext session tokens. The enum, its default, and the security implications are owned by [`docs/CONFIGURATION.md`](CONFIGURATION.md#communitysettingsjson) and [`docs/SECURITY.md`](SECURITY.md#hardening-checklist); the eviction/timeout knobs live in the same CONFIGURATION.md section. The notes below cover only operational behavior not captured by the schema.
 
-> **Authoritative reference:** [`docs/CONFIGURATION.md`](CONFIGURATION.md) is
-> the single source of truth for the on-disk layout, every Pydantic schema,
-> the `${env:VAR}` / `${file:PATH}` templating engine, and the schema-level
-> defaults. The summary below is for quick orientation only — when prose here
-> disagrees with `CONFIGURATION.md`, `CONFIGURATION.md` wins.
+##### Dynamic session launch prerequisites
 
-Layout:
+`session_creation.defaults.launch_method` selects how new dynamic community sessions start:
 
-```text
-$DH_MCP_DATA_DIR/config/
-  server.json                       # optional; HTTP transport + PSK
-  community/
-    settings.json                   # optional; session-creation defaults, timeouts, security
-    sessions/
-      <name>.json                   # zero or more static community sessions
-  enterprise/
-    settings.json                   # optional; enterprise-wide timeouts
-    systems/
-      <name>.json                   # zero or more enterprise systems
-```
+- **`docker`** (default) — needs Docker installed and running (`docker ps`); no extra Python packages.
+- **`python`** — needs the `deephaven-server` package (`pip install deephaven-server`); verify with `deephaven server --help`. Point `python.venv_path` at a different venv, or leave it `null` to reuse the MCP server's own venv.
 
-Every file is JSON5 (comments and trailing commas allowed) and validated by Pydantic v2. Unknown fields are rejected. Filename stems are cross-checked against the `session_name` / `system_name` field inside each file. The directory permission audit (POSIX strict, Windows best-effort) runs before any file is parsed. There is **no** flat `deephaven_mcp.json` file and **no** `DH_MCP_CONFIG_FILE` env var — both were removed in the multi-section refactor.
+##### Retrieving session credentials
 
-**File Format**: The configuration file supports both standard JSON and JSON5 formats:
+When `credential_retrieval_mode` is not `none`, the `session_community_credentials` tool returns a community session's browser connection details, including a plaintext `auth_token`; every retrieval is logged. Run `dh-mcp tool show session_community_credentials` for the exact return shape.
 
-- Single-line comments: `// This is a comment`
-- Multi-line comments: `/* This is a multi-line comment */`
-- Trailing commas are also supported
-
-This allows you to add documentation directly in your configuration file to explain connection details, authentication choices, or other configuration decisions.
-
-###### Environment Variables
-
-The Community Server's behavior, particularly how it finds its configuration, can be controlled by the following environment variables:
-
-| Variable             | Required | Description                                                                                                                                                              | Where Used              |
-|----------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|
-| `DH_MCP_DATA_DIR`  | No       | Path to the user-data **root** under which both `config/` (configuration tree) and `runtime/` (daemon registry / lock / log) live. When unset, the platform default is used (`~/.deephaven/ai/` on POSIX, `%APPDATA%/Deephaven/ai/` on Windows). The `--config-dir` and `--runtime-dir` CLI flags target individual subdirectories and **bypass** this env var.<br><br>Example:<br>`export DH_MCP_DATA_DIR="/home/user/.deephaven/ai"`<br>`uv run dh-mcp-systems-server`                                                                                                                                          | Systems Server, Test Client |
-| (HTTP port)          | No       | Set the `port` field in `server.json` (default: `8000`). Only relevant under `--transport http`. Overridden by the `--port` CLI flag. There is no `DH_MCP_HTTP_PORT` env var; use `"port": "${env:NAME}"` for env-var indirection.                                    | Systems Server (optional)              |
-| `PYTHONLOGLEVEL`     | No       | Sets the Python logging level for the server (e.g., `DEBUG`, `INFO`, `WARNING`, `ERROR`).                                                                                    | Server (optional)       |
-
-> Environment variables must be set in the shell or process environment before starting the server; there is no built-in `.env` file support.
-
-For the complete list of environment variables (including timeout-tuning vars and credential indirection variables), see [`docs/ENV.md`](ENV.md).
-
-###### File Structure Overview
-
-The configuration is split across files in the directory tree shown above:
-
-- **`server.json`** (optional): Server-process tunables — `transport` (`"stdio"` / `"http"`), `host`, `port`, `psk`, `server_name`. The HTTP transport is gated by the PSK in this file.
-- **`community/settings.json`** (optional): Community-wide globals — `security.credential_retrieval_mode`, `session_creation.defaults`, and a `timeouts` umbrella block (`timeouts.client.*` for outbound community client calls; `timeouts.eviction.*` for the MCP-side idle-session sweeper).
-- **`community/sessions/<name>.json`** (zero or more): One static community session per file. Each file declares `session_name` (must equal the filename stem), `host`, `port`, `programming_language`, an optional `tls` block, and an `auth.credentials` discriminated-union block.
-- **`enterprise/settings.json`** (optional): Enterprise-wide `timeouts` umbrella block (`timeouts.client.*` consumed by the enterprise client layer; `timeouts.eviction.*` consumed by the MCP-side idle-session sweeper, applied uniformly to every system) plus a `pq_tools` block holding the persistent-query tool defaults.
-- **`enterprise/systems/<name>.json`** (zero or more): One enterprise system per file. Each file declares `system_name` (filename stem match), `connection_json_url`, `auth.credentials`, optional `session_creation`, and per-system timer overrides.
-
-Authentication credentials live exclusively under `auth.credentials` as a discriminated union (`type`: `anonymous`, `psk`, `password`, `private_key`, `custom`). The legacy flat fields (`auth_type`, `auth_token`, `auth_token_env_var`, `client_private_key`, `tls_root_certs` paths, etc.) are gone. Authors who want to pull a value from an environment variable or file write `"${env:NAME}"` / `"${file:/path}"` directly inside the JSON value.
-
-For the **complete schema** — every field, every default, every example — see [`docs/CONFIGURATION.md`](CONFIGURATION.md). For ready-to-edit example files, see [`config-samples/ai/config/`](../config-samples/ai/config/).
-
-#### Systems Sessions Configuration
-
-This section formerly mirrored the per-session schema for community sessions. The schema is now authoritative in [`docs/CONFIGURATION.md`](CONFIGURATION.md#per-session-community-files); a sample file lives at [`config-samples/ai/config/community/sessions/local_dev.json`](../config-samples/ai/config/community/sessions/local_dev.json). Quick orientation only — the per-file shape is:
-
-```json5
-{
-  "session_name": "local_dev",
-  "host": "localhost",
-  "port": 10000,
-  "programming_language": "Python",
-  "auth": {
-    "credentials": {
-      "type": "psk",
-      "token": "${env:DH_LOCAL_DEV_PSK}"
-    }
-  }
-}
-```
-
-Optional blocks include `tls` (server-trust bundle + optional mTLS client cert) and the various credentials types under `auth.credentials.type`.
-
-### Security Configuration
-
-The optional `security` block in `community/settings.json` controls security-sensitive behavior for community sessions. It is the single place where the operator opts into (or out of) credential exposure to MCP tools, so security decisions are explicit and easy to audit.
-
-#### Community Session Credential Retrieval
-
-The `session_community_credentials` MCP tool allows programmatic retrieval of authentication credentials for community sessions. This is **disabled by default** for security.
-
-**Configuration:** `security.credential_retrieval_mode`
-
-Controls which community session credentials can be retrieved via the MCP tool. This setting applies to:
-
-- **Static sessions**: Pre-configured in `sessions`
-- **Dynamic sessions**: Created on-demand via `session_community_create`
-
-**Valid modes:**
-
-- **`"none"`** (default): Credential retrieval disabled for all sessions
-  - Most secure option
-  - Tool returns error with instructions to enable
-  
-- **`"dynamic_only"`**: Only auto-generated tokens (dynamic sessions)
-  - Allows retrieval for sessions created via `session_community_create`
-  - Denies retrieval for pre-configured static sessions
-  - **Recommended**: Users typically need dynamic tokens but already have static credentials
-  
-- **`"static_only"`**: Only pre-configured tokens (static sessions)
-  - Allows retrieval for sessions from `sessions`
-  - Denies retrieval for dynamically created sessions
-  - **Rare use case**: Static credentials are already in your config file
-  
-- **`"all"`**: Both dynamic and static session credentials
-  - Maximum convenience, minimum security
-  - Only enable if you fully understand the security implications
-
-**Security Considerations:**
-
-- Credentials are returned in plain text
-- All retrieval attempts are logged for audit
-- Consider: Do AI agents really need access to credentials you already have?
-- Recommendation: Use `"dynamic_only"` if needed, `"none"` otherwise
-
-**Example `community/settings.json`:**
-
-```json5
-{
-  "security": {
-    "credential_retrieval_mode": "dynamic_only"
-  },
-  "session_creation": {
-    "max_concurrent_sessions": 5,
-    "defaults": {
-      "launch_method": "docker",
-      "auth": {
-        "credentials": { "type": "psk", "token": "${env:DH_DYNAMIC_SESSION_TOKEN}" }
-      },
-      "heap_size_gb": 4
-    }
-  },
-  "timeouts": {
-    "eviction": {
-      "session_idle_timeout_seconds": 3600.0,
-      "sweep_interval_seconds": 60.0
-    }
-  }
-}
-```
-
-Static community sessions live in their own files under `community/sessions/`; the server-process PSK that gates inbound HTTP requests lives in `server.json`.
-
-**Per-Section Settings:**
-
-Duration knobs live under `timeouts.eviction.*` (community and enterprise share the same shape):
-
-- `timeouts.eviction.session_idle_timeout_seconds` (float, **optional, default: 3600.0**): Seconds of Deephaven-session inactivity after which idle sessions in the registry are closed; static sessions are kept and lazily reconnected, dynamic sessions are removed. Must be positive.
-- `timeouts.eviction.sweep_interval_seconds` (float, **optional, default: 60.0**): How often the per-registry idle sweeper wakes (seconds). Must be positive.
-
-#### Community Session Creation Configuration
-
-Dynamic community sessions are configured under the `session_creation`
-block of `community/settings.json`. The full schema (every field, every
-default, the `auth.credentials` discriminated union) lives in
-[`docs/CONFIGURATION.md`](CONFIGURATION.md#community-settingsjson) and
-is the authoritative reference; the bullets below cover only the
-operational notes that are not part of the schema itself.
-
-**Launch Method Requirements:**
-
-The `launch_method` field on `session_creation.defaults` selects how
-new dynamic sessions start.
-
-- **`"docker"`** (default):
-  - Requires [Docker](https://www.docker.com/get-started/) installed and running on the host.
-  - Works with the base `deephaven-mcp` installation; no extra Python packages.
-  - Verify with `docker ps`.
-
-- **`"python"`**:
-  - Requires the `deephaven-server` Python package: `pip install deephaven-server`.
-  - Use the optional `python.venv_path` field to point at a different venv; `null` (default) reuses the MCP server's own venv.
-  - Verify with `deephaven server --help`.
-
-> **💡 Tip**: For development environments, the python method is often faster and simpler. For production or isolated environments, the docker method provides better consistency and isolation.
-
-**MCP Tool: `session_community_credentials`**
-
-When `credential_retrieval_mode` is set to a value other than `"none"` (the default), this tool retrieves connection credentials for both static and dynamic Community sessions.
-
-**Arguments:**
-
-- `session_id` (string): Full session ID — `"community:community:session-name"` for both static and dynamic community sessions. The static-vs-dynamic distinction lives on the manager's `origin` field, not in the id.
-
-**Returns:**
-
-- `connection_url` (string): Base URL without authentication
-- `connection_url_with_auth` (string): Full URL with auth token for browser
-- `auth_token` (string): Raw authentication token
-- `auth_type` (string): Authentication type (e.g., `"io.deephaven.authentication.psk.PskAuthenticationHandler"`, `"Anonymous"`)
-
-**Example Usage (via AI agent):**
-
-```text
-User: "Get me the browser URL for my-analysis session"
-AI: [calls session_community_credentials with session_id="community:community:my-analysis"]
-AI: "Here's your browser URL: http://localhost:45123/?psk=abc123..."
-
-User: "What's the URL for my static local-dev session?"
-AI: [calls session_community_credentials with session_id="community:community:local-dev"]
-AI: "Here's the URL: http://localhost:10000/?psk=your-token"
-```
-
-**Security Notes:**
-
-- All credential retrievals are logged for audit
-- Credentials are returned in plain text
-- Only use for legitimate browser access needs
-- Consider security implications before enabling
-
-**Alternative: Console Logging**
-
-If `credential_retrieval_mode` is `"none"` (default), credentials are still accessible via console output. When a session is created with an auto-generated token, connection information is logged:
+When the mode is `none`, those details are still printed to the server console when a dynamic session is created (similar to how Jupyter prints a notebook token):
 
 ```text
 ======================================================================
@@ -809,152 +278,29 @@ If `credential_retrieval_mode` is `"none"` (default), credentials are still acce
    Base URL: http://localhost:45123
    Auth Token: abc123xyz789...
    Browser URL: http://localhost:45123/?psk=abc123xyz789
-
-   To retrieve credentials via MCP tool, set security.credential_retrieval_mode
-   in your `community/settings.json` configuration.
 ======================================================================
 ```
 
-This is similar to how Jupyter displays tokens when starting a notebook server.
+#### Enterprise systems
 
-**Example `community/settings.json`:**
+Each Enterprise system is one file at `$DH_MCP_DATA_DIR/config/enterprise/systems/<system_name>.json` (filename stem == `system_name`); the single `dh-mcp-systems-server` hosts every file it finds, and tools that target a system take a `system` argument. The per-system schema (credential kinds, `session_creation.defaults`) is owned by [`docs/CONFIGURATION.md`](CONFIGURATION.md#enterprisesystemsnamejson); the startup-load credential model, redaction, PSK/loopback posture, and the permission audit are owned by [`docs/SECURITY.md`](SECURITY.md#authentication).
 
-```json5
-{
-  "security": {
-    "credential_retrieval_mode": "dynamic_only"
-  },
-  "session_creation": {
-    "max_concurrent_sessions": 5,
-    "defaults": {
-      "launch_method": "docker",
-      "auth": {
-        "credentials": { "type": "psk", "token": "${env:DH_DYNAMIC_SESSION_TOKEN}" }
-      },
-      "heap_size_gb": 4,
-      "extra_jvm_args": ["-XX:+UseG1GC"],
-      "docker_image": "ghcr.io/deephaven/server:latest",
-      "docker_memory_limit_gb": 8.0
-    }
-  }
-}
-```
+##### Enterprise session registry internals
 
-#### Enterprise Server Configuration
+Credentials are read once at startup from each system's `auth.credentials` block and reused for the process lifetime — there is no per-request resolution. The two enterprise credential kinds map to session-factory calls:
 
-> **Note:** This describes the enterprise-side capabilities exposed by the unified `dh-mcp-systems-server`. There is no longer a separate Enterprise server process — community sessions and enterprise systems are multiplexed inside the single systems server.
+- `password` → `SessionManager.password(username, password)`.
+- `private_key` → `SessionManager.private_key(key_text)` (PEM text, typically loaded via `${file:/path/to/key.pem}`).
 
-Each Enterprise system gets one file under
-`$DH_MCP_DATA_DIR/config/enterprise/systems/<system_name>.json`. The
-filename stem must equal the `system_name` field. The single
-multiplexed `dh-mcp-systems-server` hosts every file it finds.
+At startup each validated `EnterpriseSystemConfig` drives an `EnterpriseSessionRegistry`, which builds a `CorePlusSessionFactoryManager` and starts its discovery task. Credentials are never refreshed at runtime (restart to rotate) and never written to disk.
 
-The full per-system schema (every required field, every optional
-block, the `auth.credentials` discriminated-union shape, and the
-`session_creation.defaults` block consumed by
-`session_enterprise_create`) lives in
-[`docs/CONFIGURATION.md`](CONFIGURATION.md#enterprisesystemsnamejson)
-and is the authoritative reference. The notes below cover only what
-is specific to operational use.
-
-> **Server-stored credentials.** The systems server reads the
-> credentials needed to talk to each Core+ controller from each
-> per-system `auth.credentials` block (one of `type=password`,
-> `type=private_key`) at startup. No per-request `X-Deephaven-*`
-> credential headers are involved — HTTP-transport requests are
-> gated by the single PSK in `server.json`.
-
-**Example `enterprise/systems/prod.json`:**
-
-```json5
-// $DH_MCP_DATA_DIR/config/enterprise/systems/prod.json
-{
-  "system_name": "prod",
-  "connection_json_url": "https://enterprise.example.com/iris/connection.json",
-  "auth": {
-    "credentials": {
-      "type": "password",
-      "username": "iris",
-      "password": "${env:DH_PROD_PASSWORD}"
-    }
-  },
-  "session_creation": {
-    "max_concurrent_sessions": 5,
-    "defaults": {
-      "heap_size_gb": 4.0,
-      "programming_language": "Python",
-      "auto_delete_timeout": 1800
-    }
-  }
-}
-```
-
-Drop one file per system into `enterprise/systems/` and the single
-`dh-mcp-systems-server` instance will host all of them; tools that
-operate on a specific system take a `system` argument that selects
-the right per-system registry.
-
-##### Enterprise Auth Model
-
-The systems server holds a single set of credentials per Enterprise
-system (built once at startup from each
-`enterprise/systems/<system>.json` file's `auth.credentials` block)
-and reuses it for the lifetime of the process. There is no
-per-request credential resolution, no `X-Deephaven-*` credential
-headers, and no middleware-driven exchange.
-
-**Supported credential kinds** (set `auth.credentials.type` per system):
-
-- `"password"` — builds a `PasswordCredentials` from `username`
-  plus `password` (with `${env:NAME}` templating recommended for the
-  password value rather than inlining it). At session-creation time
-  the session factory authenticates with
-  `SessionManager.password(username, password)`.
-- `"private_key"` — builds a `PrivateKeyCredentials` from `key_text`
-  (typically `"${file:/path/to/key.pem}"` so the templating engine
-  reads the PEM contents at config-load time). The session factory
-  authenticates with `SessionManager.private_key(key_text)`.
-
-The `anonymous`, `psk`, and `custom` kinds are community-only and
-are rejected on enterprise systems.
-
-**Credential lifecycle:**
-
-- Credentials are validated and embedded into the per-system
-  `EnterpriseSystemConfig` at startup; the corresponding
-  `EnterpriseSessionRegistry` uses them to build its
-  `CorePlusSessionFactoryManager` and start its discovery task.
-- Credentials are not refreshed at runtime. To pick up an updated
-  `${env:NAME}` value or rotate a private-key file, restart the
-  systems server.
-- The server never writes credentials to disk; in-memory copies live
-  only inside the per-system factory manager and are cleared when
-  the server shuts down. All `SecretStr` fields redact under
-  `model_dump(context={"redact": True})` and in `repr`.
-
-**Security Considerations:**
-
-- HTTP-transport requests are gated by the systems server's PSK
-  (`X-Deephaven-PSK`) and bind only to loopback. Production deployments
-  terminate TLS at a reverse proxy on the same host — see
-  [HTTP Transport Security](#http-transport-security).
-- Per-system files contain credentials (or the names of env vars or
-  files that hold them). Lock down `$DH_MCP_DATA_DIR/config` with
-  `chmod 700` and per-file `chmod 600`; the startup permission audit
-  fails fast otherwise.
-
-**File Paths:**
-
-Ensure any file paths referenced via `${file:...}` (private-key
-files, TLS PEM bundles) are absolute and readable by the user
-running the systems server.
-
-#### Running the Systems Server
+#### Running the systems server
 
 A single `dh-mcp-systems-server` process hosts every configured
-Community session and Enterprise system. Choose your transport:
+Community session and Enterprise system. Its transport, bind address,
+port, and config/runtime directories are set by the CLI arguments below.
 
-##### Systems Server CLI Arguments
+##### CLI arguments
 
 | Argument | Description | Default |
 |----------|-------------|---------|
@@ -990,18 +336,20 @@ on every request.
 To stop the server: `pkill -f dh-mcp-systems-server` or
 `kill $(lsof -ti tcp:8000)`.
 
-#### Using the Systems Server
+#### Using the systems server
 
 Once running, you can interact with the Systems Server in several ways:
 
-- Connect using [MCP Inspector](#mcp-inspector-with-community-server)
+- Connect using [MCP Inspector](#mcp-inspector)
 - Use with [Claude Desktop](#claude-desktop) (stdio is simplest; HTTP via `mcp-proxy` is also supported)
-- Run the [Community Server Test Client](#community-server-test-client) script
+- Run the [smoke-test client](#smoke-test-client) script
 - Build your own MCP client application
 
-#### Session ID Format and Terminology
+### Concepts and conventions
 
-The Community Server uses a consistent session identifier format across all MCP tools:
+#### Session ID format and terminology
+
+The systems server uses a consistent session identifier format across all MCP tools:
 
 **Session ID Format**: `{type}:{source}:{session_name}`
 
@@ -1011,7 +359,7 @@ Where:
 - `source`: For community sessions, always the literal `"community"` (the umbrella system name; the static-vs-dynamic distinction lives on the manager's `origin` field, not in the id). For enterprise sessions, the server's configured `system_name` (e.g. `"prod"`, `"staging"`).
 - `session_name`: The specific session name within that source
 
-For enterprise sessions, `source` equals the server's configured `system_name`, which is embedded in the session ID to support multiple enterprise servers running simultaneously without ID collisions. Each enterprise server validates that the `system_name` component of an incoming session ID matches its own, providing clear errors when a session ID from one server is accidentally sent to another.
+For enterprise sessions, `source` equals the server's configured `system_name`, Embedding it in the session ID lets the one multiplexed server host multiple enterprise systems without ID collisions; a tool call validates that the `system_name` component names a configured system and errors clearly otherwise.
 
 **Examples**:
 
@@ -1027,1375 +375,60 @@ For enterprise sessions, `source` equals the server's configured `system_name`, 
 
 All MCP tools that interact with Deephaven instances use the `session_id` parameter with this format, replacing the older `session_name` parameter from previous versions.
 
-#### Community Server Tools
+#### Response envelope
 
-> **Note:** This describes the community-side tools exposed by the unified `dh-mcp-systems-server`.
+Every systems-server tool returns a consistent response shape:
 
-The Community Server exposes the following MCP tools, each designed for a specific aspect of Deephaven worker management:
+- Success: `{ "success": true, ... }` plus tool-specific fields.
+- Error: `{ "success": false, "error": "<human-readable description>", "isError": true }`
 
-All Community Server tools return responses with a consistent format:
+This keeps response parsing and error handling uniform across all tools.
 
-- Success: `{ "success": true, ... }` with additional fields depending on the tool
-- Error: `{ "success": false, "error": "Error description", "isError": true }`
+#### Tool reference
 
-#### Error Handling
+This guide deliberately does **not** maintain a per-tool reference. Each
+tool's source docstring is the single source of truth — it is also exactly
+what an AI agent receives over MCP and what the CLI surfaces live, so it
+cannot drift from the installed code:
 
-All Community Server tools use a consistent error response format when encountering problems:
+- **Capability list** — the one-line-per-tool overview lives in
+  *Available MCP Tools* in the [README](../README.md#available-mcp-tools).
+- **Authoritative detail** — each tool's docstring (Args, Returns,
+  terminology notes, examples) under
+  [`src/deephaven_mcp/mcp_systems_server/_tools/`](../src/deephaven_mcp/mcp_systems_server/_tools/):
+  `session.py`, `session_community.py`, `session_enterprise.py`, `pq.py`,
+  `catalog.py`, `table.py`, and `script.py`.
+- **Live discovery** — `dh-mcp tool list` enumerates registered tools and
+  `dh-mcp tool show <name>` prints one tool's description and JSON input
+  schema for the version you actually have installed (see
+  [`docs/CLI.md`](CLI.md)).
 
-```json
-{
-  "success": false,
-  "error": "Human-readable error description",
-  "isError": true
-}
-```
+#### Persistent Query (PQ) concepts
 
-This consistent format makes error handling and response parsing more predictable across all tools.
+Persistent Queries (PQs) are recipes for creating and managing long-running
+worker sessions in Deephaven Enterprise. Unlike the ephemeral sessions
+created via `session_enterprise_create`, PQs can run on schedules, restart
+automatically on failure, and persist across server restarts.
 
-#### MCP Tools
+**Key concepts:**
 
-The two MCP servers together provide the following tools. Each tool is available on the **Community Server**, the **Enterprise Server**, or **both**:
+- **PQ definition** — a configuration specifying how to create a worker session (heap size, JVM args, schedule, and so on).
+- **PQ serial** — the immutable unique identifier for a PQ; prefer it for all operations. A fully qualified `pq_id` has the form `<system>:<serial>`.
+- **PQ name** — a human-readable label that can change, so it is less reliable than the serial. `pq_name_to_id` resolves a name to its canonical `pq_id`.
+- **Status categories** — PQ tools report a `status_category` of `ACTIVE`, `TRANSITIONAL`, `TERMINAL`, or `INVALID` alongside the raw `status`. Branch on the category, never on a specific raw status string (test `status_category == "ACTIVE"`, not `status == "RUNNING"`); the raw vocabulary is large and evolves.
+- **Session integration** — a running PQ exposes a session reachable through the standard session tools via the `session_id` form `enterprise:<system>:<pq_name>` (present only while the PQ is running or initializing).
 
-**Quick Reference:**
+**Typical workflows:**
 
-| Tool | Category | Purpose | Server |
-|------|----------|---------|--------|
-| [`list_systems`](#list_systems) | System | List every configured Community session and Enterprise system | Both |
-| [`enterprise_systems_status`](#enterprise_systems_status) | System | Check status of an enterprise system | Enterprise |
-| [`sessions_list`](#sessions_list) | Session Management | List all active sessions | Both |
-| [`session_details`](#session_details) | Session Management | Get detailed session information | Both |
-| [`session_community_create`](#session_community_create) | Session Management | Create new community session | Community |
-| [`session_community_delete`](#session_community_delete) | Session Management | Delete community session | Community |
-| [`session_community_credentials`](#session_community_credentials) | Session Management | Get community session credentials | Community |
-| [`session_enterprise_create`](#session_enterprise_create) | Session Management | Create new enterprise session | Enterprise |
-| [`session_enterprise_delete`](#session_enterprise_delete) | Session Management | Delete enterprise session | Enterprise |
-| [`pq_name_to_id`](#pq_name_to_id) | PQ Management | Convert PQ name to canonical pq_id | Enterprise |
-| [`pq_list`](#pq_list) | PQ Management | List all persistent queries | Enterprise |
-| [`pq_details`](#pq_details) | PQ Management | Get detailed PQ information | Enterprise |
-| [`pq_create`](#pq_create) | PQ Management | Create a new persistent query | Enterprise |
-| [`pq_delete`](#pq_delete) | PQ Management | Delete one or more persistent queries | Enterprise |
-| [`pq_modify`](#pq_modify) | PQ Management | Modify a persistent query configuration | Enterprise |
-| [`pq_start`](#pq_start) | PQ Management | Start one or more persistent queries | Enterprise |
-| [`pq_stop`](#pq_stop) | PQ Management | Stop one or more persistent queries | Enterprise |
-| [`pq_restart`](#pq_restart) | PQ Management | Restart one or more persistent queries | Enterprise |
-| [`catalog_tables_list`](#catalog_tables_list) | Catalog Tools | List catalog table entries | Enterprise |
-| [`catalog_namespaces_list`](#catalog_namespaces_list) | Catalog Tools | List catalog namespaces | Enterprise |
-| [`catalog_tables_schema`](#catalog_tables_schema) | Catalog Tools | Get catalog table schemas | Enterprise |
-| [`catalog_table_sample`](#catalog_table_sample) | Catalog Tools | Sample catalog table data | Enterprise |
-| [`session_tables_schema`](#session_tables_schema) | Data Tools | Get table schemas from session | Both |
-| [`session_tables_list`](#session_tables_list) | Data Tools | List table names in session | Both |
-| [`session_table_data`](#session_table_data) | Data Tools | Retrieve table data | Both |
-| [`session_script_run`](#session_script_run) | Data Tools | Execute Python script | Both |
-| [`session_pip_list`](#session_pip_list) | Data Tools | List installed pip packages | Both |
+1. **Create and start a PQ:** `pq_create` → `pq_start` → use the returned `session_id` with the session tools.
+2. **Manage an existing PQ:** `pq_list` → `pq_details` → `pq_stop` → `pq_restart`.
+3. **Query a running PQ's data:** `pq_details` → read its `session_id` → `session_tables_list` → `session_table_data`.
 
----
+### Test components
 
-### System Tools
+#### Test server
 
-#### `list_systems`
-
-**Purpose**: List every Deephaven system the systems server is
-configured to serve.
-
-**Parameters**: None
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "systems": [
-    { "name": "community", "type": "community" },
-    { "name": "prod",      "type": "enterprise" },
-    { "name": "staging",   "type": "enterprise" }
-  ]
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "isError": true
-}
-```
-
-**Description**: Returns a discovery list of every Community session
-and Enterprise system the multiplexed `dh-mcp-systems-server` was
-configured with at startup. The umbrella Community side (when
-`community/sessions/` is non-empty) appears as a single
-`("community", "community")` entry; each file under
-`enterprise/systems/` becomes one `(<name>, "enterprise")` entry.
-Useful for AI agents to discover which `system` arguments are valid
-for enterprise-targeted tools.
-
-> **Note:** The previous `mcp_reload` tool has been removed.
-> Configuration changes require a server restart.
-
-#### `enterprise_systems_status`
-
-**Purpose**: Get status of the configured enterprise (Core+) system with its status and configuration details (redacted).
-
-**Parameters**:
-
-- `attempt_to_connect` (optional, boolean): If True, actively attempts to connect to the system to verify its status. Default is False (only checks existing connections for faster response).
-
-**Returns**:
-
-```json5
-{
-  "success": true,
-  "systems": [
-    {
-      "name": "prod",
-      "liveness_status": "ONLINE",
-      "liveness_detail": "System is healthy and ready for operational use",
-      "is_alive": true,
-      "config": {
-        "system_name": "prod",
-        "connection_json_url": "https://enterprise.example.com/iris/connection.json",
-        "auth": {
-          "type": "password",
-          "username": "iris",
-          "password": "[REDACTED]"
-        }
-      }
-    }
-  ]
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "isError": true
-}
-```
-
-**Description**: This tool provides status information about the configured enterprise system. Status values include "ONLINE", "OFFLINE", "UNAUTHORIZED", "MISCONFIGURED", or "UNKNOWN". Sensitive configuration fields are redacted for security.
-
-#### Enterprise Session Tools
-
-> **Note:** This describes the enterprise-side tools exposed by the unified `dh-mcp-systems-server`.
-
-##### `session_enterprise_create`
-
-**Purpose**: Create a new enterprise session on the configured enterprise system.
-
-**Parameters**:
-
-- `session_name` (optional, string): Custom name for the session. If not provided, an auto-generated name will be used
-- `heap_size_gb` (optional, float | int): JVM heap size in gigabytes for the session (e.g., 4 or 2.5). Enterprise library handles conversion internally
-- `programming_language` (optional, string): Programming language for the session ("Python" or "Groovy")
-- `auto_delete_timeout` (optional, integer): Auto-deletion timeout in seconds for idle sessions
-- `server` (optional, string): Target server/environment name where the session will be created
-- `engine` (optional, string): Engine type for the session (e.g., "DeephavenCommunity")
-- `extra_jvm_args` (optional, array): Additional JVM arguments for the session
-- `extra_environment_vars` (optional, array): Environment variables for the session in format ["NAME=value"]
-- `admin_groups` (optional, array): User groups with administrative permissions for the session
-- `viewer_groups` (optional, array): User groups with read-only access to the session
-- `timeout_seconds` (optional, float): Session startup timeout in seconds
-- `session_arguments` (optional, object): Additional arguments for pydeephaven.Session constructor
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "session_id": "enterprise:prod:analytics-worker-001",
-  "system_name": "prod",
-  "session_name": "analytics-worker-001",
-  "configuration": {
-    "heap_size_gb": null,
-    "auto_delete_timeout": null,
-    "server": null,
-    "engine": "DeephavenCommunity"
-  }
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "isError": true
-}
-```
-
-**Description**: This tool creates a new enterprise session on the configured enterprise system and registers it in the shared registry for future use. The session is configured with either provided parameters or defaults from the enterprise system configuration. Parameter resolution follows the priority: tool parameter → config default → API default.
-
-##### `session_enterprise_delete`
-
-**Purpose**: Delete an enterprise session by terminating it and removing it from the shared session registry.
-
-**Parameters**:
-
-- `session_id` (required, string): Full session identifier in format `"enterprise:{system_name}:{session_name}"`. The server validates that the `system_name` component matches its own configured system name; a mismatch returns a clear error rather than "not found".
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "session_id": "enterprise:prod:analytics-worker-001",
-  "system_name": "prod",
-  "session_name": "analytics-worker-001"
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "isError": true
-}
-```
-
-Cross-server error:
-
-```json
-{
-  "success": false,
-  "error": "Session 'enterprise:dev:session-1' belongs to system 'dev', but this server manages 'prod'",
-  "isError": true
-}
-```
-
-**Description**: This tool permanently terminates an enterprise session and removes it from the shared session registry (visible to every connected MCP client). The session cannot be recovered after deletion. Use with caution as any unsaved work in the session will be lost.
-
-#### Persistent Query (PQ) Management Tools
-
-Persistent Queries (PQs) are recipes for creating and managing long-running worker sessions in Deephaven Enterprise. Unlike ephemeral sessions created via `session_enterprise_create`, PQs can be configured to run on schedules, restart automatically on failure, and persist across server restarts.
-
-**Key Concepts:**
-
-- **PQ Definition**: A configuration specifying how to create a worker session (heap size, JVM args, schedule, etc.)
-- **PQ Serial**: Immutable unique identifier for a PQ (recommended for all operations)
-- **PQ Name**: Human-readable name (can change, less reliable than serial)
-- **PQ States**: UNINITIALIZED, RUNNING, STOPPED, FAILED, COMPLETED, etc.
-- **Session Integration**: Running PQs create sessions accessible via standard session tools using `session_id` format `enterprise:system:{pq_name}`
-
-##### `pq_name_to_id`
-
-**Purpose**: Convert a PQ name to its canonical pq_id format.
-
-**Parameters**:
-
-- `pq_name` (required, string): Name of the persistent query
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "pq_id": "enterprise:system:12345",
-  "serial": 12345,
-  "name": "analytics_worker",
-  "system_name": "system"
-}
-```
-
-**Description**: Helper tool to look up a PQ by name and return its pq_id in the canonical format `enterprise:{system_name}:{serial}`. Use this when you know the PQ name but need the pq_id for other PQ operations. The tool performs a network lookup to find the serial number. Returns an error if the PQ doesn't exist.
-
-##### `pq_list`
-
-**Purpose**: List all persistent queries on the configured enterprise system.
-
-**Parameters**: None
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "system_name": "system",
-  "pqs": [
-    {
-      "pq_id": "enterprise:system:12345",
-      "serial": 12345,
-      "name": "analytics_worker",
-      "status": "RUNNING",
-      "enabled": true,
-      "owner": "admin_user",
-      "heap_size_gb": 8.0,
-      "worker_kind": "DeephavenCommunity",
-      "configuration_type": "Script",
-      "script_language": "Python",
-      "server_name": "QueryServer_1",
-      "admin_groups": ["admins"],
-      "viewer_groups": ["analysts"],
-      "is_scheduled": true,
-      "num_failures": 0,
-      "session_id": "enterprise:system:analytics_worker"
-    }
-  ]
-}
-```
-
-**Description**: Returns a list of all PQs with comprehensive metadata. The `status` field indicates the current state (RUNNING, STOPPED, INITIALIZING, FAILED, etc.). Running or initializing PQs include a `session_id` field that can be used with session data tools. Filter results by status, owner, worker_kind, configuration_type, or script_language.
-
-##### `pq_details`
-
-**Purpose**: Get detailed information about a specific persistent query.
-
-**Parameters**:
-
-- `pq_id` (required, string): PQ identifier in format `"enterprise:{system_name}:{serial}"`
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "pq_id": "enterprise:prod:12345",
-  "serial": 12345,
-  "name": "analytics_worker",
-  "state": "RUNNING",
-  "session_id": "enterprise:prod:analytics_worker",
-  "config": {
-    "heap_size_gb": 8.0,
-    "engine": "DeephavenCommunity",
-    "script_language": "Python"
-  },
-  "state_details": {
-    "connection_details": {
-      "processor_host": "worker-01.example.com"
-    }
-  },
-  "replicas": [],
-  "spares": []
-}
-```
-
-**Description**: Returns comprehensive PQ details including configuration, state, and worker connection information. Worker host/port are in the `state_details.connection_details` subobject. Use the `session_id` with session tools to interact with the running PQ session.
-
-##### `pq_create`
-
-**Purpose**: Create a new persistent query.
-
-**Parameters**:
-
-- `pq_name` (required, string): Human-readable name for the PQ
-- `heap_size_gb` (required, float | int): JVM heap size in GB
-- `script_body` (optional, string): Inline script code (mutually exclusive with script_path)
-- `script_path` (optional, string): Path to script in Git repository (mutually exclusive with script_body)
-- `programming_language` (optional, string): "Python" or "Groovy" (default: "Python")
-- `configuration_type` (optional, string): "Script" or "RunAndDone" (default: "Script")
-- `enabled` (optional, bool): Whether PQ is enabled (default: true)
-- `schedule` (optional, list[string]): Scheduling configuration as ["Key=Value", ...]
-- `server` (optional, string): Specific server to run on
-- `engine` (optional, string): Worker engine type (default: "DeephavenCommunity")
-- `jvm_profile` (optional, string): JVM profile name
-- `extra_jvm_args` (optional, list[string]): Additional JVM arguments
-- `extra_class_path` (optional, list[string]): Additional classpath entries
-- `python_virtual_environment` (optional, string): Python virtual environment name
-- `extra_environment_vars` (optional, list[string]): Environment variables as ["KEY=value", ...]
-- `init_timeout_nanos` (optional, int): Initialization timeout in nanoseconds
-- `auto_delete_timeout` (optional, int): Seconds of inactivity before auto-deletion (default: None - permanent PQ)
-- `admin_groups` (optional, list[string]): Groups with admin access
-- `viewer_groups` (optional, list[string]): Groups with viewer access
-- `restart_users` (optional, string): Restart permission policy (default: None)
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "pq_id": "enterprise:prod:12345",
-  "serial": 12345,
-  "name": "analytics_worker",
-  "state": "UNINITIALIZED",
-  "message": "PQ 'analytics_worker' created successfully with serial 12345"
-}
-```
-
-**Description**: Creates a new PQ in UNINITIALIZED state. Use `pq_start` to run it.
-
-##### `pq_delete`
-
-**Purpose**: Permanently delete one or more persistent queries (best-effort batch operation).
-
-**Parameters**:
-
-- `pq_id` (required, string | list[string]): PQ identifier or list of identifiers in format `"enterprise:{system_name}:{serial}"`
-- `timeout_seconds` (optional, int): Max seconds to retrieve PQ information (default: 10)
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "results": [
-    {
-      "pq_id": "enterprise:prod:12345",
-      "serial": 12345,
-      "success": true,
-      "name": "analytics_worker",
-      "error": null
-    },
-    {
-      "pq_id": "enterprise:prod:67890",
-      "serial": 67890,
-      "success": false,
-      "name": null,
-      "error": "PQ not found"
-    }
-  ],
-  "summary": {
-    "total": 2,
-    "succeeded": 1,
-    "failed": 1
-  },
-  "message": "Deleted 1 of 2 PQ(s), 1 failed"
-}
-```
-
-**Description**: Permanently removes PQs and all associated data. Operates in **best-effort mode**: processes each PQ independently, continuing even if some deletions fail. All PQ IDs must be from the same enterprise system. Use `pq_name_to_id` if you only have PQ names. If running, it will be stopped first. This operation cannot be undone.
-
-##### `pq_modify`
-
-**Purpose**: Modify an existing persistent query configuration.
-
-**Parameters**:
-
-- `pq_id` (required, string): PQ identifier in format `"enterprise:{system_name}:{serial}"`
-- `restart` (optional, bool): Restart PQ after modification to apply changes (default: false)
-- `pq_name` (optional, string): New name for the PQ
-- `heap_size_gb` (optional, float | int): JVM heap size in GB
-- `script_body` (optional, string): Inline script code (mutually exclusive with script_path)
-- `script_path` (optional, string): Path to script file (mutually exclusive with script_body)
-- `programming_language` (optional, string): "Python" or "Groovy"
-- `configuration_type` (optional, string): Query type ("Script", "RunAndDone", etc.)
-- `enabled` (optional, bool): Whether query is enabled
-- `schedule` (optional, list[string]): Scheduling configuration
-- `server` (optional, string): Specific server to run on
-- `engine` (optional, string): Engine type (e.g., "DeephavenCommunity")
-- `jvm_profile` (optional, string): Named JVM profile
-- `extra_jvm_args` (optional, list[string]): Additional JVM arguments
-- `extra_class_path` (optional, list[string]): Additional classpath entries
-- `python_virtual_environment` (optional, string): Named Python virtual environment
-- `extra_environment_vars` (optional, list[string]): Additional environment variables
-- `init_timeout_nanos` (optional, int): Initialization timeout in nanoseconds
-- `auto_delete_timeout` (optional, int): Auto-deletion timeout in seconds. Omit to leave unchanged, 0 for permanent (no expiration), positive integer for timeout
-- `admin_groups` (optional, list[string]): User groups with admin access
-- `viewer_groups` (optional, list[string]): User groups with viewer access
-- `restart_users` (optional, string): Who can restart ("RU_ADMIN", "RU_ADMIN_AND_VIEWERS", "RU_VIEWERS_WHEN_DOWN")
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "pq_id": "enterprise:prod:12345",
-  "serial": 12345,
-  "name": "analytics_worker",
-  "restarted": false,
-  "message": "PQ 'analytics_worker' modified successfully"
-}
-```
-
-**Description**: Updates a PQ's configuration by merging provided parameters with the current config. Only specified (non-None) parameters are updated - all others remain unchanged. Changes can be applied to PQs in any state.
-
-**Important Notes**:
-
-- At least one parameter must be provided (returns error if no changes specified)
-- List parameters (extra_jvm_args, schedule, etc.) completely replace existing values
-- `restart=true` restarts the PQ immediately to apply changes
-- `restart=false` saves changes but requires manual restart to take effect
-- Some changes (heap size, script content, JVM args) require restart to apply
-- Can modify RUNNING PQs but `restart=true` will disrupt active sessions
-- Use `pq_details` first to see current configuration before modifying
-
-##### `pq_start`
-
-**Purpose**: Start one or more persistent queries (best-effort batch operation).
-
-**Parameters**:
-
-- `pq_id` (required, string | list[string]): PQ identifier or list of identifiers in format `"enterprise:{system_name}:{serial}"`
-- `timeout_seconds` (optional, int): Max seconds to wait for PQs to start (default: 30). Set to 0 for fire-and-forget.
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "results": [
-    {
-      "pq_id": "enterprise:prod:12345",
-      "serial": 12345,
-      "success": true,
-      "name": "analytics",
-      "state": "RUNNING",
-      "session_id": "enterprise:prod:analytics",
-      "error": null
-    },
-    {
-      "pq_id": "enterprise:prod:67890",
-      "serial": 67890,
-      "success": false,
-      "name": null,
-      "state": null,
-      "session_id": null,
-      "error": "Timeout waiting for PQ to start"
-    }
-  ],
-  "summary": {
-    "total": 2,
-    "succeeded": 1,
-    "failed": 1
-  },
-  "message": "Started 1 of 2 PQ(s), 1 failed"
-}
-```
-
-**Description**: Starts stopped or newly created PQs. Operates in **best-effort mode**: processes each PQ independently. Returns `session_id` for successfully started PQs. If timeout occurs, PQ continues starting in background. All PQ IDs must be from the same enterprise system.
-
-##### `pq_stop`
-
-**Purpose**: Stop one or more running persistent queries (best-effort batch operation).
-
-**Parameters**:
-
-- `pq_id` (required, string | list[string]): PQ identifier or list of identifiers in format `"enterprise:{system_name}:{serial}"`
-- `timeout_seconds` (optional, int): Max seconds to wait for PQs to stop (default: 30). Set to 0 for fire-and-forget.
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "results": [
-    {
-      "pq_id": "enterprise:prod:12345",
-      "serial": 12345,
-      "success": true,
-      "name": "analytics_worker",
-      "state": "STOPPED",
-      "error": null
-    },
-    {
-      "pq_id": "enterprise:prod:67890",
-      "serial": 67890,
-      "success": false,
-      "name": null,
-      "state": null,
-      "error": "PQ already stopped"
-    }
-  ],
-  "summary": {
-    "total": 2,
-    "succeeded": 1,
-    "failed": 1
-  },
-  "message": "Stopped 1 of 2 PQ(s), 1 failed"
-}
-```
-
-**Description**: Gracefully stops running PQs. Operates in **best-effort mode**: processes each PQ independently. PQ definitions are preserved and can be restarted. If timeout occurs, PQ continues stopping in background. All PQ IDs must be from the same enterprise system.
-
-##### `pq_restart`
-
-**Purpose**: Restart one or more persistent queries (best-effort batch operation).
-
-**Parameters**:
-
-- `pq_id` (required, string | list[string]): PQ identifier or list of identifiers in format `"enterprise:{system_name}:{serial}"`
-- `timeout_seconds` (optional, int): Max seconds to wait for PQs to restart (default: 30). Set to 0 for fire-and-forget.
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "results": [
-    {
-      "pq_id": "enterprise:prod:12345",
-      "serial": 12345,
-      "success": true,
-      "name": "analytics_worker",
-      "state": "RUNNING",
-      "session_id": "enterprise:prod:analytics_worker",
-      "error": null
-    },
-    {
-      "pq_id": "enterprise:prod:67890",
-      "serial": 67890,
-      "success": false,
-      "name": null,
-      "state": null,
-      "session_id": null,
-      "error": "PQ cannot be restarted"
-    }
-  ],
-  "summary": {
-    "total": 2,
-    "succeeded": 1,
-    "failed": 1
-  },
-  "message": "Restarted 1 of 2 PQ(s), 1 failed"
-}
-```
-
-**Description**: Restarts stopped, failed, or completed PQs using original configuration. Operates in **best-effort mode**: processes each PQ independently. More efficient than deleting and recreating. Preserves PQ serial numbers. If timeout occurs, PQ continues restarting in background. All PQ IDs must be from the same enterprise system.
-
-**Workflow Examples**:
-
-1. **Create and start a new PQ:**
-
-   ```text
-   pq_create → pq_start → use session_id with session tools
-   ```
-
-2. **Manage existing PQ:**
-
-   ```text
-   pq_list → pq_details → pq_stop → pq_restart
-   ```
-
-3. **Query running PQ data:**
-
-   ```text
-   pq_details → get session_id → session_tables_list → session_table_data
-   ```
-
-#### Community Session Tools
-
-> **Note:** This describes the community-side tools exposed by the unified `dh-mcp-systems-server`.
-
-##### `session_community_create`
-
-**Purpose**: Create a new dynamically launched Deephaven Community session via Docker or Python.
-
-**Parameters**:
-
-- `session_name` (required, string): Unique name for the session
-- `launch_method` (optional, string): How to launch the session: `"docker"` or `"python"` (default: from config or "docker")
-- `programming_language` (optional, string): Programming language for Docker sessions: `"Python"` or `"Groovy"` (default: from config or "Python"). Docker only. Mutually exclusive with `docker_image`. Automatically selects Docker image: Python → ghcr.io/deephaven/server:latest, Groovy → ghcr.io/deephaven/server-slim:latest. Raises error if used with python launch method.
-- `auth_type` (optional, string): Authentication type: `"PSK"` or `"Anonymous"` (case-insensitive shorthand), or full class name `"io.deephaven.authentication.psk.PskAuthenticationHandler"` (default: `"io.deephaven.authentication.psk.PskAuthenticationHandler"`). Note: Basic auth is not supported for dynamic sessions.
-- `auth_token` (optional, string): Pre-shared key for PSK authentication. If omitted with PSK auth, a secure token is auto-generated
-- `docker_image` (optional, string): Custom Docker image to use (Docker only). Mutually exclusive with `programming_language`. If neither specified, defaults to Python image. Raises error if used with python launch method.
-- `docker_memory_limit_gb` (optional, float): Container memory limit in GB (Docker only)
-- `docker_cpu_limit` (optional, float): Container CPU limit in cores (Docker only)
-- `docker_volumes` (optional, array): Volume mounts in format `["host:container:mode"]` (Docker only)
-- `python_venv_path` (optional, string): Path to custom Python venv directory (Python only). If provided, uses deephaven from that venv. If null (default), uses same venv as MCP server. Raises error if used with docker.
-- `heap_size_gb` (optional, float | int): JVM heap size in gigabytes (e.g., 4 or 2.5, default: from config or 4). Integer values use 'g' suffix (4 → `-Xmx4g`). Float values converted to MB (2.5 → `-Xmx2560m`)
-- `extra_jvm_args` (optional, array): Additional JVM arguments
-- `environment_vars` (optional, object): Environment variables as key-value pairs
-
-**Note**: Startup parameters (`startup_timeout_seconds`, `startup_check_interval_seconds`, `startup_retries`) are configured via the `community/settings.json` `session_creation.defaults` block only and are not exposed as tool parameters.
-
-**Returns**:
-
-```json5
-{
-  "success": true,
-  "session_id": "community:community:my-session",
-  "session_name": "my-session",
-  "connection_url": "http://localhost:45123",
-  "auth_type": "io.deephaven.authentication.psk.PskAuthenticationHandler",
-  "launch_method": "docker",
-  "port": 45123,
-  "container_id": "a1b2c3d4..."
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Session limit reached: 5/5 sessions active",
-  "isError": true
-}
-```
-
-**Description**: This tool dynamically creates a new Deephaven Community session by launching it via Docker or Python-based Deephaven. The session is registered in the MCP server and will be automatically cleaned up when the MCP server shuts down. Auto-generated PSK tokens are logged at WARNING level for visibility. Parameter resolution follows the priority: tool parameter → config default → hardcoded default.
-
-##### `session_community_delete`
-
-**Purpose**: Delete a dynamically created Deephaven Community session.
-
-**Parameters**:
-
-- `session_id` (required, string): Full session identifier in format `"community:community:{session_name}"`. Only dynamically created sessions (manager `origin` `DYNAMIC`) can be deleted; passing a static session ID (manager `origin` `STATIC`) returns a clear error.
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "session_id": "community:community:my-session",
-  "session_name": "my-session"
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Session 'community:community:nonexistent' not found",
-  "isError": true
-}
-```
-
-**Description**: This tool deletes a community session that was created via `session_community_create`. It stops the underlying Docker container or python process and removes the session from the registry. Only dynamically created sessions (source='dynamic') can be deleted - static sessions from configuration cannot be deleted. This operation is irreversible.
-
-##### `session_community_credentials`
-
-**Purpose**: Retrieve authentication credentials for a community session.
-
-**Parameters**:
-
-- `session_id` (required, string): The session ID in format `community:{source}:{session_name}`
-
-**Returns**:
-
-```json5
-{
-  "success": true,
-  "auth_type": "PSK",
-  "auth_token": "your-secure-token-123",
-  "connection_url": "http://localhost:45123",
-  "connection_url_with_auth": "http://localhost:45123/?psk=your-secure-token-123"
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Credential retrieval is disabled. Set security.credential_retrieval_mode in config.",
-  "isError": true
-}
-```
-
-**Description**: This tool retrieves connection credentials for community sessions, allowing AI agents or users to obtain the authentication token and connection URLs needed to access a session via browser or API. This functionality is **disabled by default** for security and must be explicitly enabled via the `security.credential_retrieval_mode` configuration setting. The retrieval mode can be set to allow credentials for dynamic sessions only (`"dynamic_only"`), static sessions only (`"static_only"`), all sessions (`"all"`), or none (`"none"`, the default).
-
-**Security Note**: When enabled, this tool provides access to authentication credentials. Use appropriate access controls and consider the security implications for your environment.
-
-#### General Session Tools
-
-##### `sessions_list`
-
-**Purpose**: List all sessions (community and enterprise) with basic metadata.
-
-**Parameters**: None
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "sessions": [
-    {
-      "session_id": "community:community:session_name",
-      "type": "community",
-      "system": "community",
-      "origin": "static",
-      "session_name": "session_name"
-    },
-    {
-      "session_id": "enterprise:staging_env:analytics_session",
-      "type": "enterprise",
-      "system": "staging_env",
-      "origin": null,
-      "session_name": "analytics_session"
-    }
-  ]
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "isError": true
-}
-```
-
-**Description**: This is a lightweight operation that doesn't connect to sessions or check their status. For detailed information about a specific session, use `session_details`. When enterprise session discovery is still in progress or completed with errors, an optional `initialization` field is included with a `status` string and optional `errors` dict mapping factory names to error descriptions.
-
-##### `session_details`
-
-**Purpose**: Get detailed information about a specific session.
-
-**Parameters**:
-
-- `session_id` (required, string): The session identifier (fully qualified name) to get details for.
-- `attempt_to_connect` (optional, boolean): Whether to attempt connecting to the session to verify its status. Defaults to False for faster response.
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "session": {
-    "session_id": "community:community:session_name",
-    "type": "community",
-    "system": "community",
-    "origin": "static",
-    "session_name": "session_name",
-    "available": true,
-    "liveness_status": "ONLINE",
-    "programming_language": "python",
-    "deephaven_community_version": "0.36.1"
-  }
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "isError": true
-}
-```
-
-**Description**: This tool provides comprehensive status information about a specific session. It supports two operational modes: quick status check (default) or active connection verification. Additional optional fields may appear depending on session type: `liveness_detail` (detailed status explanation), `programming_language_version`, `deephaven_community_version`, `deephaven_enterprise_version`, and for dynamically created sessions: `connection_url`, `connection_url_with_auth`, `auth_type`, `launch_method`, `port`, `container_id` (Docker), or `process_id` (Python). Fields with null values are omitted.
-
-##### `catalog_tables_list`
-
-**Purpose**: Retrieve catalog table entries from a Deephaven Enterprise (Core+) session with optional filtering.
-
-**Parameters**:
-
-- `session_id` (required, string): ID of the Deephaven enterprise session to query.
-- `max_rows` (optional, integer): Maximum number of catalog entries to return. Defaults to 10000. Set to null to retrieve entire catalog (use with caution for large deployments).
-- `filters` (optional, list[string]): List of Deephaven where clause expressions to filter catalog results. Multiple filters are combined with AND logic. Use backticks (`) for string literals.
-- `format` (optional, string): Output format for catalog data. Options: "optimize-rendering" (default), "optimize-accuracy", "optimize-cost", "optimize-speed", or explicit formats: "json-row", "json-column", "csv", "markdown-table", "markdown-kv", "yaml", "xml".
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "session_id": "enterprise:prod:analytics",
-  "format": "json-row",
-  "row_count": 150,
-  "is_complete": true,
-  "columns": [
-    {"name": "Namespace", "type": "string"},
-    {"name": "TableName", "type": "string"},
-    {"name": "Size", "type": "int64"}
-  ],
-  "data": [
-    {"Namespace": "market_data", "TableName": "daily_prices", "Size": 1000000},
-    {"Namespace": "market_data", "TableName": "live_trades", "Size": 5000000}
-  ]
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "isError": true
-}
-```
-
-**Filter Examples**:
-
-```python
-# Exact namespace match
-filters=["Namespace = `market_data`"]
-
-# Table name contains (case-sensitive)
-filters=["TableName.contains(`price`)"]
-
-# Table name contains (case-insensitive)
-filters=["TableName.toLowerCase().contains(`price`)"]
-
-# Multiple filters (AND logic)
-filters=["Namespace = `market_data`", "TableName.contains(`daily`)"]
-
-# Exclude test tables
-filters=["Namespace not in `test`, `staging`"]
-
-# Regex pattern matching
-filters=["TableName.matches(`.*_daily_.*`)"]
-```
-
-**Description**: This tool retrieves catalog table entries from an enterprise session, which contains metadata about all accessible tables including names, namespaces, and other descriptive information. Only works with Deephaven Enterprise (Core+) sessions. The catalog enables discovery of available data sources before querying specific tables.
-
-**Important Notes**:
-
-- String literals in filters MUST use backticks (`), not single (') or double (") quotes
-- Filters are case-sensitive by default; use `.toLowerCase()` for case-insensitive matching
-- Multiple filters in the list are combined with AND logic
-- For complete filter syntax, see: <https://deephaven.io/core/docs/how-to-guides/use-filters/>
-
-##### `catalog_namespaces_list`
-
-**Purpose**: Retrieve distinct namespaces from a Deephaven Enterprise (Core+) catalog for efficient data domain discovery.
-
-**Parameters**:
-
-- `session_id` (required, string): ID of the Deephaven enterprise session to query.
-- `max_rows` (optional, integer): Maximum number of namespaces to return. Defaults to 1000. Set to null to retrieve all namespaces (use with caution).
-- `filters` (optional, list[string]): List of Deephaven where clause expressions to filter the catalog before extracting namespaces. Use backticks (`) for string literals.
-- `format` (optional, string): Output format for namespace data. Options: "optimize-rendering" (default), "optimize-accuracy", "optimize-cost", "optimize-speed", or explicit formats: "json-row", "json-column", "csv", "markdown-table", "markdown-kv", "yaml", "xml".
-
-**Returns**:
-
-- `success` (boolean): True if namespaces were retrieved successfully
-- `session_id` (string): The session ID (on success)
-- `format` (string): Actual format used (on success)
-- `row_count` (integer): Number of namespaces returned (on success)
-- `is_complete` (boolean): True if all namespaces returned, False if truncated (on success)
-- `columns` (list): Schema information with single column: `{"name": "Namespace", "type": "string"}`
-- `data` (list/dict/string): Namespace data in requested format (on success)
-- `error` (string): Error message (on failure)
-- `isError` (boolean): True (on failure only)
-
-**Example Usage**:
-
-```json
-{
-  "session_id": "enterprise:prod:analytics"
-}
-```
-
-**Description**: This tool retrieves the distinct list of namespaces from an enterprise catalog, enabling efficient discovery of data domains before drilling down into specific tables. This is typically the first step in exploring an enterprise data catalog. Much faster than retrieving the full catalog when you just need to know what data domains exist.
-
-**Important Notes**:
-
-- Returns only distinct namespace values (one column: "Namespace")
-- Filters are applied to the full catalog before extracting namespaces
-- Default max_rows of 1000 is lighter than catalog_tables (10000)
-- Ideal for top-down data exploration: namespaces → tables → schemas → data
-
-##### `catalog_tables_schema`
-
-**Purpose**: Retrieve full metadata schemas for catalog tables in a Deephaven Enterprise (Core+) session with flexible filtering.
-
-**Parameters**:
-
-- `session_id` (required, string): ID of the Deephaven enterprise session to query.
-- `namespace` (optional, string): Filter to tables in this specific namespace. If None, searches all namespaces.
-- `table_names` (optional, list[string]): List of specific table names to retrieve schemas for. If None, retrieves schemas for all tables (up to max_tables limit).
-- `filters` (optional, list[string]): List of Deephaven where clause expressions to filter the catalog. Multiple filters are combined with AND logic. Use backticks (`) for string literals.
-- `max_tables` (optional, integer): Maximum number of table schemas to retrieve. Defaults to 100 for safety. Set to null to retrieve all matching schemas (use with extreme caution for large catalogs).
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "schemas": [
-    {
-      "success": true,
-      "namespace": "market_data",
-      "table": "daily_prices",
-      "format": "json-row",
-      "data": [
-        {"Name": "Date", "DataType": "LocalDate", "IsPartitioning": false},
-        {"Name": "Price", "DataType": "double", "IsPartitioning": false}
-      ],
-      "meta_columns": [
-        {"name": "Name", "type": "string"},
-        {"name": "DataType", "type": "string"},
-        {"name": "IsPartitioning", "type": "bool"}
-      ],
-      "row_count": 2
-    },
-    {
-      "success": false,
-      "namespace": "market_data",
-      "table": "missing_table",
-      "error": "Table not found in catalog",
-      "isError": true
-    }
-  ],
-  "count": 2,
-  "is_complete": true
-}
-```
-
-On complete failure:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "isError": true
-}
-```
-
-**Example Usage**:
-
-```python
-# Get schemas for all tables in a namespace (up to 100)
-catalog_tables_schema(session_id="enterprise:prod:analytics", namespace="market_data")
-
-# Get schemas for specific tables in a namespace
-catalog_tables_schema(
-    session_id="enterprise:prod:analytics",
-    namespace="market_data",
-    table_names=["daily_prices", "quotes"]
-)
-
-# Filter-based discovery across namespaces
-catalog_tables_schema(
-    session_id="enterprise:prod:analytics",
-    filters=["TableName.contains(`price`)"]
-)
-
-# Get all schemas (requires explicit None, use with caution)
-catalog_tables_schema(
-    session_id="enterprise:prod:analytics",
-    max_tables=None
-)
-```
-
-**Description**: This tool retrieves FULL metadata schemas for tables in the enterprise catalog. The metadata includes all column properties (Name, DataType, IsPartitioning, ComponentType, etc.), not just simplified name/type pairs. Essential for understanding the complete structure of catalog tables before loading them with `db.live_table()` or `db.historical_table()`. Only works with Deephaven Enterprise (Core+) sessions. The tool supports flexible filtering by namespace, specific table names, or custom filter expressions.
-
-**Response Fields** (per table):
-
-- `format`: Always "json-row" - indicates data is a list of dicts
-- `data`: Full metadata rows with all column properties
-- `meta_columns`: Schema of the metadata table itself (describes what fields are in `data`)
-- `row_count`: Number of columns in the catalog table (equals length of `data`)
-- `namespace`: Catalog namespace (only in catalog schemas, not session schemas)
-- `count`: Total number of table schemas returned (top-level field)
-- `is_complete`: Whether all matching tables were retrieved or truncated by max_tables
-
-**Performance Considerations**:
-
-- Default max_tables=100 is safe for most use cases
-- Fetching schemas for 1000+ tables can take significant time (several minutes)
-- Use namespace or filters to narrow down the search space
-- Specify exact table_names when you know what you need for fastest results
-- Each schema fetch requires a separate query to the catalog
-
-**Important Notes**:
-
-- Individual table failures don't stop processing of other tables (similar to `session_tables_schema`)
-- Returns both `namespace` and `table` fields for each schema result
-- String literals in filters MUST use backticks (`), not quotes
-- Filters are applied at the catalog level before fetching schemas
-- Use `catalog_tables_list` first to discover available tables, then use this tool to get their schemas
-
-##### `catalog_table_sample`
-
-**Purpose**: Retrieve sample data from a catalog table in a Deephaven Enterprise (Core+) session for previewing contents.
-
-**Parameters**:
-
-- `session_id` (required, string): ID of the Deephaven enterprise session to query.
-- `namespace` (required, string): The catalog namespace containing the table.
-- `table_name` (required, string): Name of the catalog table to sample.
-- `max_rows` (optional, integer): Maximum number of rows to retrieve. Defaults to 100. Set to null to retrieve entire table (use with caution for large tables).
-- `head` (optional, boolean): If True (default), retrieve from beginning. If False, retrieve from end (most recent rows for time-series data).
-- `format` (optional, string): Output format. Options: "optimize-rendering" (default), "optimize-accuracy", "optimize-cost", "optimize-speed", or explicit formats: "json-row", "json-column", "csv", "markdown-table", "markdown-kv", "yaml", "xml".
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "namespace": "market_data",
-  "table_name": "daily_prices",
-  "format": "markdown-table",
-  "schema": [
-    {"name": "Date", "type": "date32[day]"},
-    {"name": "Symbol", "type": "string"},
-    {"name": "Price", "type": "double"}
-  ],
-  "row_count": 100,
-  "is_complete": false,
-  "data": "| Date | Symbol | Price |\n| --- | --- | --- |\n| 2024-01-01 | AAPL | 150.25 |\n..."
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "isError": true
-}
-```
-
-**Description**: This tool retrieves sample data from catalog tables for previewing contents before loading the full table. It attempts to load the table using `historical_table` first, then falls back to `live_table` if needed. The tool enforces a 50MB response limit to prevent memory issues. Only works with Deephaven Enterprise (Core+) sessions.
-
-**Use Cases**:
-
-- Preview catalog table contents before loading full tables
-- Verify table structure and data format
-- Sample recent data from time-series tables (use `head=false`)
-- Quick data exploration without loading entire tables
-
-**Performance Considerations**:
-
-- Default max_rows=100 is safe for previewing
-- Use `optimize-rendering` (default) for best table display in AI interfaces
-- Use `optimize-cost` (csv) for large samples to minimize token usage
-- Response size limit: 50MB maximum to prevent memory issues
-
-**Important Notes**:
-
-- Only works with enterprise (Core+) sessions
-- Requires valid namespace and table_name from the catalog
-- Check `is_complete` field to know if sample represents entire table
-- Combine with `catalog_tables_schema` to understand table structure first
-- Use `catalog_tables_list` to discover available tables and namespaces
-
----
-
-### Session Data Tools
-
-#### `session_tables_schema`
-
-**Purpose**: Retrieve full metadata schemas for one or more tables from a Deephaven session.
-
-**Parameters**:
-
-- `session_id` (required, string): ID of the Deephaven session to query.
-- `table_names` (optional, list[string]): List of table names to retrieve schemas for. If None, all available tables will be queried.
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "count": 2,
-  "schemas": [
-    {
-      "success": true,
-      "table": "table_name",
-      "format": "json-row",
-      "data": [
-        {"Name": "column1", "DataType": "int", "IsPartitioning": false},
-        {"Name": "column2", "DataType": "java.lang.String", "IsPartitioning": false}
-      ],
-      "meta_columns": [
-        {"name": "Name", "type": "string"},
-        {"name": "DataType", "type": "string"},
-        {"name": "IsPartitioning", "type": "bool"}
-      ],
-      "row_count": 2
-    },
-    {
-      "success": false,
-      "table": "missing_table",
-      "error": "Table not found",
-      "isError": true
-    }
-  ]
-}
-```
-
-On complete failure (e.g., session not available):
-
-```json
-{
-  "success": false,
-  "error": "Failed to connect to session: ...",
-  "isError": true
-}
-```
-
-**Description**: This tool returns the FULL metadata schemas for the specified tables in the given Deephaven session. The metadata includes all column properties (Name, DataType, IsPartitioning, ComponentType, etc.), not just simplified name/type pairs. If no table_names are provided, schemas for all tables in the session are returned. The tool maintains the ability to report individual table successes/failures while providing an overall operation status.
-
-**Response Fields**:
-
-- `format`: Always "json-row" - indicates data is a list of dicts
-- `data`: Full metadata rows with all column properties
-- `meta_columns`: Schema of the metadata table itself (describes what fields are in `data`)
-- `row_count`: Number of columns in the original table (equals length of `data`)
-- `count`: Total number of table schemas returned (top-level field)
-
-##### `session_script_run`
-
-**Purpose**: Execute a script on a specified Deephaven session.
-
-**Parameters**:
-
-- `session_id` (required, string): ID of the Deephaven session on which to execute the script.
-- `script` (optional, string): The Python script to execute.
-- `script_path` (optional, string): Path to a Python script file to execute.
-
-**Note**: Exactly one of `script` or `script_path` must be provided.
-
-**Returns**:
-
-```json
-{
-  "success": true
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "isError": true
-}
-```
-
-**Description**: This tool executes a Python script on the specified Deephaven session. The script can be provided either as a string or as a file path. The tool only returns success status and does not include stdout or created tables in the response.
-
-##### `session_pip_list`
-
-**Purpose**: Retrieve installed pip packages from a specified Deephaven session.
-
-**Parameters**:
-
-- `session_id` (required, string): ID of the Deephaven session to query.
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "result": [
-    {"package": "numpy", "version": "1.25.0"},
-    {"package": "pandas", "version": "2.1.0"},
-    {"package": "deephaven-core", "version": "0.36.1"}
-  ]
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "isError": true
-}
-```
-
-**Description**: This tool queries the specified Deephaven session for information about installed pip packages using importlib.metadata. It executes a query on the session to retrieve package names and versions for all installed Python packages available in that session's environment.
-
-##### `session_table_data`
-
-**Purpose**: Retrieve table data from a specified Deephaven session with flexible formatting options optimized for AI agent consumption.
-
-**Parameters**:
-
-- `session_id` (required, string): ID of the Deephaven session to query.
-- `table_name` (required, string): Name of the table to retrieve data from.
-- `max_rows` (optional, int): Maximum number of rows to retrieve. Defaults to 1000. Set to None for entire table.
-- `head` (optional, boolean): If True (default), retrieve from beginning. If False, retrieve from end.
-- `format` (optional, string): Output format. See Format Options below. Defaults to "optimize-rendering".
-
-**Format Options**:
-
-Different formats have different tradeoffs for AI agent comprehension and token usage. Based on empirical research ([source](https://www.improvingagents.com/blog/best-input-data-format-for-llms)), format accuracy ranges from 61% (markdown-kv) to 44% (csv).
-
-**Optimization Strategies:**
-
-- `"optimize-rendering"` (default): Always use markdown-table (best for AI agent table display, ~55% accuracy)
-- `"optimize-accuracy"`: Always use markdown-kv (highest comprehension at ~61%, more tokens)
-- `"optimize-cost"`: Always use csv (fewest tokens, ~44% accuracy, may be harder to parse)
-- `"optimize-speed"`: Always use json-column (fastest conversion, ~50% accuracy)
-
-**Explicit Formats:**
-
-- `"json-row"`: Array of row objects `[{col1: val1}, ...]`
-- `"json-column"`: Column-oriented object `{col1: [val1, val2], ...}`
-- `"csv"`: Comma-separated values string
-- `"markdown-table"`: Markdown table format (pipe-delimited)
-- `"markdown-kv"`: Markdown key-value pairs per record
-- `"yaml"`: YAML format
-- `"xml"`: XML format
-
-**When to Use Each Format:**
-
-- **Table Display**: Use `optimize-rendering` (default, best for displaying tables in AI interfaces)
-- **Better Comprehension**: Use `optimize-accuracy` or explicit `markdown-kv` (uses more tokens)
-- **Large Tables**: Use `optimize-cost` or explicit `csv` (fewer tokens)
-- **Fastest Response**: Use `optimize-speed` or explicit `json-column`
-- **Legacy Systems**: Use `xml` for enterprise integrations
-- **Structured Data**: Use `yaml` for configuration-like tables
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "table_name": "my_table",
-  "format": "markdown-kv",
-  "schema": [
-    {"name": "col1", "type": "int64"},
-    {"name": "col2", "type": "string"}
-  ],
-  "row_count": 100,
-  "is_complete": true,
-  "data": "## Record 1\ncol1: 1\ncol2: a\n\n## Record 2\ncol1: 2\ncol2: b\n..."
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "isError": true
-}
-```
-
-**Description**: This tool retrieves actual table data with flexible output formatting. Different formats have different tradeoffs between AI agent comprehension and token usage. The tool enforces a 50MB response limit to prevent memory issues. The `is_complete` field indicates whether the entire table was retrieved or truncated by `max_rows`. The `format` field in the response shows the actual format used (important when using optimization strategies, as they resolve to specific formats).
-
-##### `session_tables_list`
-
-**Purpose**: Retrieve the names of all tables in a Deephaven session (lightweight operation).
-
-**Parameters**:
-
-- `session_id` (required, string): ID of the Deephaven session to query.
-
-**Returns**:
-
-```json
-{
-  "success": true,
-  "session_id": "community:community:session_name",
-  "table_names": ["table1", "table2", "table3"],
-  "count": 3
-}
-```
-
-On error:
-
-```json
-{
-  "success": false,
-  "error": "Error message",
-  "isError": true
-}
-```
-
-**Description**: This tool provides a lightweight way to discover what tables exist in a session without fetching their schemas. It's much faster than `session_tables_schema` when you only need table names. Works with both Community and Enterprise sessions. Use this for quick table discovery, then follow up with `session_tables_schema` for specific tables you're interested in.
-
-#### Community Server Test Components
-
-##### Community Test Server
-
-For development and testing the MCP Community server, you often need a running Deephaven Community Core server. A script is provided for this:
+For developing and testing the community tools, you often need a running Deephaven Community Core server. A script is provided for this:
 
 ```sh
 uv run scripts/run_deephaven_test_server.py --table-group {simple|financial|all} [--auth-token TOKEN]
@@ -2408,7 +441,7 @@ uv run scripts/run_deephaven_test_server.py --table-group {simple|financial|all}
 - `--port PORT` (default: `10000`): Port to listen on
 - `--auth-token TOKEN` (optional): Authentication token for PSK auth. If omitted, uses anonymous auth.
 
-##### Community Server Test Client
+#### Smoke-test client
 
 A Python script ([`../scripts/mcp_systems_test_client.py`](../scripts/mcp_systems_test_client.py)) is available as a smoke-test client for the systems MCP server. It connects to a running server, lists all registered tools, and calls a representative read-only subset. Exits with code `0` on full success and `1` if any tool call raised — usable as a CI smoke gate or post-deploy ping.
 
@@ -2440,7 +473,7 @@ uv run scripts/mcp_systems_test_client.py --psk your-psk --strict
 >
 > - The systems server must be running (see [Running the Systems Server](#running-the-systems-server))
 > - For HTTP transport, the server is gated by `PSKMiddleware`; pass the configured PSK via `--psk`
-> - For troubleshooting connection issues, see [Common Errors & Solutions](#common-errors--solutions)
+> - For troubleshooting connection issues, see [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -2477,24 +510,7 @@ The MCP Docs Server requires an Inkeep API key for accessing documentation and g
 
 ##### Docs Server Environment Variables
 
-- **`INKEEP_API_KEY`**: (Required) Your Inkeep API key for accessing the documentation assistant. This is the only API used by the `docs_chat` tool and must be set; the server refuses to start without it.
-- **`PYTHONLOGLEVEL`**: (Optional) Set to 'DEBUG', 'INFO', 'WARNING', etc. to control logging verbosity. Useful for troubleshooting issues.
-- **`MCP_DOCS_HOST`**: (Optional) Host to bind the server to (default: `127.0.0.1`). Set to `0.0.0.0` for external access.
-- **`MCP_DOCS_PORT`**: (Optional) Port for the server (default: `8001`). Falls back to `PORT` env var for Cloud Run compatibility.
-
-For a full list of environment variables across all servers, see [`docs/ENV.md`](ENV.md).
-
-##### Example Configuration
-
-```sh
-# Required for accessing Deephaven documentation knowledge base
-export INKEEP_API_KEY=your-inkeep-api-key
-
-# Optional for detailed logging
-export PYTHONLOGLEVEL=DEBUG
-```
-
-> **Security Note:** Always store API keys in environment variables or secure configuration files, never hardcode them in application code.
+The docs server has no JSON config; its entire surface is a handful of environment variables (`INKEEP_API_KEY` is required — the server refuses to start without it). See [`docs/ENV.md`](ENV.md#docs-server) for the canonical list, defaults, and the `PORT` fallback. Store the API key in the environment or a secret store, never in code — see [`docs/SECURITY.md`](SECURITY.md).
 
 #### Running the Docs Server
 
@@ -2518,96 +534,16 @@ The Deephaven MCP Docs Server exposes a single MCP-compatible tool:
 
 ##### `docs_chat`
 
-- **Purpose**: Interact with the Deephaven documentation assistant using conversational natural language queries
-- **Parameters**:
-  - `prompt` (required): Query or question about Deephaven or its documentation as a natural language string
-  - `history` (optional): Previous conversation history for context (list of messages with 'role' and 'content' keys)
-
-    ```python
-    [
-        {"role": "user", "content": "How do I install Deephaven?"},
-        {"role": "assistant", "content": "To install Deephaven, ..."}
-    ]
-    ```
-
-  - `deephaven_core_version` (optional): The version of Deephaven Community Core installed for the relevant worker. Providing this enables the documentation assistant to tailor its answers for greater accuracy.
-  - `deephaven_enterprise_version` (optional): The version of Deephaven Core+ (Enterprise) installed for the relevant worker. Providing this enables the documentation assistant to tailor its answers for greater accuracy.
-  - `programming_language` (optional): Programming language context for the user's question (e.g., "python", "groovy"). If provided, the assistant tailors its answer for this language.
-- **Returns**:
-  
-  ```json
-  {
-    "success": true,
-    "response": "Assistant's response message"
-  }
-  ```
-
-  On error:
-
-  ```json
-  {
-    "success": false,
-    "error": "Error message",
-    "isError": true
-  }
-  ```
-
-- **Error Handling**: If the underlying LLM API call fails, a structured error response is returned. Common errors include:
-  - Invalid or missing API keys
-  - Network connectivity issues
-  - Rate limiting from the LLM provider
-  - Invalid message format in history
-  All errors are logged and returned in the structured format for consistent error handling
-- **Usage Notes**:
-  - This tool is asynchronous and should be awaited when used programmatically
-  - For multi-turn conversations, providing conversation history improves contextual understanding
-  - Providing Deephaven version arguments for a worker will result in more accurate and context-specific answers.
-  - Providing the `programming_language` argument will tailor the assistant's answer for that language (e.g., "python", "groovy").
-  - Powered by Inkeep's LLM API service for retrieving documentation-specific responses
-
-**Example (programmatic use):**
-
-```python
-from unittest.mock import MagicMock
-from deephaven_mcp.mcp_docs_server._mcp import docs_chat
-
-async def get_docs_answer():
-    # context is injected by the MCP framework; pass a mock for direct calls
-    context = MagicMock()
-    response = await docs_chat(
-        context=context,
-        prompt="How do I filter tables in Deephaven?",
-        history=[
-            {"role": "user", "content": "How do I create a table?"},
-            {"role": "assistant", "content": "To create a table in Deephaven..."},
-        ],
-        deephaven_core_version="1.2.3",
-        deephaven_enterprise_version="4.5.6",
-        programming_language="python",
-    )
-    return response
-```
+`docs_chat` answers natural-language questions about Deephaven documentation via the Inkeep LLM API. Its parameters (`prompt`; optional `history`, `deephaven_core_version`, `deephaven_enterprise_version`, `programming_language`), return shape, and error handling are documented in the source docstring — `mcp_docs_server/_mcp.py` (`docs_chat`), the single source of truth. A runnable example is in [Programmatic API → Docs Server Example](#docs-server-example).
 
 #### Docs Server HTTP Endpoints
 
-**Example Usage:**
+The docs server exposes `GET /health`, which returns `200` with body `{"status": "ok"}` and requires no auth — for liveness/readiness probes (Kubernetes, Cloud Run, load balancers). It is the same endpoint described under [Health-check endpoint](#health-check-endpoint).
 
 ```sh
 curl http://localhost:8001/health
-# Response: {"status": "ok"}
+# {"status": "ok"}
 ```
-
-**`/health` (GET)**
-
-- **Purpose**: Health check endpoint for liveness and readiness probes in deployment environments
-- **Parameters**: None
-- **Returns**: JSON response `{"status": "ok"}` with HTTP 200 status code
-- **Usage**: Used by load balancers, orchestrators, or monitoring tools to verify the server is running
-- **Implementation**: Defined using `@mcp_server.custom_route("/health", methods=["GET"])` decorator in the source code
-- **Availability**: Available when the server is running (streamable-http only)
-- **Authentication**: No authentication or parameters required
-- **Deployment**: Intended for use as a liveness or readiness probe in Kubernetes, Cloud Run, or similar environments
-- **Note**: This endpoint is available on both MCP servers in this repo (Systems and Docs). On the systems server, `/health` is added to `PSKMiddleware`'s `bypass_paths`, so external probes do not need to share the PSK (see [Transport Security → Health-check endpoint](#health-check-endpoint)).
 
 #### Docs Server Test Components
 
@@ -2637,8 +573,8 @@ uv run scripts/mcp_docs_test_client.py --prompt "How do I filter this table?" \
 
 > ⚠️ **Prerequisites:**
 >
-> - For the Docs Server test client, you need a valid [Inkeep API key](https://inkeep.com/) (required)
-> - For troubleshooting API issues, see [Common Errors & Solutions](#common-errors--solutions)
+> - A running docs server to connect to. The docs **server** (not this client) requires a valid [Inkeep API key](https://inkeep.com/) set as `INKEEP_API_KEY`.
+> - For troubleshooting API issues, see [Troubleshooting](#troubleshooting)
 
 > 💡 **Tips:**
 >
@@ -2654,7 +590,7 @@ uv run scripts/mcp_docs_test_client.py --prompt "How do I filter this table?" \
 
 The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) is a web-based tool for interactively exploring and testing MCP servers. It provides an intuitive UI for discovering available tools, invoking them, and inspecting responses.
 
-#### MCP Inspector with Community Server
+#### MCP Inspector with the systems server
 
 1. **Start a Deephaven Community Core worker** (in one terminal):
 
@@ -2705,135 +641,30 @@ The [MCP Inspector](https://github.com/modelcontextprotocol/inspector) is a web-
 
 ### Claude Desktop
 
-Claude Desktop is very useful for debugging and interactively exploring MCP servers. The configuration file format described in this documentation is also used by most AI Agents that support MCP, making it easy to reuse your setup across different tools.
-
-#### Configuration
-
-1. **Open Claude Desktop.**
-2. **Navigate to `Settings > Developer > Edit Config`.**
-3. **Edit the `claude_desktop_config.json` file.**
-4. **Add your MCP server under the `mcpServers` section.**
-   - Both servers (Systems, Docs) are HTTP-only. Start them first, then configure Claude Desktop using `mcp-proxy` as a stdio bridge (Claude Desktop does not support HTTP transport natively). `mcp-proxy` is **not** a dependency of this project; install it separately with `uv tool install --python-preference managed mcp-proxy`.
-   - Example configuration:
-
-     ```json5
-     {
-       "mcpServers": {
-         "mcp-systems": {
-           "command": "mcp-proxy",
-           "args": ["--transport=streamablehttp", "http://127.0.0.1:8000/mcp"]
-         },
-         "mcp-docs": {
-           "command": "mcp-proxy",
-           "args": ["--transport=streamablehttp", "http://127.0.0.1:8001/mcp"]
-         }
-       }
-     }
-     ```
-
-   > **Note:** Start the Docs Server before connecting Claude Desktop:
-   >
-   > ```sh
-   > INKEEP_API_KEY=your-inkeep-api-key uv run dh-mcp-docs-server
-   > ```
-
-   > **Note:** When using HTTP transport, the Systems Server must
-   > already be running before Claude Desktop connects. Start it with:
-   >
-   > ```sh
-   > export DH_MCP_PSK='your-shared-secret'
-   > uv run dh-mcp-systems-server --transport http --port 8000
-   > ```
-   >
-   > For stdio transport, no separate process is needed — Claude
-   > Desktop launches the server as a subprocess (set
-   > `"command": "dh-mcp-systems-server"` and
-   > `"args": ["--transport", "stdio"]` in your MCP block).
-
-5. **Save the configuration and restart Claude Desktop if needed.**
-
-#### Claude Desktop Log Locations
-
-For troubleshooting Claude Desktop MCP integration, log files are located at:
-
-- **macOS:** `~/Library/Logs/Claude`
-- **Windows:** `%APPDATA%\Claude\logs`
-
-- `mcp.log` contains general logging about MCP connections and connection failures
-- Files named `mcp-server-SERVERNAME.log` contain error (stderr) logs from each configured server
+See [README → Claude Desktop setup](../README.md#claude-desktop) for the current (stdio-first) configuration and the HTTP-bridged variant, and [Log Analysis and Debugging](../README.md#log-analysis-and-debugging) for log file locations. Claude Desktop integration is an end-user path owned by the README.
 
 ### mcp-proxy
 
-[mcp-proxy](https://github.com/modelcontextprotocol/mcp-proxy) enables MCP clients that only support stdio to connect to streamable-HTTP servers. This is useful for clients that do not natively support streamable-HTTP. `mcp-proxy` is **not** a dependency of this project; install it separately with `uv tool install --python-preference managed mcp-proxy` (this places `mcp-proxy` on your PATH).
-
-**Use Cases:**
-
-- **Legacy Client Support**: Enable older MCP clients that only support stdio to use modern streamable-http servers
-- **Development Testing**: Test streamable-http servers with stdio-based tooling
-
-#### mcp-proxy with Community Server
-
-1. Ensure the MCP Systems Server is running:
-
-   ```sh
-   export DH_MCP_PSK='your-shared-secret'
-   uv run dh-mcp-systems-server --transport http --port 8000
-   ```
-
-2. Configure Claude Desktop to launch `mcp-proxy` as a stdio bridge:
-
-   ```json5
-   {
-     "mcpServers": {
-       "deephaven-community": {
-         "command": "mcp-proxy",
-         "args": ["--transport=streamablehttp", "http://127.0.0.1:8000/mcp"]
-       }
-     }
-   }
-   ```
-
-   (Replace the URL if your server uses a different host or port)
-
-#### mcp-proxy with Docs Server
-
-1. Ensure the MCP Docs Server is running:
-
-   ```sh
-   INKEEP_API_KEY=your-api-key uv run dh-mcp-docs-server
-   ```
-
-2. Configure Claude Desktop to launch `mcp-proxy` as a stdio bridge:
-
-   ```json5
-   {
-     "mcpServers": {
-       "deephaven-docs": {
-         "command": "mcp-proxy",
-         "args": ["--transport=streamablehttp", "http://127.0.0.1:8001/mcp"]
-       }
-     }
-   }
-   ```
+`mcp-proxy` bridges stdio-only clients to the HTTP servers. Installation and bridge configuration — including forwarding the PSK via the `X-Deephaven-PSK` header — live in the README: [Quick Start](../README.md#quick-start) and [Claude Desktop setup](../README.md#claude-desktop).
 
 ### Programmatic API
 
 Both servers can be used programmatically within Python applications:
 
-#### Community Server Example
+#### Systems Server Example
 
 ```python
-# Community Server
-from deephaven_mcp.mcp_systems_server.server import community
+# The single multiplexed systems server is started via its entry point.
+# main() parses --transport, --host, --port, --config-dir, etc. and runs
+# the server (it does not return until the server stops).
+from deephaven_mcp.mcp_systems_server.server import main
 
-# Enterprise Server
-from deephaven_mcp.mcp_systems_server.server import enterprise
+# stdio (default) carries no auth; --transport http serves streamable-HTTP
+# gated by server.json's PSK and bound only to loopback.
+main(["--transport", "http", "--port", "8000"])
 
-# main() parses --transport, --host, --port, --config-dir, etc. and starts the server.
-# stdio (default) carries no auth; --transport http serves streamable-HTTP gated
-# by server.json's PSK and bound only to loopback.
-# Typically invoked via the CLI command:
-#   dh-mcp-systems-server [--transport stdio|http]
+# Equivalent to the installed console script:
+#   dh-mcp-systems-server --transport http --port 8000
 ```
 
 #### Docs Server Example
@@ -2905,8 +736,6 @@ Both servers expose their tools through FastMCP, following the Model Context Pro
    > rm -rf .venv && uv venv -p 3.12 && uv pip install -e ".[dev]"
    > ```
 
-   > [`uv`](https://github.com/astral-sh/uv) is a fast Python package installer and resolver, but you can also use regular `pip install -e ".[dev]"` if preferred.
-
 4. **Run the test server** (in one terminal):
 
    ```sh
@@ -2925,6 +754,23 @@ Both servers expose their tools through FastMCP, following the Model Context Pro
    ```
 
 6. **Use the MCP Inspector or test client** to validate your changes.
+
+### Contributing workflow
+
+This repo uses an **agent-skill system** to keep contributions consistent. Two artifacts drive it:
+
+- **[`AGENTS.md`](../AGENTS.md)** — always-on rules every contributor (human or AI) follows: testing via `uv run pytest`, timeout expectations, version-control conventions, and pointers into the skills below.
+- **[`.agents/skills/`](../.agents/skills/)** — task playbooks indexed in [`.agents/skills/README.md`](../.agents/skills/README.md); each skill is a focused procedure for a recurring task.
+
+The skills you'll reach for most:
+
+- `run-precommit` / [`bin/precommit.sh`](../bin/precommit.sh) — isort, black, ruff, mypy, markdownlint; run before every commit.
+- `tests-run` / `tests-run-file` — unit suite with coverage.
+- `review-changes` — deep review of a change set before opening a PR.
+- `mcp-tool-add`, `cli-command-add`, `config-field-add` — add a tool, CLI command, or config field the project's way.
+- `docs-improve` / `docs-accuracy` — edit a markdown doc in scope (they load `_documentation-roles`).
+
+For fork-and-PR mechanics, see [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
 ### Advanced Development Techniques
 
@@ -3066,8 +912,10 @@ deephaven-mcp/
 ├── docs/                     # Project documentation
 ├── ops/                      # Operations (Docker, Terraform)
 ├── .github/                  # GitHub Actions workflows
+├── .agents/                  # Agent skills (.agents/skills/) shared across AI tools
 ├── bin/                      # Executable scripts (e.g., precommit.sh)
 ├── pyproject.toml            # Project definition and dependencies
+├── AGENTS.md                 # Always-on agent/contributor rules (imported by CLAUDE.md)
 ├── README.md                 # Main project README
 ├── LICENSE
 └── CONTRIBUTING.md
@@ -3084,14 +932,15 @@ deephaven-mcp/
   - `run_terraform.sh`: Unified helper script for workspace-aware Terraform operations
   - `README.md`: Comprehensive guide for infrastructure and deployment operations
 - **`bin/`**: Executable helper scripts, often used for CI/CD or local development hooks.
+- **`.agents/`** and **`AGENTS.md`**: The agent-assisted contribution system — `AGENTS.md` holds always-on contributor rules and `.agents/skills/` holds the task playbooks (build, review, test, add-a-tool, and more). See [Contributing workflow](#contributing-workflow).
 
 #### Key Module Details
 
-**MCP Community/Enterprise Servers (`mcp_systems_server/`)**:
+**MCP Systems Server (`mcp_systems_server/`)**:
 
 - Implements the MCP protocol for Deephaven Community Core and Enterprise workers
 - Provides tools for worker management, session orchestration, and script execution
-- HTTP-only (streamable-http transport)
+- Two transports: `stdio` (default) and streamable-HTTP (loopback-only, PSK-gated)
 - Built with FastMCP for robust async lifecycle management
 
 **MCP Docs Server (`mcp_docs_server/`)**:
@@ -3099,7 +948,7 @@ deephaven-mcp/
 - Provides LLM-powered documentation Q&A capabilities
 - Integrates with the Inkeep LLM API (OpenAI-compatible endpoint) for conversational assistance
 - HTTP-only (streamable-http transport)
-- Includes rate limiting and query management features
+- Rate-limits its own outbound Inkeep API calls; the server does not rate-limit inbound requests (front it with a gateway — see [`docs/SECURITY.md`](SECURITY.md))
 
 **Resource Manager (`resource_manager/`)**:
 
@@ -3151,7 +1000,7 @@ The project includes several utility scripts to help with development and testin
 | [`../scripts/run_deephaven_test_server.py`](../scripts/run_deephaven_test_server.py) | Starts a local Deephaven server for testing | `uv run scripts/run_deephaven_test_server.py --table-group simple [--auth-token TOKEN]` |
 | [`../scripts/mcp_systems_test_client.py`](../scripts/mcp_systems_test_client.py) | Smoke-test client for the systems server (exits 0 on full success, 1 on tool failure) | `uv run scripts/mcp_systems_test_client.py --psk YOUR_PSK` |
 | [`../scripts/mcp_docs_test_client.py`](../scripts/mcp_docs_test_client.py) | Tests the Docs Server chat functionality | `uv run scripts/mcp_docs_test_client.py --prompt "What is Deephaven?"` |
-| [`../scripts/mcp_docs_stress_test.py`](../scripts/mcp_docs_stress_test.py) | Comprehensive stress test for docs server (validates timeout fixes) | `uv run scripts/mcp_docs_stress_test.py` |
+| [`../scripts/mcp_docs_stress_test.py`](../scripts/mcp_docs_stress_test.py) | In-process concurrent load test of the `docs_chat` tool | `uv run scripts/mcp_docs_stress_test.py` |
 | [`../scripts/mcp_docs_stress_http.py`](../scripts/mcp_docs_stress_http.py) | Stress tests the streamable-HTTP endpoint with concurrent connections | `uv run scripts/mcp_docs_stress_http.py --url "http://localhost:8001/mcp"` |
 | [`../bin/precommit.sh`](../bin/precommit.sh) | Runs pre-commit code quality checks | `bin/precommit.sh` |
 
@@ -3191,16 +1040,14 @@ Multiple scripts are provided for comprehensive performance testing of the MCP s
 
 #### MCP Docs Server Stress Testing
 
-The [`../scripts/mcp_docs_stress_test.py`](../scripts/mcp_docs_stress_test.py) script provides comprehensive stress testing of the MCP docs server to validate performance, stability, and error handling under concurrent load. This script was specifically created to validate fixes for "Truncated response body" timeout errors that occurred during high-volume usage.
+The [`../scripts/mcp_docs_stress_test.py`](../scripts/mcp_docs_stress_test.py) script is an in-process concurrent load test of the `docs_chat` tool. It imports `docs_chat` directly (no MCP transport) and drives many concurrent calls against it, reporting performance and error statistics. For a transport-level stress test against a deployed HTTP endpoint, use [HTTP Transport Stress Testing](#http-transport-stress-testing) instead.
 
 **Key Features:**
 
-- Tests concurrent requests against the `docs_chat` tool
-- Validates timeout fixes and connection management
+- Drives concurrent in-process calls to the `docs_chat` tool
 - Measures response times, throughput, and success rates
 - Generates detailed performance metrics and error reports
-- Uses the same dependency injection pattern as production
-- Includes proper resource cleanup to prevent connection leaks
+- Writes per-request metrics to a JSON results file
 
 **Usage:**
 
@@ -3214,9 +1061,9 @@ uv run scripts/mcp_docs_stress_test.py
 
 **Expected Results:**
 
-- 100% success rate (no timeout errors)
-- Response times: 15-180 seconds per request
-- Throughput: 0.5-2.0 requests/second
+- High success rate under healthy conditions
+- Response times: 15-180 seconds per request (depends on query complexity)
+- Throughput: 0.5-2.0 requests/second (limited by API rate limits)
 - Detailed JSON results saved to `stress_test_results.json`
 
 **Troubleshooting:**
@@ -3230,7 +1077,7 @@ uv run scripts/mcp_docs_stress_test.py
 
 A script is also provided for stress testing the streamable-HTTP transport for production deployments. This is useful for validating the stability and performance of production or staging deployments under load. The script uses [aiohttp](https://docs.aiohttp.org/) for asynchronous HTTP requests and [aiolimiter](https://github.com/mjpieters/aiolimiter) for rate limiting.
 
-#### Usage Example
+##### Usage example
 
 The [`../scripts/mcp_docs_stress_http.py`](../scripts/mcp_docs_stress_http.py) script can be used to stress test HTTP endpoints:
 
@@ -3244,7 +1091,7 @@ uv run scripts/mcp_docs_stress_http.py \
     --max-response-time 2
 ```
 
-#### Arguments
+##### Arguments
 
 - `--concurrency`: Number of concurrent connections (default: 100)
 - `--requests-per-conn`: Number of requests per connection (default: 100)
@@ -3349,95 +1196,17 @@ uv pip install -e ".[dev]"
 
 </div>
 
-### Common Issues
+For operator and end-user troubleshooting — JSON/config errors, HTTP `401`/PSK and loopback failures, port conflicts, connectivity, and debug logging — see the [README Troubleshooting section](../README.md#troubleshooting), [`docs/CONFIGURATION.md`](CONFIGURATION.md), [`docs/ENV.md`](ENV.md), and [`docs/SECURITY.md`](SECURITY.md). The HTTP transport's PSK/loopback model is detailed above in [HTTP Transport Security](#http-transport-security). The issues below are specific to working *on* the codebase.
 
-1. **Worker Configuration Errors**:
-   - The worker configuration must be valid JSON or JSON5 (comments and trailing commas are supported)
-   - All required fields must be present for each worker
-   - Unknown fields in community session configuration will cause validation errors; unknown fields in enterprise configuration are logged as warnings and ignored
-   - Check error messages for specific validation issues
+### Development-specific issues
 
-2. **API Key Issues**:
-   - Ensure your Inkeep API key is valid and active
-   - Verify the API key is properly set in environment variables
-   - Check for typos in key names or values
-
-3. **HTTP Transport Connection Failures**:
-   - Verify the server is running with `--transport http` and listening on the expected port (default: `8000`, override with `--port` or the `port` field in `server.json`)
-   - Check for firewall or network issues
-   - Ensure the client is using the correct URL: `http://127.0.0.1:8000/mcp` (or whichever `--port` you chose)
-   - Ensure the client sends `X-Deephaven-PSK: <psk>` on every non-`/health` request
-
-4. **Deephaven Worker Connectivity**:
-   - Confirm the Deephaven server is running and accessible
-   - Verify that the worker configuration has the correct host/port
-   - Check for authentication issues if using secured connections
-
-5. **Environment Variable Problems**:
-   - Make sure `DH_MCP_DATA_DIR` points to a valid, readable directory (or unset both `DH_MCP_DATA_DIR` and `--config-dir` to use the platform default)
-   - The value should be an absolute path for reliability across different working directories
-   - Environment variables must be set in the shell before starting the server; there is no built-in `.env` file support
-
-6. **Debug with Logging**:
-   - Set `PYTHONLOGLEVEL=DEBUG` for more detailed logs
-   - All servers use streamable-http transport; logs appear in the terminal where the server is running
-   - The server automatically redacts sensitive fields (auth_token, binary credentials) in logs
-
-### Common Errors & Solutions
-
-1. **Config Directory Not Found / permissions audit failure:**
-   - Ensure `DH_MCP_DATA_DIR` (or `--config-dir`) points to a valid directory containing the expected `community/` and/or `enterprise/` subtrees
-   - Example error: `FileNotFoundError: No such file or directory: ...` or a permission audit failure naming the offending file
-   - Fix: Verify the directory path; on POSIX, `chmod 700` the directory and `chmod 600` each file
-
-2. **Invalid JSON/Schema in Config:**
-   - Double-check your Deephaven MCP config file for syntax errors or unsupported fields
-   - Use a JSON validator if unsure about the format
-   - Common errors: missing commas, unquoted keys (JSON5 supports comments and trailing commas)
-
-3. **Port Already in Use:**
-   - Change the port in your config or ensure no other process is using it
-   - Example error: `OSError: [Errno 98] Address already in use`
-   - Fix: Use a different port or stop the process using the current port
-
-4. **Connection Timeouts:**
-   - Check that Deephaven workers are running and reachable
-   - Verify network connectivity between MCP server and workers
-   - If using TLS, ensure certificates are valid and trusted
-
-5. **Transport Issues:**
-   - The systems server uses stdio (default) or streamable-http; for HTTP, verify the URL (e.g., `http://127.0.0.1:8000/mcp`)
-   - Ensure the server port is open and not firewalled
-   - Verify the `port` in `server.json` or the `--port` CLI arg matches the URL your client connects to
-
-6. **HTTP transport startup refusal / `401 Unauthorized`:**
-   - **Symptom (startup):** `--host` rejected because it is not a loopback address.
-   - **Symptom (runtime):** Requests rejected with HTTP `401` from `PSKMiddleware`.
-   - **Cause:** The HTTP transport binds only to loopback and requires the `X-Deephaven-PSK` header on every non-`/health` request.
-   - **Fix:** See [HTTP Transport Security](#http-transport-security):
-     - Bind to `127.0.0.1`, `::1`, or `localhost` only.
-     - Make sure `server.json` declares a `psk` value (with optional `${env:NAME}` templating) and that the env var is set if you used the indirection.
-     - Have your MCP client send `X-Deephaven-PSK: <psk>` on every request (the `/health` endpoint is exempt).
-     - To expose the server beyond loopback, terminate TLS at a reverse proxy on the same host and forward to `127.0.0.1:<port>`.
-
-7. **Missing Dependencies:**
-   - Ensure all Python dependencies are installed (`uv pip install ".[dev]"`)
-   - Java must be installed and in PATH for running Deephaven test servers
-
-8. **Session Errors:**
-   - Review logs for session cache or connection errors
-   - Configuration changes require a server restart — the `mcp_reload` tool has been removed.
-
-9. **Development-Specific Issues:**
-   - **Test Execution**: Always use `uv run pytest` instead of `pytest` for consistency
-   - **Code Quality**: Run [`bin/precommit.sh`](../bin/precommit.sh) before committing to catch style and lint issues
-   - **Virtual Environment**: Ensure you're using the correct virtual environment with `uv` or `pip+venv`
-   - **IDE Configuration**: Use absolute paths in IDE configurations for MCP server integration
-   - **Module Import Errors**: If encountering import errors, verify the package is installed in development mode: `uv pip install -e ".[dev]"`
-   - **Resource Manager Issues**: Check async safety and ensure proper session lifecycle management
-   - **Performance Testing**: Use the stress test scripts in [`scripts/`](../scripts/) to identify bottlenecks or connection issues
-
----
+- **Test execution** — always use `uv run pytest` instead of `pytest` for consistency.
+- **Code quality** — run [`bin/precommit.sh`](../bin/precommit.sh) before committing to catch style and lint issues.
+- **Module import errors** — verify the package is installed in development mode: `uv pip install -e ".[dev]"`.
+- **Java on PATH** — the Deephaven test server ([`scripts/run_deephaven_test_server.py`](../scripts/run_deephaven_test_server.py)) requires a JDK on `PATH`.
+- **Coroutine errors after code changes** — restart the server; re-install with `-e` if you changed entry points.
+- **Resource-manager / session issues** — check async safety and session-lifecycle management when changing the registry layer.
+- **Performance** — use the stress-test scripts in [`scripts/`](../scripts/) to find bottlenecks; see [Performance Testing](#performance-testing).
 
 ## Resources
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -16,6 +16,7 @@ policy, see the root [`SECURITY.md`](../SECURITY.md).
 - [Transport security](#transport-security)
 - [Secret handling](#secret-handling)
 - [Rotation](#rotation)
+- [Docs server](#docs-server)
 - [Further reading](#further-reading)
 
 ## Am I in scope for this guide?
@@ -31,6 +32,10 @@ machine** to talk to a running `dh-mcp-systems-server` over HTTP
 deployment, etc.). The HTTP transport requires explicit decisions
 about authentication and a fronting TLS layer; the rest of this
 page walks through those decisions.
+
+If instead you deploy `dh-mcp-docs-server` (the public
+documentation Q&A service), skip to [Docs server](#docs-server) —
+it has a deliberately different, unauthenticated posture.
 
 ## Trust model
 
@@ -214,6 +219,34 @@ do **not** accept a `tls` block — the upstream Enterprise
 - **Outbound credential rotation:** update the `${env:NAME}` source
   or the `${file:PATH}` target and **restart the server**. In-memory
   credentials are not re-resolved at runtime.
+
+## Docs server
+
+Everything above describes `dh-mcp-systems-server`. The second
+binary, `dh-mcp-docs-server`, has a deliberately different posture:
+it is an **intentionally public, unauthenticated** documentation
+Q&A service.
+
+- **No PSK gate, by design.** The docs server exposes a single
+  read-only tool (`docs_chat`) that forwards questions to an
+  upstream LLM documentation API. It carries no inbound secrets and
+  hosts no Deephaven session, so there is no PSK middleware. The
+  shipped container image (`ops/docker/mcp-docs/Dockerfile`) binds
+  `0.0.0.0` on purpose so it can run behind a public ingress
+  (e.g. Cloud Run).
+- **Abuse control belongs to the fronting deployment.** Because
+  `docs_chat` consumes a metered upstream API key
+  (`INKEEP_API_KEY`), rate limiting and request shaping are the
+  responsibility of the deployment in front of the server (ingress,
+  API gateway, or load balancer). The server does not rate-limit
+  itself.
+- **The only secret is outbound.** `INKEEP_API_KEY` is read from the
+  environment and used solely for the upstream call; it is never
+  returned to clients. Keep it in the deployment's secret store, not
+  in an image layer.
+
+If you run the docs server only on loopback for local development,
+none of this applies — treat it like any other local process.
 
 ## Further reading
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -178,6 +178,10 @@ perform TLS termination; choose one of:
 | **TLS-terminating reverse proxy** | Production. nginx / Caddy / Envoy / cloud LB on the same host terminates TLS and forwards to `127.0.0.1:<port>`. The proxy verifies its peer; the server trusts everything that arrives on the loopback port (subject to the PSK gate). |
 | **mcp-proxy / IDE bridge** | When an IDE-side MCP client speaks stdio but the server runs over HTTP, run an stdio-↔-HTTP bridge on the client host and forward the PSK in `X-Deephaven-PSK`. |
 
+Whichever reverse proxy you choose, ensure it forwards the client's
+`X-Deephaven-PSK` header through to the loopback port — the server still
+applies the PSK gate to proxied requests.
+
 Outbound TLS for Community sessions is configured per session under
 the optional `tls` block on each `community/sessions/<name>.json`
 file. Presence of the block (even `"tls": {}`) enables TLS; the

--- a/ops/docker/mcp-docs/Dockerfile
+++ b/ops/docker/mcp-docs/Dockerfile
@@ -7,9 +7,10 @@
 #
 # REQUIREMENTS:
 #   - The INKEEP_API_KEY environment variable must be set at runtime.
-#     - Locally: via .env file or docker-compose.yml (see docker/mcp-docs/README.md)
+#     - Locally: via .env file or docker-compose.yml (see ops/docker/mcp-docs/README.md)
 #     - In CI/CD: via GitHub secret
-#   - The server listens on port 8000 by default.
+#   - The server listens on port 8001 by default (override with MCP_DOCS_PORT,
+#     or PORT for Cloud Run compatibility).
 #
 # BUILD CONTEXT:
 #   - Build context must be the repository root (.) so all code/assets are available.
@@ -18,14 +19,14 @@
 #   - Standard image/tag: mcp-docs:latest (see Compose and workflow)
 #
 # USAGE:
-#   - Build:   docker build -f docker/mcp-docs/Dockerfile -t mcp-docs:latest .
-#   - Run:     docker run --rm -e INKEEP_API_KEY=your-actual-api-key -p 8000:8000 mcp-docs:latest
-#   - Orchestration: see docker/mcp-docs/docker-compose.yml for multi-service/local dev
+#   - Build:   docker build -f ops/docker/mcp-docs/Dockerfile -t mcp-docs:latest .
+#   - Run:     docker run --rm -e INKEEP_API_KEY=your-actual-api-key -p 8001:8001 mcp-docs:latest
+#   - Orchestration: see ops/docker/mcp-docs/docker-compose.yml for multi-service/local dev
 #   - In CI/CD, see .github/workflows/docker-mcp-docs.yml
 #
 # ENTRYPOINT:
-#   - The default container entrypoint runs the docs server using the 'dh-mcp-docs' script
-#     (see pyproject.toml) with SSE transport.
+#   - The default container entrypoint runs the docs server using the
+#     'dh-mcp-docs-server' script (see pyproject.toml) with streamable-HTTP transport.
 # ------------------------------------------------------------------------------
 
 # Use the official Python slim image for compatibility and minimal size

--- a/scripts/mcp_docs_stress_http.py
+++ b/scripts/mcp_docs_stress_http.py
@@ -20,8 +20,8 @@ Arguments:
     --requests-per-conn   Number of requests per connection (default: 100)
     --url                 Target streamable-HTTP endpoint URL
     --max-errors          Maximum number of errors before stopping the test (default: 5)
-    --rps                 Requests per second limit per connection (default: 0, no limit)
-    --max-response-time   Maximum allowed response time in seconds (default: 1)
+    --rps                 Requests per second limit, shared across all connections (default: 10000; 0 disables the limit)
+    --max-response-time   Maximum allowed response time in seconds (default: 1; 0 disables the check)
 
 Output:
     - Logs warnings and errors for slow responses, bad status codes, or exceptions.
@@ -77,13 +77,13 @@ parser.add_argument(
     "--rps",
     type=float,
     default=10000,
-    help="Requests per second limit per connection (default: 0, no limit)",
+    help="Requests per second limit, shared across all connections (default: 10000; 0 disables the limit).",
 )
 parser.add_argument(
     "--max-response-time",
     type=float,
     default=1,
-    help="Maximum allowed response time in seconds (default: 0, no check)",
+    help="Maximum allowed response time in seconds (default: 1; 0 disables the check).",
 )
 args = parser.parse_args()
 

--- a/scripts/mcp_docs_stress_test.py
+++ b/scripts/mcp_docs_stress_test.py
@@ -1,106 +1,28 @@
 #!/usr/bin/env python3
 """
-MCP Docs Server Stress Test Script
+In-process concurrent load test for the Deephaven MCP docs ``docs_chat`` tool.
 
-This script performs comprehensive stress testing of the Deephaven MCP docs server
-to validate performance, stability, and error handling under concurrent load.
+This script imports the ``docs_chat`` tool function directly (no MCP transport)
+and drives many concurrent calls against it, then reports per-request timing,
+success rates, throughput, and response-length statistics. ``docs_chat`` creates
+its own Inkeep-backed client per request from ``INKEEP_API_KEY``, so the only
+prerequisite is that the key is set in the environment (or a ``.env`` file).
 
-OVERVIEW
-========
-The script runs concurrent requests against the docs_chat tool to:
-- Validate that timeout fixes prevent "Truncated response body" errors
-- Measure response times and throughput under load
-- Test resource cleanup and connection management
-- Generate detailed performance metrics and error reports
+For an HTTP-transport stress test against a deployed endpoint, use
+``scripts/mcp_docs_stress_http.py`` instead.
 
-BACKGROUND
-==========
-This script was created to validate fixes for critical timeout issues that were
-causing "Truncated response body" errors during high-volume usage of the MCP docs
-server. The original issues were caused by:
-- HTTP connection leaks in the OpenAI client
-- Missing lifecycle management in the MCP server
-- Lack of proper resource cleanup
-- Connection pool exhaustion under concurrent load
-
-FIXES VALIDATED
-===============
-This stress test validates the following architectural improvements:
-1. OpenAI client connection cleanup with proper close() method
-2. FastMCP lifecycle management with @asynccontextmanager
-3. Dependency injection pattern for resource management
-4. Advanced HTTP client configuration (timeouts, connection limits, retries)
-5. Proper error handling and logging throughout the request pipeline
-
-USAGE
-=====
-Prerequisites:
-- Set INKEEP_API_KEY environment variable (or use .env file)
-- Run from the project root directory
-- Ensure the MCP server dependencies are installed
-
-Basic usage:
+Usage:
+    # Set INKEEP_API_KEY (in the environment or a .env file), then:
     python scripts/mcp_docs_stress_test.py
 
-The script will:
-- Load environment variables from .env file if available
-- Run 100 concurrent requests to the docs_chat tool
-- Measure response times, success rates, and error patterns
-- Save detailed results to stress_test_results.json
-- Print summary statistics to the console
-
-CONFIGURATION
-=============
-Default settings:
+Defaults:
 - Query: "Write a query to join quotes onto trades."
 - Iterations: 100 concurrent requests
-- Model: inkeep-context-expert (Inkeep API)
-- Base URL: https://api.inkeep.com/v1
 
-To modify test parameters, edit the main() function or create a custom version.
-
-OUTPUT
-======
-The script generates:
-1. Real-time logging of request progress with timestamps
-2. Summary statistics (success rate, response times, throughput)
-3. Detailed JSON results file with per-request metrics
-4. Error analysis for any failed requests
-
-PERFORMANCE EXPECTATIONS
-========================
-With the timeout fixes in place, expected results:
-- 100% success rate (no "Truncated response body" errors)
-- Response times: 15-180 seconds per request (depends on query complexity)
-- Throughput: 0.5-2.0 requests/second (limited by API rate limits)
-- Zero connection leaks or resource exhaustion errors
-
-TROUBLESHOOTING
-===============
-Common issues:
-- "INKEEP_API_KEY environment variable must be set" → Set API key in .env file
-- "Invalid model" error → Verify model name matches server configuration
-- Import errors → Run from project root with proper Python environment
-- Connection timeouts → Check network connectivity and API key validity
-
-DEVELOPMENT NOTES
-=================
-This script uses the new dependency injection architecture introduced to fix
-the timeout issues. It creates a proper context with the OpenAI client and
-passes it to the docs_chat function, matching the production MCP server pattern.
-
-The script includes proper resource cleanup to prevent connection leaks and
-uses the same OpenAI client configuration as the production server for
-accurate testing results.
-
-For more information on the timeout fixes and architectural changes, see:
-- src/deephaven_mcp/openai.py (OpenAI client with connection management)
-- src/deephaven_mcp/mcp_docs_server/_mcp.py (MCP server with lifecycle management)
-- tests/mcp_docs_server/ (comprehensive unit tests with 100% coverage)
-
-Author: Deephaven MCP Development Team
-Created: 2025-01-23 (during timeout issue resolution)
-Last Updated: 2025-01-23
+Output:
+- Real-time logging of progress.
+- Summary statistics (success rate, response times, throughput) to the console.
+- Detailed per-request metrics written to ``stress_test_results.json``.
 """
 
 import asyncio
@@ -109,7 +31,7 @@ import os
 import statistics
 import sys
 import time
-from typing import Any, Dict, List
+from typing import Any
 
 # Load environment variables from .env file
 try:
@@ -127,70 +49,21 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
 try:
     from deephaven_mcp.mcp_docs_server._mcp import docs_chat
-    from deephaven_mcp.openai import OpenAIClient
-except ImportError as e:
-    print(f"Error: Could not import required modules: {e}")
+except (ImportError, RuntimeError) as e:
+    # ``docs_chat``'s module reads INKEEP_API_KEY at import time and raises
+    # RuntimeError if it is unset, so a missing key surfaces here as an import
+    # failure rather than a per-request error.
+    print(f"Error: Could not import docs_chat: {e}")
     print(
-        "Make sure you're running from the project root and dependencies are installed."
+        "Make sure you're running from the project root, dependencies are "
+        "installed, and INKEEP_API_KEY is set."
     )
     sys.exit(1)
 
-# Global client instance for the stress test
-_client = None
 
-
-async def get_client():
-    """
-    Get or create the OpenAI client instance.
-
-    Creates a singleton OpenAI client configured to match the production
-    MCP docs server settings. Uses the same model, base URL, and advanced
-    HTTP client configuration that was implemented to fix timeout issues.
-
-    Returns:
-        OpenAIClient: Configured client instance for Inkeep API communication.
-
-    Raises:
-        RuntimeError: If INKEEP_API_KEY environment variable is not set.
-    """
-    global _client
-    if _client is None:
-        api_key = os.getenv("INKEEP_API_KEY")
-        if not api_key:
-            raise RuntimeError(
-                "INKEEP_API_KEY environment variable must be set. "
-                "Add it to your .env file or set it in your environment."
-            )
-
-        _client = OpenAIClient(
-            api_key=api_key,
-            base_url="https://api.inkeep.com/v1",
-            model="inkeep-context-expert",
-        )
-    return _client
-
-
-async def cleanup_client():
-    """
-    Clean up the OpenAI client and close HTTP connections.
-
-    This is critical for preventing connection leaks that were causing
-    the original "Truncated response body" errors. The cleanup ensures
-    all HTTP connections are properly closed.
-    """
-    global _client
-    if _client:
-        await _client.close()
-        _client = None
-
-
-async def run_single_query(query: str, iteration: int) -> Dict[str, Any]:
+async def run_single_query(query: str, iteration: int) -> dict[str, Any]:
     """
     Run a single docs_chat query and measure timing and success.
-
-    This function replicates the exact calling pattern used by MCP clients,
-    including the dependency injection context that was implemented to fix
-    the architectural inconsistencies that contributed to timeout issues.
 
     Args:
         query: The documentation query to send to the docs_chat tool.
@@ -202,13 +75,10 @@ async def run_single_query(query: str, iteration: int) -> Dict[str, Any]:
     start_time = time.time()
 
     try:
-        # Get the OpenAI client and create context (matches production pattern)
-        client = await get_client()
-        context = {"inkeep_client": client}
-
-        # Call the docs_chat function with proper dependency injection
+        # docs_chat ignores the context for client creation (it builds its own
+        # Inkeep client per request from INKEEP_API_KEY); pass an empty context.
         result = await docs_chat(
-            context=context,
+            context={},
             prompt=query,
             history=None,
             deephaven_core_version=None,
@@ -219,12 +89,14 @@ async def run_single_query(query: str, iteration: int) -> Dict[str, Any]:
         end_time = time.time()
         duration_ms = (end_time - start_time) * 1000
 
+        success = bool(result.get("success"))
+        response = result.get("response", "") or ""
         return {
             "iteration": iteration,
-            "success": True,
+            "success": success,
             "duration_ms": duration_ms,
-            "response_length": len(result) if result else 0,
-            "error": None,
+            "response_length": len(response),
+            "error": None if success else result.get("error"),
         }
 
     except Exception as e:
@@ -242,13 +114,12 @@ async def run_single_query(query: str, iteration: int) -> Dict[str, Any]:
 
 async def stress_test_docs_chat(
     query: str, num_iterations: int = 100
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Run comprehensive stress test with specified number of concurrent iterations.
 
     This function executes the core stress test by running multiple concurrent
-    requests and collecting detailed performance metrics. The concurrent execution
-    pattern replicates the conditions that originally caused timeout issues.
+    requests and collecting detailed performance metrics.
 
     Args:
         query: The documentation query to test with.
@@ -263,7 +134,7 @@ async def stress_test_docs_chat(
 
     start_time = time.time()
 
-    # Run all queries concurrently (this pattern exposed the original timeout issues)
+    # Run all queries concurrently.
     tasks = [run_single_query(query, i + 1) for i in range(num_iterations)]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -381,8 +252,7 @@ async def main():
     """
     Main function to execute the stress test.
 
-    Configures and runs the stress test, saves results to JSON file,
-    and ensures proper cleanup of resources.
+    Configures and runs the stress test and saves results to a JSON file.
     """
     # Test configuration
     query = "Write a query to join quotes onto trades."
@@ -392,8 +262,7 @@ async def main():
         print("=" * 70)
         print("MCP DOCS SERVER STRESS TEST")
         print("=" * 70)
-        print(f"This test validates the timeout fixes implemented to prevent")
-        print(f"'Truncated response body' errors during concurrent usage.")
+        print("Concurrent in-process load test of the docs_chat tool.")
         print("=" * 70)
 
         results = await stress_test_docs_chat(query, iterations)
@@ -408,9 +277,7 @@ async def main():
         # Provide interpretation of results
         success_rate = results["summary"]["success_rate_percent"]
         if success_rate == 100.0:
-            print(
-                "\n✅ EXCELLENT: 100% success rate - timeout fixes are working perfectly!"
-            )
+            print(f"\n✅ EXCELLENT: 100% success rate")
         elif success_rate >= 95.0:
             print(
                 f"\n✅ GOOD: {success_rate:.1f}% success rate - minor issues detected"
@@ -430,9 +297,6 @@ async def main():
     except Exception as e:
         print(f"Stress test failed with error: {e}")
         return 1
-    finally:
-        # Critical: Clean up the OpenAI client to prevent connection leaks
-        await cleanup_client()
 
     return 0
 

--- a/scripts/mcp_docs_test_client.py
+++ b/scripts/mcp_docs_test_client.py
@@ -21,9 +21,10 @@ import asyncio
 import json
 import logging
 import sys
+from contextlib import AsyncExitStack
 
-import httpx
-from mcp.client.streamable_http import streamable_http_client
+from mcp import ClientSession
+from mcp.client.streamable_http import create_mcp_http_client, streamable_http_client
 
 # Configure logging
 logging.basicConfig(
@@ -97,55 +98,52 @@ async def main():
     _LOGGER.info(f"Connecting to MCP Docs server via streamable-http")
     _LOGGER.info(f"Server URL: {args.url}")
 
-    headers = {}
-    if args.token:
-        headers["Authorization"] = f"Bearer {args.token}"
+    async with AsyncExitStack() as stack:
+        # Only pre-build a client when we need to inject the Authorization
+        # header (Bearer token for a proxied/prod deployment). Otherwise let
+        # the library create its default client with recommended MCP timeouts.
+        http_client = None
+        if args.token:
+            http_client = await stack.enter_async_context(
+                create_mcp_http_client(
+                    headers={"Authorization": f"Bearer {args.token}"}
+                )
+            )
+        read, write, _get_session_id = await stack.enter_async_context(
+            streamable_http_client(args.url, http_client=http_client)
+        )
+        session = await stack.enter_async_context(ClientSession(read, write))
 
-    http_client = httpx.AsyncClient(headers=headers) if headers else None
+        init_result = await session.initialize()
+        _LOGGER.info(f"Connected to MCP server: {init_result!r}")
 
-    try:
-        async with streamable_http_client(args.url, http_client=http_client) as (
-            read,
-            write,
-        ):
-            async with read, write:
-                await write.send_initialize()
-                result = await read.recv_initialize()
-                _LOGGER.info(f"Connected to MCP server: {result}")
+        # List tools
+        tools_result = await session.list_tools()
+        tool_names = [t.name for t in tools_result.tools]
+        _LOGGER.info(f"Available tools: {tool_names}")
 
-                session = await write.get_result(read)
+        if "docs_chat" not in tool_names:
+            _LOGGER.error("docs_chat tool not found on server!")
+            print("docs_chat tool not found on server!", file=sys.stderr)
+            sys.exit(1)
 
-                # List tools
-                tools_result = await session.list_tools()
-                tools = tools_result.tools
-                tool_names = [t.name for t in tools]
-                _LOGGER.info(f"Available tools: {tool_names}")
+        # Call docs_chat
+        _LOGGER.info(f"Calling docs_chat with prompt: {args.prompt!r}")
+        if history:
+            _LOGGER.info(f"Using chat history with {len(history)} messages")
 
-                if "docs_chat" not in tool_names:
-                    _LOGGER.error("docs_chat tool not found on server!")
-                    print("docs_chat tool not found on server!", file=sys.stderr)
-                    sys.exit(1)
-
-                # Call docs_chat
-                _LOGGER.info(f"Calling docs_chat with prompt: {args.prompt!r}")
-                if history:
-                    _LOGGER.info(f"Using chat history with {len(history)} messages")
-
-                try:
-                    call_args = {"prompt": args.prompt}
-                    if history:
-                        call_args["history"] = history
-                    result = await session.call_tool("docs_chat", arguments=call_args)
-                    _LOGGER.info("docs_chat call completed successfully")
-                    print("\ndocs_chat result:")
-                    print(result.content[0].text if result.content else str(result))
-                except Exception as e:
-                    _LOGGER.error(f"Error calling docs_chat: {e}")
-                    print(f"Error calling docs_chat: {e}", file=sys.stderr)
-                    sys.exit(3)
-    finally:
-        if http_client:
-            await http_client.aclose()
+        try:
+            call_args = {"prompt": args.prompt}
+            if history:
+                call_args["history"] = history
+            result = await session.call_tool("docs_chat", arguments=call_args)
+            _LOGGER.info("docs_chat call completed successfully")
+            print("\ndocs_chat result:")
+            print(result.content[0].text if result.content else str(result))
+        except Exception as e:
+            _LOGGER.error(f"Error calling docs_chat: {e}")
+            print(f"Error calling docs_chat: {e}", file=sys.stderr)
+            sys.exit(3)
 
 
 if __name__ == "__main__":

--- a/src/deephaven_mcp/cli/_commands/session.py
+++ b/src/deephaven_mcp/cli/_commands/session.py
@@ -1,0 +1,227 @@
+"""``dh-mcp session`` noun group: inspect running Deephaven sessions.
+
+Verbs: ``credentials``.
+"""
+
+from __future__ import annotations
+
+__all__ = ["session"]
+
+import json
+from typing import Any
+
+import click
+from mcp.types import CallToolResult, TextContent
+
+from deephaven_mcp.cli._async import run_async
+from deephaven_mcp.cli._commands.shared import acquire_daemon, registry_corrupt_message
+from deephaven_mcp.cli._errors import CliError, ErrorCode
+from deephaven_mcp.cli._format import format_output
+from deephaven_mcp.cli._help import (
+    HelpfulGroup,
+    OutputField,
+    OutputSpec,
+    build_help,
+)
+from deephaven_mcp.cli._mcp_client import McpClient, McpClientError
+from deephaven_mcp.cli._runtime import Runtime
+from deephaven_mcp.daemon_registry import DaemonRegistryEntry
+
+_CREDENTIALS_TOOL = "session_community_credentials"
+"""Name of the MCP tool the ``credentials`` verb wraps."""
+
+_CREDENTIAL_FIELDS = (
+    "auth_type",
+    "auth_token",
+    "connection_url",
+    "connection_url_with_auth",
+)
+"""Payload keys rendered on success, single-sourced from the wrapped tool."""
+
+
+@click.group(cls=HelpfulGroup)
+def session() -> None:
+    """Inspect Deephaven sessions hosted by the daemon.
+
+    These commands connect to the daemon (auto-starting it unless
+    --no-auto-start is set) and speak MCP: 'credentials' fetches the
+    browser-login credentials for one Community session.
+    """
+
+
+_EXIT_CODES = (
+    (0, "success"),
+    (2, "user-facing failure (config, daemon, or MCP request)"),
+)
+
+# credentials exits 3 when the wrapped tool reports failure (retrieval
+# disabled by configuration, session not found, or wrong session type).
+_CREDENTIALS_EXIT_CODES = (
+    *_EXIT_CODES,
+    (3, "the credentials tool reported an error"),
+)
+
+# Error codes the shared _acquire path can raise (daemon lifecycle +
+# MCP transport), single-sourced so the verb cannot drift from what
+# _acquire actually raises.
+_ACQUIRE_ERROR_CODES = (
+    ("daemon_not_running", "No daemon and --no-auto-start was set."),
+    ("daemon_startup_timeout", "Auto-started daemon did not register in time."),
+    ("daemon_registry_corrupt", "daemon.json exists but cannot be parsed."),
+    ("mcp_request_failed", "The MCP transport reported an error."),
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+async def _acquire(runtime: Runtime, *, retry_command: str) -> DaemonRegistryEntry:
+    """Acquire a live daemon for a ``dh-mcp session`` subcommand.
+
+    Args:
+        runtime (Runtime): The active CLI runtime.
+        retry_command (str): The command rendered into the
+            corrupt-registry recovery hint for the operator to re-run.
+
+    Returns:
+        DaemonRegistryEntry: The validated registry entry for the
+            running daemon.
+
+    Raises:
+        CliError: When the daemon cannot be acquired (startup timeout,
+            client error, or corrupt registry).
+    """
+    return await acquire_daemon(
+        runtime,
+        auto_start=runtime.config.cli.daemon.auto_start,
+        client_error_code=ErrorCode.DAEMON_NOT_RUNNING,
+        on_registry_corrupt=lambda exc: CliError(
+            registry_corrupt_message(exc, retry_command=retry_command),
+            code=ErrorCode.DAEMON_REGISTRY_CORRUPT,
+        ),
+    )
+
+
+def _payload(result: CallToolResult) -> dict[str, Any]:
+    """Extract the JSON payload dict returned by the credentials tool.
+
+    Prefers the structured result; falls back to parsing the first
+    JSON text block when the server does not populate one.
+
+    Args:
+        result (CallToolResult): The raw MCP call result.
+
+    Returns:
+        dict[str, Any]: The decoded payload dict.
+
+    Raises:
+        CliError: When no structured dict payload can be recovered.
+    """
+    if isinstance(result.structuredContent, dict):
+        return result.structuredContent
+    for block in result.content:
+        if isinstance(block, TextContent):
+            try:
+                parsed = json.loads(block.text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                return parsed
+    raise CliError(
+        f"{_CREDENTIALS_TOOL!r} returned no structured result.",
+        code=ErrorCode.MCP_REQUEST_FAILED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# credentials
+# ---------------------------------------------------------------------------
+
+_OUTPUT_CREDENTIALS = OutputSpec(
+    "object",
+    (
+        OutputField("auth_type", "string", "Authentication type, uppercased."),
+        OutputField(
+            "auth_token",
+            "string",
+            "Plaintext auth token (empty for anonymous auth).",
+        ),
+        OutputField(
+            "connection_url", "string", "Base server URL without auth parameters."
+        ),
+        OutputField(
+            "connection_url_with_auth",
+            "string",
+            "Browser-ready URL including the auth token when applicable.",
+        ),
+    ),
+)
+
+
+@session.command(
+    "credentials",
+    output_spec=_OUTPUT_CREDENTIALS,
+    help=build_help(
+        summary="Print one Community session's browser-login credentials.",
+        description=(
+            "Wraps the session_community_credentials MCP tool. The output "
+            "contains a PLAINTEXT auth token by design (unlike 'dh-mcp daemon', "
+            "which redacts secrets) so you can open the session in a browser. "
+            "Retrieval is gated by security.credential_retrieval_mode in "
+            "community/settings.json, which defaults to 'none'; when retrieval "
+            "is disabled, or the session is missing or not a Community session, "
+            "the command exits 3 with the tool's explanation."
+        ),
+        arguments=(
+            (
+                "SESSION_ID",
+                "Community session id, e.g. 'community:community:my-session'. "
+                "Run 'dh-mcp tool call sessions_list' to discover ids.",
+            ),
+        ),
+        output=_OUTPUT_CREDENTIALS,
+        examples=(
+            "$ dh-mcp session credentials community:community:my-session",
+            "$ dh-mcp -o json session credentials community:community:my-session",
+        ),
+        see_also=("dh-mcp tool call sessions_list",),
+        exit_codes=_CREDENTIALS_EXIT_CODES,
+        error_codes=(
+            (
+                "tool_returned_error",
+                "Credential retrieval is disabled or the session is "
+                "missing/ineligible (exit 3).",
+            ),
+            *_ACQUIRE_ERROR_CODES,
+        ),
+    ),
+)
+@click.argument("session_id")
+@click.pass_obj
+@run_async
+async def session_credentials(runtime: Runtime, session_id: str) -> None:
+    """Fetch one Community session's browser-login credentials."""
+    handle = await _acquire(runtime, retry_command="dh-mcp session credentials")
+
+    try:
+        async with McpClient(
+            handle,
+            request_timeout_seconds=runtime.config.cli.request.timeouts.default_seconds,
+        ) as client:
+            result = await client.call_tool(
+                _CREDENTIALS_TOOL, {"session_id": session_id}
+            )
+    except McpClientError as exc:
+        raise CliError(str(exc), code=ErrorCode.MCP_REQUEST_FAILED) from exc
+
+    payload = _payload(result)
+    if not payload.get("success", False):
+        raise CliError(
+            str(payload.get("error") or "Credential retrieval failed."),
+            code=ErrorCode.TOOL_RETURNED_ERROR,
+        )
+
+    credentials = {field: payload.get(field) for field in _CREDENTIAL_FIELDS}
+    click.echo(format_output(credentials, output=runtime.config.cli.output.format))

--- a/src/deephaven_mcp/cli/_main.py
+++ b/src/deephaven_mcp/cli/_main.py
@@ -30,6 +30,7 @@ from deephaven_mcp.cli._async import run_async
 from deephaven_mcp.cli._commands.config import config as config_group
 from deephaven_mcp.cli._commands.daemon import daemon as daemon_group
 from deephaven_mcp.cli._commands.introspect import introspect as introspect_command
+from deephaven_mcp.cli._commands.session import session as session_group
 from deephaven_mcp.cli._commands.tool import tool as tool_group
 from deephaven_mcp.cli._errors import CliError, ErrorCode, render_error
 from deephaven_mcp.cli._format import OUTPUT_MODES, OutputMode
@@ -267,6 +268,7 @@ async def cli(
 # Register noun groups + meta commands on the root.
 cli.add_command(daemon_group)
 cli.add_command(tool_group)
+cli.add_command(session_group)
 cli.add_command(config_group)
 cli.add_command(introspect_command)
 

--- a/src/deephaven_mcp/mcp_systems_server/_tools/pq.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/pq.py
@@ -700,7 +700,7 @@ async def _setup_batch_pq_operation(
             {"success": False, "error": parse_error, "isError": True},
         )
     # parse_error is None implies system_name is set
-    if system_name is None:  # pragma: no cover - defensive
+    if system_name is None:
         raise InternalError(
             "Internal invariant violated: _validate_and_parse_pq_ids returned "
             "system_name=None without an error."

--- a/src/deephaven_mcp/mcp_systems_server/_tools/script.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/script.py
@@ -92,22 +92,18 @@ async def session_script_run(
         _LOGGER.debug(
             f"[mcp_systems_server:session_script_run] Validating script parameters for session '{session_id}'"
         )
-        if script is None and script_path is None:
-            _LOGGER.warning(
-                "[mcp_systems_server:session_script_run] No script or script_path provided. Returning error."
-            )
-            result["error"] = "Must provide either script or script_path."
-            result["isError"] = True
-            return result
-
         if script is None:
+            if script_path is None:
+                _LOGGER.warning(
+                    "[mcp_systems_server:session_script_run] No script or script_path provided. Returning error."
+                )
+                result["error"] = "Must provide either script or script_path."
+                result["isError"] = True
+                return result
+
             _LOGGER.info(
                 f"[mcp_systems_server:session_script_run] Reading script from file: {script_path!r}"
             )
-            if script_path is None:
-                raise RuntimeError(
-                    "Internal error: script_path is None after prior guard"
-                )  # pragma: no cover
             _LOGGER.debug(
                 f"[mcp_systems_server:session_script_run] Opening script file '{script_path}' for reading"
             )

--- a/src/deephaven_mcp/mcp_systems_server/_tools/session_enterprise.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/session_enterprise.py
@@ -60,9 +60,7 @@ async def _collect_one_enterprise_system_status(
     )
     is_alive = await factory_manager.is_alive()
 
-    if (
-        multi_config.enterprise is None or system not in multi_config.enterprise.systems
-    ):  # pragma: no cover - defensive; get_enterprise_registry would have raised first
+    if multi_config.enterprise is None or system not in multi_config.enterprise.systems:
         raise InvalidSessionNameError(
             f"Enterprise system {system!r} is not configured."
         )
@@ -508,7 +506,7 @@ async def session_enterprise_create(
         )
 
         # Get enterprise system configuration from the lifespan-loaded multi-config.
-        if (  # pragma: no cover - defensive; get_enterprise_registry would have raised first
+        if (
             multi_config.enterprise is None
             or system_name not in multi_config.enterprise.systems
         ):

--- a/src/deephaven_mcp/resource_manager/_registry_enterprise.py
+++ b/src/deephaven_mcp/resource_manager/_registry_enterprise.py
@@ -328,7 +328,7 @@ class EnterpriseSessionRegistry(MutableSessionRegistry):
             InternalError: If the registry has not been initialized.
         """
         self._check_initialized()
-        if self._factory_manager is None:  # pragma: no cover - defensive
+        if self._factory_manager is None:
             raise InternalError(
                 f"{self.__class__.__name__} factory manager is not available; "
                 "initialize() did not run to completion."

--- a/tests/cli/_commands/test_session.py
+++ b/tests/cli/_commands/test_session.py
@@ -1,0 +1,284 @@
+"""Tests for ``deephaven_mcp.cli._commands.session``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from click.testing import CliRunner
+from mcp.types import CallToolResult, ImageContent, TextContent
+
+from deephaven_mcp.cli import _main
+from deephaven_mcp.cli._commands import session as session_mod
+from deephaven_mcp.cli._commands import shared as shared_mod
+from deephaven_mcp.cli._commands.session import _payload
+from deephaven_mcp.cli._daemon import (
+    DaemonClientError,
+    DaemonStartupTimeoutError,
+)
+from deephaven_mcp.cli._errors import CliError, ErrorCode
+from deephaven_mcp.cli._main import cli
+from deephaven_mcp.cli._mcp_client import McpClientError
+from deephaven_mcp.cli._runtime import Runtime
+from deephaven_mcp.daemon_registry import RegistryCorruptError
+
+from .._helpers import fake_load_runtime, make_entry, make_runtime
+
+_SESSION_ID = "community:community:my-session"
+
+_SUCCESS_PAYLOAD = {
+    "success": True,
+    "auth_type": "PSK",
+    "auth_token": "tok-123",
+    "connection_url": "http://localhost:45123",
+    "connection_url_with_auth": "http://localhost:45123/?psk=tok-123",
+}
+
+
+def _invoke(args: list[str], runtime: Runtime):
+    runner = CliRunner()
+    with patch.object(_main, "load_runtime", fake_load_runtime(runtime)):
+        return runner.invoke(cli, args)
+
+
+def _fake_client(result: CallToolResult) -> AsyncMock:
+    fake = AsyncMock()
+    fake.__aenter__.return_value = fake
+    fake.__aexit__.return_value = None
+    fake.call_tool.return_value = result
+    return fake
+
+
+def _success_result() -> CallToolResult:
+    return CallToolResult(
+        content=[TextContent(type="text", text=json.dumps(_SUCCESS_PAYLOAD))],
+        structuredContent=_SUCCESS_PAYLOAD,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _payload
+# ---------------------------------------------------------------------------
+
+
+def test_payload_prefers_structured_content() -> None:
+    result = CallToolResult(
+        content=[TextContent(type="text", text="ignored")],
+        structuredContent={"success": True, "auth_token": "abc"},
+    )
+    assert _payload(result) == {"success": True, "auth_token": "abc"}
+
+
+def test_payload_falls_back_to_json_text_block() -> None:
+    result = CallToolResult(
+        content=[TextContent(type="text", text=json.dumps({"success": False}))],
+    )
+    assert _payload(result) == {"success": False}
+
+
+def test_payload_skips_non_json_and_non_dict_text_blocks() -> None:
+    result = CallToolResult(
+        content=[
+            TextContent(type="text", text="not json"),
+            TextContent(type="text", text="[1, 2, 3]"),
+            TextContent(type="text", text=json.dumps({"ok": 1})),
+        ],
+    )
+    assert _payload(result) == {"ok": 1}
+
+
+def test_payload_ignores_non_text_blocks() -> None:
+    result = CallToolResult(
+        content=[
+            ImageContent(type="image", data="Zg==", mimeType="image/png"),
+            TextContent(type="text", text=json.dumps({"ok": 2})),
+        ],
+    )
+    assert _payload(result) == {"ok": 2}
+
+
+def test_payload_raises_when_no_dict_payload() -> None:
+    result = CallToolResult(content=[])
+    with pytest.raises(CliError) as excinfo:
+        _payload(result)
+    assert excinfo.value.code is ErrorCode.MCP_REQUEST_FAILED
+
+
+# ---------------------------------------------------------------------------
+# session credentials — success
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_success_human(tmp_path: Path) -> None:
+    rt = make_runtime(tmp_path)
+    fake = _fake_client(_success_result())
+    with (
+        patch.object(
+            shared_mod, "get_or_start_daemon", AsyncMock(return_value=make_entry())
+        ),
+        patch.object(session_mod, "McpClient", return_value=fake),
+    ):
+        result = _invoke(["session", "credentials", _SESSION_ID], rt)
+    assert result.exit_code == 0
+    assert "tok-123" in result.output
+    assert "connection_url_with_auth" in result.output
+    fake.call_tool.assert_awaited_once()
+    args, _ = fake.call_tool.await_args
+    assert args[0] == "session_community_credentials"
+    assert args[1] == {"session_id": _SESSION_ID}
+
+
+def test_credentials_success_json_excludes_success_key(tmp_path: Path) -> None:
+    rt = make_runtime(tmp_path)
+    fake = _fake_client(_success_result())
+    with (
+        patch.object(
+            shared_mod, "get_or_start_daemon", AsyncMock(return_value=make_entry())
+        ),
+        patch.object(session_mod, "McpClient", return_value=fake),
+    ):
+        result = _invoke(["-o", "json", "session", "credentials", _SESSION_ID], rt)
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload == {
+        "auth_type": "PSK",
+        "auth_token": "tok-123",
+        "connection_url": "http://localhost:45123",
+        "connection_url_with_auth": "http://localhost:45123/?psk=tok-123",
+    }
+    assert "success" not in payload
+
+
+def test_credentials_success_yaml(tmp_path: Path) -> None:
+    rt = make_runtime(tmp_path)
+    fake = _fake_client(_success_result())
+    with (
+        patch.object(
+            shared_mod, "get_or_start_daemon", AsyncMock(return_value=make_entry())
+        ),
+        patch.object(session_mod, "McpClient", return_value=fake),
+    ):
+        result = _invoke(["-o", "yaml", "session", "credentials", _SESSION_ID], rt)
+    assert result.exit_code == 0
+    assert "auth_token: tok-123" in result.output
+
+
+# ---------------------------------------------------------------------------
+# session credentials — tool-level failure (exit 3)
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_gate_disabled_exits_3(tmp_path: Path) -> None:
+    rt = make_runtime(tmp_path)
+    disabled = {
+        "success": False,
+        "error": "Credential retrieval is disabled (mode='none').",
+        "isError": True,
+    }
+    fake = _fake_client(
+        CallToolResult(
+            content=[TextContent(type="text", text=json.dumps(disabled))],
+            structuredContent=disabled,
+        )
+    )
+    with (
+        patch.object(
+            shared_mod, "get_or_start_daemon", AsyncMock(return_value=make_entry())
+        ),
+        patch.object(session_mod, "McpClient", return_value=fake),
+    ):
+        result = _invoke(["session", "credentials", _SESSION_ID], rt)
+    assert result.exit_code == 3
+
+
+def test_credentials_failure_without_error_message_exits_3(tmp_path: Path) -> None:
+    rt = make_runtime(tmp_path)
+    fake = _fake_client(
+        CallToolResult(
+            content=[TextContent(type="text", text=json.dumps({"success": False}))],
+            structuredContent={"success": False},
+        )
+    )
+    with (
+        patch.object(
+            shared_mod, "get_or_start_daemon", AsyncMock(return_value=make_entry())
+        ),
+        patch.object(session_mod, "McpClient", return_value=fake),
+    ):
+        result = _invoke(["session", "credentials", _SESSION_ID], rt)
+    assert result.exit_code == 3
+
+
+def test_credentials_no_structured_payload_exits_2(tmp_path: Path) -> None:
+    rt = make_runtime(tmp_path)
+    fake = _fake_client(CallToolResult(content=[]))
+    with (
+        patch.object(
+            shared_mod, "get_or_start_daemon", AsyncMock(return_value=make_entry())
+        ),
+        patch.object(session_mod, "McpClient", return_value=fake),
+    ):
+        result = _invoke(["session", "credentials", _SESSION_ID], rt)
+    assert result.exit_code == 2
+
+
+# ---------------------------------------------------------------------------
+# session credentials — daemon / transport failures (exit 2)
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_daemon_failure(tmp_path: Path) -> None:
+    rt = make_runtime(tmp_path)
+    with patch.object(
+        shared_mod,
+        "get_or_start_daemon",
+        AsyncMock(side_effect=DaemonClientError("nope")),
+    ):
+        result = _invoke(["session", "credentials", _SESSION_ID], rt)
+    assert result.exit_code == 2
+
+
+def test_credentials_startup_timeout(tmp_path: Path) -> None:
+    rt = make_runtime(tmp_path)
+    with patch.object(
+        shared_mod,
+        "get_or_start_daemon",
+        AsyncMock(side_effect=DaemonStartupTimeoutError("slow")),
+    ):
+        result = _invoke(["session", "credentials", _SESSION_ID], rt)
+    assert result.exit_code == 2
+
+
+def test_credentials_registry_corrupt(tmp_path: Path) -> None:
+    rt = make_runtime(tmp_path)
+    with patch.object(
+        shared_mod,
+        "get_or_start_daemon",
+        AsyncMock(side_effect=RegistryCorruptError("bad json")),
+    ):
+        result = _invoke(["session", "credentials", _SESSION_ID], rt)
+    assert result.exit_code == 2
+    # The corrupt-registry path renders this command's own recovery hint.
+    assert "dh-mcp daemon reset" in result.output
+
+
+def test_credentials_mcp_failure(tmp_path: Path) -> None:
+    rt = make_runtime(tmp_path)
+    fake = AsyncMock()
+    fake.__aenter__.side_effect = McpClientError("boom")
+    with (
+        patch.object(
+            shared_mod, "get_or_start_daemon", AsyncMock(return_value=make_entry())
+        ),
+        patch.object(session_mod, "McpClient", return_value=fake),
+    ):
+        result = _invoke(["session", "credentials", _SESSION_ID], rt)
+    assert result.exit_code == 2
+
+
+def test_credentials_requires_session_id(tmp_path: Path) -> None:
+    rt = make_runtime(tmp_path)
+    result = _invoke(["session", "credentials"], rt)
+    assert result.exit_code == 2

--- a/tests/mcp_systems_server/_tools/test_pq.py
+++ b/tests/mcp_systems_server/_tools/test_pq.py
@@ -125,6 +125,7 @@ def create_mock_pq_info(serial, name, state="RUNNING", heap_size=8.0):
 
 import deephaven_mcp.mcp_systems_server._tools.pq as _pq_module
 from deephaven_mcp import config
+from deephaven_mcp._exceptions import InternalError
 
 # Capture real protobuf class at collection time — before any session-scoped fixture
 # patches sys.modules["deephaven_enterprise.proto"] with a mock module.
@@ -151,6 +152,7 @@ from deephaven_mcp.mcp_systems_server._tools.pq import (
     _format_worker_protocol,
     _parse_pq_id,
     _pq_state_category,
+    _setup_batch_pq_operation,
     _validate_and_parse_pq_ids,
     _validate_max_concurrent,
     pq_create,
@@ -2381,6 +2383,24 @@ def test_validate_and_parse_pq_ids_rejects_mixed_systems():
     assert system_name is None
     assert error is not None
     assert "same" in error.lower()
+
+
+@pytest.mark.asyncio
+async def test_setup_batch_pq_operation_raises_on_none_system_name_without_error():
+    """``_setup_batch_pq_operation`` raises ``InternalError`` when the parser
+    returns ``system_name=None`` with no parse error — a broken invariant."""
+    with patch.object(
+        _pq_module,
+        "_validate_and_parse_pq_ids",
+        return_value=([("system:12345", 12345)], None, None),
+    ):
+        with pytest.raises(InternalError, match="Internal invariant violated"):
+            await _setup_batch_pq_operation(
+                MagicMock(),
+                "system:12345",
+                "pq_delete",
+                max_concurrent=1,
+            )
 
 
 # Note: ``test_parse_pq_id_*`` variants live further down in this module;

--- a/tests/mcp_systems_server/_tools/test_session_enterprise.py
+++ b/tests/mcp_systems_server/_tools/test_session_enterprise.py
@@ -15,10 +15,11 @@ from conftest import (
 )
 
 from deephaven_mcp import config
-from deephaven_mcp._exceptions import RegistryItemNotFoundError
+from deephaven_mcp._exceptions import InvalidSessionNameError, RegistryItemNotFoundError
 from deephaven_mcp.mcp_systems_server._tools.session_enterprise import (
     _check_session_id_available,
     _check_session_limit,
+    _collect_one_enterprise_system_status,
     _generate_session_name_if_none,
     _resolve_session_parameters,
     enterprise_systems_status,
@@ -38,6 +39,50 @@ from deephaven_mcp.resource_manager import (
 )
 
 _TEST_SYSTEM_NAME = "system"
+
+_SE_MODULE = "deephaven_mcp.mcp_systems_server._tools.session_enterprise"
+
+
+@pytest.mark.asyncio
+async def test_collect_one_enterprise_system_status_raises_when_system_missing_from_config():
+    """``_collect_one_enterprise_system_status`` raises when the registry
+    resolves a system that the loaded multi-config does not contain — a
+    registry/config inconsistency that bypasses ``get_enterprise_registry``."""
+    mock_registry = MagicMock(spec=EnterpriseSessionRegistry)
+    mock_registry.system_name = "prod"
+    mock_registry.get_all = AsyncMock(return_value=MagicMock())
+    mock_registry.factory_manager.liveness_status = AsyncMock(
+        return_value=(MagicMock(), None)
+    )
+    mock_registry.factory_manager.is_alive = AsyncMock(return_value=True)
+
+    multi_config = SimpleNamespace(enterprise=None)
+
+    with (
+        patch(f"{_SE_MODULE}.get_enterprise_registry", return_value=mock_registry),
+        patch(f"{_SE_MODULE}.get_multi_config", return_value=multi_config),
+    ):
+        with pytest.raises(InvalidSessionNameError, match="not configured"):
+            await _collect_one_enterprise_system_status(MagicMock(), "prod", False)
+
+
+@pytest.mark.asyncio
+async def test_session_enterprise_create_system_missing_from_config_returns_error():
+    """``session_enterprise_create`` returns an error response when the
+    registry resolves a system absent from the loaded multi-config — a
+    registry/config inconsistency that bypasses ``get_enterprise_registry``."""
+    mock_registry = MagicMock(spec=EnterpriseSessionRegistry)
+    multi_config = SimpleNamespace(enterprise=None)
+
+    with (
+        patch(f"{_SE_MODULE}.get_enterprise_registry", return_value=mock_registry),
+        patch(f"{_SE_MODULE}.get_multi_config", return_value=multi_config),
+    ):
+        result = await session_enterprise_create(MagicMock(), "prod", None)
+
+    assert result["success"] is False
+    assert result["isError"] is True
+    assert "not configured" in result["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/resource_manager/test__registry_enterprise.py
+++ b/tests/resource_manager/test__registry_enterprise.py
@@ -430,6 +430,16 @@ def test_factory_manager_returns_factory():
     assert fm is registry._factory_manager
 
 
+def test_factory_manager_initialized_but_unset_raises():
+    """factory_manager raises InternalError when the registry is marked
+    initialized but ``_factory_manager`` was never assigned."""
+    registry = _make_initialized_registry()
+    registry._factory_manager = None
+
+    with pytest.raises(InternalError, match="did not run to completion"):
+        _ = registry.factory_manager
+
+
 # ---------------------------------------------------------------------------
 # 5. _load_items / initialize
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This pull request makes several improvements and clarifications to documentation, configuration samples, and developer tooling for the MCP project. The most significant changes are a shift to using code docstrings as the single source of truth for tool reference documentation, the addition of a sample CLI configuration, improved clarity on the security posture of the docs server, and updates to stress testing scripts.

**Documentation and Reference Ownership**

* The project now treats each tool's docstring as the authoritative reference for its parameters, return shape, and examples. All documentation files (including `README.md` and `docs/DEVELOPER_GUIDE.md`) now instruct users to use `dh-mcp tool show <name>` for detailed tool reference, and only maintain a one-line-per-tool capability list in the `README.md`. No markdown document hand-maintains per-tool reference details. [[1]](diffhunk://#diff-2391db23050f66b7c9eebe16cde9fd74fdf71e2525e2d06eca13d082c0ca9728L15-R31) [[2]](diffhunk://#diff-170d90dd0717bd69fe85c29554455e4300aac3bc3edd434e1313c6aaf945eff2L17-R17) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L482-R482)

**Configuration and Sample Files**

* Added a sample `cli.json` configuration to `config-samples/ai/config/`, demonstrating default CLI options for output format, daemon control, and request timeouts. [[1]](diffhunk://#diff-a1f1741272640109ad6b714a2ebfc8d29f05910454a3cc8b54577c5b2d083ef1R41) [[2]](diffhunk://#diff-801db2db6c5e3a61789e9c97cde068d14519c84b9c5abe7c833850c75d81ebecR1-R17)

**Security and Deployment Documentation**

* Expanded `docs/SECURITY.md` with a dedicated section for the public docs server (`dh-mcp-docs-server`), clarifying that it is intentionally unauthenticated, exposes no secrets, and must be protected by rate limiting at the ingress layer. Additional guidance is provided for reverse proxy configuration and header forwarding. [[1]](diffhunk://#diff-2605206b7e64be69186fabc8e8fed35676e0015832ff630141aa4aecd73354e0R19) [[2]](diffhunk://#diff-2605206b7e64be69186fabc8e8fed35676e0015832ff630141aa4aecd73354e0R36-R39) [[3]](diffhunk://#diff-2605206b7e64be69186fabc8e8fed35676e0015832ff630141aa4aecd73354e0R181-R184) [[4]](diffhunk://#diff-2605206b7e64be69186fabc8e8fed35676e0015832ff630141aa4aecd73354e0R227-R254)
* Updated `ops/docker/mcp-docs/Dockerfile` to reflect the correct default port (8001), script name, and file paths. [[1]](diffhunk://#diff-6b9624242f64e6155c50c7af15ea1dcd354c440e4865e17e5a642b20c49d4080L10-R13) [[2]](diffhunk://#diff-6b9624242f64e6155c50c7af15ea1dcd354c440e4865e17e5a642b20c49d4080L21-R29)

**CLI and Troubleshooting Documentation**

* Added documentation for the new `dh-mcp session credentials` command, including its purpose, output, and error codes, and clarified log file locations for Claude Desktop on both macOS and Windows. [[1]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761R254-R279) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L973-R973)

**Developer Tooling and Stress Testing**

* Improved the stress testing scripts:
  - [`scripts/mcp_docs_stress_http.py`](diffhunk://#diff-00de7d9b15f2501780f4bd60082bb3eae9758ec1cfaed3fcba73e568f96c730cL23-R24): Clarified that the RPS (requests per second) limit is shared across all connections and updated the default and help text for response time checks. [[1]](diffhunk://#diff-00de7d9b15f2501780f4bd60082bb3eae9758ec1cfaed3fcba73e568f96c730cL23-R24) [[2]](diffhunk://#diff-00de7d9b15f2501780f4bd60082bb3eae9758ec1cfaed3fcba73e568f96c730cL80-R86)
  - [`scripts/mcp_docs_stress_test.py`](diffhunk://#diff-59286f1e3df5475ce63a5e37623c3351daf13212a3a6b177538e25e0952a3f3aL3-R25): Rewrote the script's documentation to clarify its purpose (in-process load test, not HTTP), usage, output, and prerequisites, and simplified imports. [[1]](diffhunk://#diff-59286f1e3df5475ce63a5e37623c3351daf13212a3a6b177538e25e0952a3f3aL3-R25) [[2]](diffhunk://#diff-59286f1e3df5475ce63a5e37623c3351daf13212a3a6b177538e25e0952a3f3aL112-R34)