### PR TITLE
fix: Allow pq_create and pq_modify to specify owner and fix pq_create auto deletion of PQs after 10 min

### DIFF
--- a/src/deephaven_mcp/client/_controller_client.py
+++ b/src/deephaven_mcp/client/_controller_client.py
@@ -53,6 +53,7 @@ from deephaven_mcp._exceptions import (
 )
 
 from ._base import ClientObjectWrapper
+from ._pq_config import apply_pq_config_fields, validate_pq_config_args
 from ._protobuf import (
     CorePlusQueryConfig,
     CorePlusQueryInfo,
@@ -61,23 +62,6 @@ from ._protobuf import (
 from ._timeouts import EnterpriseClientTimeouts
 
 _LOGGER = logging.getLogger(__name__)
-
-
-# Default scheduling entries applied by ``CorePlusControllerClient.make_pq_config`` to
-# a *permanent* PQ (``auto_delete_timeout=None``) when the caller passes
-# ``schedule=None``. Produces a continuous scheduler that auto-starts the PQ after
-# the controller accepts it. See ``make_pq_config`` for the full three-way semantics.
-_DEFAULT_PERMANENT_CONTINUOUS_SCHEDULING: tuple[str, ...] = (
-    "SchedulerType=com.illumon.iris.controller.IrisQuerySchedulerContinuous",
-    "StartTime=00:00:00",
-    "TimeZone=America/New_York",
-    "DailyRestart=false",
-    "StopTimeDisabled=true",
-    "RestartErrorCount=0",
-    "RestartErrorDelay=0",
-    "RestartWhenRunning=Yes",
-    "SchedulingDisabled=false",
-)
 
 
 class CorePlusControllerClient(
@@ -144,7 +128,7 @@ class CorePlusControllerClient(
 
     def __init__(
         self,
-        controller_client: "deephaven_enterprise.client.controller.ControllerClient",  # noqa: F821
+        controller_client: "deephaven_enterprise.client.controller.ControllerClient",
         timeouts: EnterpriseClientTimeouts,
     ):
         """Initialize the CorePlusControllerClient with a ControllerClient instance.
@@ -766,74 +750,11 @@ class CorePlusControllerClient(
             )
             raise QueryError(f"Failed to create query: {e}") from e
 
-    def _apply_pq_config_parameters(  # noqa: C901
-        self,
-        config: Any,
-        programming_language: str | None,
-        script_body: str | None,
-        script_path: str | None,
-        configuration_type: str | None,
-        enabled: bool | None,
-        restart_users: str | None,
-        extra_class_path: list[str] | None,
-        schedule: list[str] | None,
-        init_timeout_nanos: int | None,
-        jvm_profile: str | None,
-        python_virtual_environment: str | None,
-    ) -> None:
-        """Apply caller-supplied configuration parameters to a protobuf config in place.
-
-        Every field except ``schedule`` follows a "None means skip" rule, so the
-        existing default is preserved when the caller does not supply a value.
-        See the ``schedule`` entry below for its three-way semantics.
-
-        Args:
-            config (Any): The protobuf config object to modify
-            programming_language (str | None): Programming language ("Python" or "Groovy"), or None to use default
-            script_body (str | None): Inline script code, or None if not specified
-            script_path (str | None): Path to script file in Git repository, or None if not specified
-            configuration_type (str | None): Query type ("Script", "RunAndDone", etc.), or None to use default
-            enabled (bool | None): Whether query is enabled, or None to use default
-            restart_users (str | None): Restart permission setting, or None to use controller default
-            extra_class_path (list[str] | None): Additional classpath entries, or None if not specified
-            schedule (list[str] | None): Scheduling entries. ``None`` leaves the
-                existing scheduling untouched; ``[]`` clears it; a non-empty list
-                replaces it wholesale.
-            init_timeout_nanos (int | None): Initialization timeout in nanoseconds, or None to use default
-            jvm_profile (str | None): Named JVM profile, or None if not specified
-            python_virtual_environment (str | None): Named Python venv, or None if not specified
-        """
-        if programming_language is not None:
-            config.scriptLanguage = programming_language
-        if script_body is not None:
-            config.scriptCode = script_body
-        if script_path is not None:
-            config.scriptPath = script_path
-        if configuration_type is not None:
-            config.configurationType = configuration_type
-        if enabled is not None:
-            config.enabled = enabled
-        if restart_users is not None:
-            config.restartUsers = restart_users
-        if extra_class_path:
-            config.extraClassPath.extend(extra_class_path)
-        # schedule has three-way semantics: None leaves config.scheduling
-        # untouched; [] clears it; [...] replaces it wholesale.
-        if schedule is not None:
-            del config.scheduling[:]
-            if schedule:
-                config.scheduling.extend(schedule)
-        if init_timeout_nanos is not None:
-            config.initTimeoutNanos = init_timeout_nanos
-        if jvm_profile is not None:
-            config.jvmProfile = jvm_profile
-        if python_virtual_environment is not None:
-            config.pythonVirtualEnvironment = python_virtual_environment
-
     async def make_pq_config(
         self,
         name: str,
         heap_size_gb: float | int,
+        *,
         script_body: str | None = None,
         script_path: str | None = None,
         programming_language: str | None = None,
@@ -852,6 +773,7 @@ class CorePlusControllerClient(
         admin_groups: list[str] | None = None,
         viewer_groups: list[str] | None = None,
         restart_users: str | None = None,
+        owner: str | None = None,
     ) -> CorePlusQueryConfig:
         """Create a persistent query configuration.
 
@@ -859,23 +781,21 @@ class CorePlusControllerClient(
         scheduling, resource settings, and access controls. The configuration is not persisted
         until passed to add_query().
 
-        Scheduler semantics (three-way, based on ``schedule``):
-            - ``schedule=None`` (default): install the default scheduler and make no
-              further changes.
-                - For a *permanent* PQ (``auto_delete_timeout=None``) the default is a
-                  continuous scheduler with ``SchedulingDisabled=false`` and
-                  ``RestartWhenRunning=Yes``; the controller will begin acquiring a worker
-                  immediately after ``add_query()`` (assuming ``enabled`` is ``True``,
-                  which is the controller default).
-                - For a *temporary* PQ (``auto_delete_timeout`` is a positive integer)
-                  the default is whatever ``make_temporary_config`` installs.
-            - ``schedule=[]``: the caller is explicitly requesting no scheduling. The
-              scheduling list is cleared before the config is returned; the server is
-              responsible for accepting or rejecting a PQ with no scheduling entries.
-            - ``schedule=[...]`` (non-empty list): the caller-supplied list **replaces**
-              the scheduling block wholesale. No default keys are merged in; the caller
-              is responsible for including ``SchedulerType`` and any other required
-              entries.
+        Scheduler semantics:
+            ``auto_delete_timeout`` and ``schedule`` are mutually exclusive (a ValueError is
+            raised if both are supplied), because ``auto_delete_timeout`` installs its own
+            scheduler:
+            - No ``schedule`` and ``auto_delete_timeout`` is ``None`` or ``0``: a continuous
+              (permanent) scheduler with ``SchedulingDisabled=false`` and
+              ``RestartWhenRunning=Yes``; the controller begins acquiring a worker immediately
+              after ``add_query()`` (assuming ``enabled`` is ``True``).
+            - No ``schedule`` and ``auto_delete_timeout`` is a positive integer: a temporary
+              scheduler that auto-deletes the PQ after that many seconds of inactivity.
+            - ``schedule=[...]`` (non-empty list): the caller-supplied list **replaces** the
+              scheduling block wholesale; the caller includes ``SchedulerType`` and any other
+              required entries.
+            - ``schedule=[]``: the scheduling list is cleared; the server decides whether to
+              accept a PQ with no scheduling entries.
 
         Args:
             name (str): The name of the persistent query. This is used for identification.
@@ -897,18 +817,23 @@ class CorePlusControllerClient(
             python_virtual_environment (str | None): Named Python virtual environment for Core+ workers.
             extra_environment_vars (list[str] | None): A list of extra environment variables for the worker.
             init_timeout_nanos (int | None): Initialization timeout in nanoseconds.
-            auto_delete_timeout (int | None): The timeout in seconds for auto-deletion of the query
-                after it becomes idle. None (default) creates a permanent query.
+            auto_delete_timeout (int | None): Seconds of inactivity before the controller
+                auto-deletes the query. None (default) and 0 both create a permanent query
+                (auto-delete disabled); a positive value creates a temporary query that is
+                deleted after that many seconds of inactivity.
             admin_groups (list[str] | None): A list of user groups that will have admin access to the query.
             viewer_groups (list[str] | None): A list of user groups that will have viewer access to the query.
             restart_users (str | None): Who can restart the query. Values: "RU_ADMIN", "RU_ADMIN_AND_VIEWERS",
                 "RU_VIEWERS_WHEN_DOWN". Defaults to controller setting.
+            owner (str | None): The user to set as the query owner. None (default) leaves the
+                owner as the authenticated user set by make_temporary_config.
 
         Returns:
             CorePlusQueryConfig: The configuration object for the persistent query.
 
         Raises:
-            ValueError: If invalid parameters are provided.
+            ValueError: If invalid parameters are provided (script_body/script_path or
+                auto_delete_timeout/schedule supplied together).
             DeephavenConnectionError: If not authenticated or unable to communicate with the controller.
             QueryError: If configuration creation fails for any other reason.
         """
@@ -920,23 +845,17 @@ class CorePlusControllerClient(
             f"script_body={'<set>' if script_body else None}, script_path={script_path!r}, "
             f"schedule={schedule}, jvm_profile={jvm_profile!r}, "
             f"python_virtual_environment={python_virtual_environment!r}, "
-            f"admin_groups={admin_groups}, viewer_groups={viewer_groups}, restart_users={restart_users!r}"
+            f"admin_groups={admin_groups}, viewer_groups={viewer_groups}, restart_users={restart_users!r}, "
+            f"owner={owner!r}"
         )
 
-        # Validate mutually exclusive parameters
-        if script_body is not None and script_path is not None:
-            raise ValueError(
-                "script_body and script_path are mutually exclusive - specify only one"
-            )
+        validate_pq_config_args(auto_delete_timeout, schedule, script_body, script_path)
 
         try:
-            # Step 1: call make_temporary_config to produce a baseline config.
-            # For permanent queries (auto_delete_timeout=None) we must still pass a
-            # placeholder timeout because the server rejects temporary scheduling
-            # that lacks a valid timeout; we overwrite the scheduling below.
-            is_permanent = auto_delete_timeout is None
-            effective_timeout = 600 if is_permanent else auto_delete_timeout
-
+            # Baseline config from the vendor: serial, version, defaults, and the
+            # natively-supported fields (name, heap, server, engine, groups, jvm args,
+            # env vars). Pass auto_delete_timeout=None so no stray TerminationDelay or
+            # temporary scheduling leaks in; the shared applier installs the scheduler.
             config = await asyncio.to_thread(
                 self.wrapped.make_temporary_config,
                 name,
@@ -945,46 +864,43 @@ class CorePlusControllerClient(
                 extra_jvm_args,
                 extra_environment_vars,
                 engine,
-                effective_timeout,
+                None,
                 admin_groups,
                 viewer_groups,
             )
 
-            # Step 2: install the default scheduler for permanent queries when the
-            # caller did not supply a schedule. Replaces the temporary scheduling
-            # that make_temporary_config installs with a continuous scheduler that
-            # causes the PQ to auto-start once the controller accepts it. This step
-            # lives here (not in _apply_pq_config_parameters) because it needs the
-            # ``is_permanent`` context which is local to this method.
-            # Note: protobuf RepeatedScalarContainer has no clear(); use slice del.
-            if is_permanent and schedule is None:
-                del config.scheduling[:]
-                for entry in _DEFAULT_PERMANENT_CONTINUOUS_SCHEDULING:
-                    config.scheduling.append(entry)
-                _LOGGER.debug(
-                    f"[CorePlusControllerClient:make_pq_config] "
-                    f"Installed default continuous scheduler for permanent query '{name}'"
-                )
-
-            # Step 3: apply all caller-supplied parameters (including any
-            # caller-supplied scheduling override) through the single helper.
-            # Scheduling is applied with three-way semantics inside the helper:
-            #   schedule=None      -> no override (default from step 2 stays)
-            #   schedule=[]        -> explicit "no scheduling"; clear the block
-            #   schedule=[...]     -> replace wholesale with the caller's list
-            self._apply_pq_config_parameters(
+            # With no explicit schedule, auto_delete_timeout dictates the scheduler;
+            # None and 0 both mean permanent (continuous). An explicit schedule is
+            # mutually exclusive with auto_delete_timeout (validated above), so when
+            # one is given the other is None.
+            effective_auto_delete = (
+                auto_delete_timeout
+                if schedule is not None
+                else (auto_delete_timeout or 0)
+            )
+            apply_pq_config_fields(
                 config,
-                programming_language,
-                script_body,
-                script_path,
-                configuration_type,
-                enabled,
-                restart_users,
-                extra_class_path,
-                schedule,
-                init_timeout_nanos,
-                jvm_profile,
-                python_virtual_environment,
+                pq_name=None,
+                heap_size_gb=None,
+                programming_language=programming_language,
+                script_body=script_body,
+                script_path=script_path,
+                configuration_type=configuration_type,
+                enabled=enabled,
+                schedule=schedule,
+                server=None,
+                engine=None,
+                jvm_profile=jvm_profile,
+                extra_jvm_args=None,
+                extra_class_path=extra_class_path,
+                python_virtual_environment=python_virtual_environment,
+                extra_environment_vars=None,
+                init_timeout_nanos=init_timeout_nanos,
+                auto_delete_timeout=effective_auto_delete,
+                admin_groups=None,
+                viewer_groups=None,
+                restart_users=restart_users,
+                owner=owner,
             )
 
             _LOGGER.debug(
@@ -996,6 +912,107 @@ class CorePlusControllerClient(
                 f"[CorePlusControllerClient:make_pq_config] Failed to create config for '{name}': {e}"
             )
             raise
+
+    def update_pq_config(
+        self,
+        config: CorePlusQueryConfig,
+        *,
+        pq_name: str | None = None,
+        heap_size_gb: float | int | None = None,
+        script_body: str | None = None,
+        script_path: str | None = None,
+        programming_language: str | None = None,
+        configuration_type: str | None = None,
+        enabled: bool | None = None,
+        schedule: list[str] | None = None,
+        server: str | None = None,
+        engine: str | None = None,
+        jvm_profile: str | None = None,
+        extra_jvm_args: list[str] | None = None,
+        extra_class_path: list[str] | None = None,
+        python_virtual_environment: str | None = None,
+        extra_environment_vars: list[str] | None = None,
+        init_timeout_nanos: int | None = None,
+        auto_delete_timeout: int | None = None,
+        admin_groups: list[str] | None = None,
+        viewer_groups: list[str] | None = None,
+        restart_users: str | None = None,
+        owner: str | None = None,
+    ) -> bool:
+        """Apply changes to an existing persistent query configuration in place.
+
+        The modify-side counterpart to ``make_pq_config``: both shape a
+        ``PersistentQueryConfigMessage`` through the same field-applier, so the same
+        argument values produce the same config. Every field follows a "None means skip"
+        rule, so only the supplied fields change. This mutates ``config`` in place and does
+        not persist it; pass the result to ``modify_query``.
+
+        ``auto_delete_timeout`` installs its own scheduler and is mutually exclusive with
+        ``schedule`` (a ValueError is raised if both are supplied): ``0`` installs the
+        continuous (permanent) scheduler and clears the auto-delete grace period; a positive
+        integer installs the temporary scheduler and sets the grace period to that many
+        seconds; ``None`` leaves scheduling and auto-delete untouched.
+
+        Args:
+            config (CorePlusQueryConfig): The existing configuration to modify in place.
+            pq_name (str | None): New PQ name.
+            heap_size_gb (float | int | None): New heap size in GB.
+            script_body (str | None): New inline script code (mutually exclusive with script_path).
+            script_path (str | None): New Git script path (mutually exclusive with script_body).
+            programming_language (str | None): "Python" or "Groovy", case-insensitive.
+            configuration_type (str | None): Query type ("Script", "RunAndDone", etc.).
+            enabled (bool | None): Whether the query is enabled.
+            schedule (list[str] | None): Scheduling entries; replaces existing wholesale.
+            server (str | None): Target server name.
+            engine (str | None): Worker kind/engine type.
+            jvm_profile (str | None): Named JVM profile.
+            extra_jvm_args (list[str] | None): JVM arguments; replaces existing.
+            extra_class_path (list[str] | None): Classpath entries; replaces existing.
+            python_virtual_environment (str | None): Python venv control.
+            extra_environment_vars (list[str] | None): Env vars; replaces existing.
+            init_timeout_nanos (int | None): Initialization timeout in nanoseconds.
+            auto_delete_timeout (int | None): Seconds of inactivity before auto-deletion.
+                None leaves it unchanged; 0 makes the query permanent; a positive integer
+                makes it temporary, auto-deleted after that many seconds.
+            admin_groups (list[str] | None): Admin groups; replaces existing.
+            viewer_groups (list[str] | None): Viewer groups; replaces existing.
+            restart_users (str | None): Restart-permission enum name (e.g., "RU_ADMIN").
+            owner (str | None): New query owner.
+
+        Returns:
+            bool: True if any field changed, False if every parameter was None.
+
+        Raises:
+            ValueError: If script_body/script_path or auto_delete_timeout/schedule are
+                supplied together, or if a parameter value is invalid.
+            MissingEnterprisePackageError: If a temporary scheduler or enum conversion is
+                requested but the enterprise package is unavailable.
+        """
+        validate_pq_config_args(auto_delete_timeout, schedule, script_body, script_path)
+        return apply_pq_config_fields(
+            config.pb,
+            pq_name=pq_name,
+            heap_size_gb=heap_size_gb,
+            programming_language=programming_language,
+            script_body=script_body,
+            script_path=script_path,
+            configuration_type=configuration_type,
+            enabled=enabled,
+            schedule=schedule,
+            server=server,
+            engine=engine,
+            jvm_profile=jvm_profile,
+            extra_jvm_args=extra_jvm_args,
+            extra_class_path=extra_class_path,
+            python_virtual_environment=python_virtual_environment,
+            extra_environment_vars=extra_environment_vars,
+            init_timeout_nanos=init_timeout_nanos,
+            auto_delete_timeout=auto_delete_timeout,
+            admin_groups=admin_groups,
+            viewer_groups=viewer_groups,
+            restart_users=restart_users,
+            owner=owner,
+        )
 
     # ===========================================================================
     # Query Lifecycle Management
@@ -1111,17 +1128,16 @@ class CorePlusControllerClient(
                        controller errors.
 
         Example:
-            # Get current query info and modify it
+            # Get current query info and apply changes via update_pq_config (the
+            # partial-update helper; "None means skip" for every field).
             query_info = await controller.get(serial)
             config = query_info.config
+            controller.update_pq_config(config, heap_size_gb=16.0)
 
-            # Update heap size in the protobuf
-            config.pb.heapSizeGb = 16.0
-
-            # Modify without restarting (changes saved for next restart)
+            # Persist without restarting (changes saved for next restart)
             await controller.modify_query(config, restart=False)
 
-            # Or modify and restart immediately
+            # Or persist and restart immediately to apply runtime changes
             await controller.modify_query(config, restart=True)
         """
         timeout_seconds = self._timeouts.pq_management_timeout_seconds

--- a/src/deephaven_mcp/client/_pq_config.py
+++ b/src/deephaven_mcp/client/_pq_config.py
@@ -1,0 +1,432 @@
+"""Construction and mutation of Deephaven Enterprise persistent-query configurations.
+
+Pure, synchronous helpers that build and modify ``PersistentQueryConfigMessage`` protobufs
+for the controller client's ``make_pq_config`` (create) and ``update_pq_config`` (modify).
+The public entry points are :func:`validate_pq_config_args` and :func:`apply_pq_config_fields`;
+everything else is internal. These helpers perform no IO.
+"""
+
+import json
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from deephaven_enterprise.proto.persistent_query_pb2 import (  # pragma: no cover
+        PersistentQueryConfigMessage,
+        RestartUsersEnum,
+    )
+
+from deephaven_mcp._exceptions import MissingEnterprisePackageError
+
+# Runtime sentinels for the optional enterprise symbols used here. Both are also imported
+# under TYPE_CHECKING above so annotations like ``RestartUsersEnum.ValueType`` resolve. A
+# try/except (rather than is_enterprise_available()) guards these specific submodule imports:
+# it matches pq.py and catches a partial/version-skewed enterprise install where the top
+# package is present but a submodule is missing. Helpers that need them raise
+# MissingEnterprisePackageError when they are None.
+try:
+    from deephaven_enterprise.client.generate_scheduling import GenerateScheduling
+    from deephaven_enterprise.proto.persistent_query_pb2 import RestartUsersEnum
+except (
+    ImportError
+):  # pragma: no cover - only reached when the enterprise package is absent
+    GenerateScheduling = None  # type: ignore[misc,assignment]
+    RestartUsersEnum = None  # type: ignore[misc,assignment]
+
+
+# Default scheduling entries applied to a *permanent* PQ (auto_delete_timeout None or 0).
+# Produces a continuous scheduler that auto-starts the PQ after the controller accepts it.
+_DEFAULT_PERMANENT_CONTINUOUS_SCHEDULING: tuple[str, ...] = (
+    "SchedulerType=com.illumon.iris.controller.IrisQuerySchedulerContinuous",
+    "StartTime=00:00:00",
+    "TimeZone=America/New_York",
+    "DailyRestart=false",
+    "StopTimeDisabled=true",
+    "RestartErrorCount=0",
+    "RestartErrorDelay=0",
+    "RestartWhenRunning=Yes",
+    "SchedulingDisabled=false",
+)
+
+# Temporary-scheduler parameters used when auto_delete_timeout requests an auto-deleting
+# (temporary) PQ. These mirror the values the enterprise controller's make_temporary_config
+# applies, so PQs created via make_pq_config and modified via update_pq_config are identical.
+_TEMPORARY_QUEUE_NAME = "InteractiveConsoleTemporaryQueue"
+_TEMPORARY_EXPIRATION_MINUTES = 2880
+
+
+def _normalize_programming_language(language: str) -> str:
+    """Normalize and validate a programming language string for PQ configuration.
+
+    Accepts case-insensitive input and returns the canonical capitalized form expected by
+    the Deephaven Enterprise controller API.
+
+    Args:
+        language (str): Programming language string, case-insensitive
+            (e.g., "python", "Python", "PYTHON", "groovy", "Groovy").
+
+    Returns:
+        str: Canonical form accepted by the controller: "Python" or "Groovy".
+
+    Raises:
+        ValueError: If language is not a case-insensitive match for "Python" or "Groovy".
+    """
+    lang_lower = language.lower()
+    if lang_lower == "python":
+        return "Python"
+    elif lang_lower == "groovy":
+        return "Groovy"
+    else:
+        raise ValueError(
+            f"Invalid programming_language: '{language}'. "
+            "Must be 'Python' or 'Groovy' (case-insensitive)."
+        )
+
+
+def _convert_restart_users_to_enum(
+    restart_users_str: str,
+) -> "RestartUsersEnum.ValueType":
+    """Convert a restart_users string to its protobuf enum value.
+
+    Args:
+        restart_users_str (str): Restart users enum name (e.g., "RU_ADMIN").
+
+    Returns:
+        RestartUsersEnum.ValueType: Typed protobuf enum value suitable for direct assignment
+            to ``PersistentQueryConfigMessage.restartUsers``.
+
+    Raises:
+        MissingEnterprisePackageError: If RestartUsersEnum is unavailable (enterprise package
+            not installed).
+        ValueError: If restart_users_str is not a valid enum value.
+    """
+    if RestartUsersEnum is None:
+        raise MissingEnterprisePackageError()
+
+    try:
+        # EnumTypeWrapper.Value() is untyped (Any) in the runtime google.protobuf package;
+        # the cast pins the precise protobuf type at the point upstream type info is lost so
+        # callers assigning to ``restartUsers`` need no cast or suppression.
+        return cast(
+            "RestartUsersEnum.ValueType", RestartUsersEnum.Value(restart_users_str)
+        )
+    except ValueError:
+        valid_values = list(RestartUsersEnum.keys())
+        raise ValueError(
+            f"Invalid restart_users: '{restart_users_str}'. "
+            f"Must be one of: {', '.join(sorted(valid_values))}"
+        ) from None
+
+
+def _set_termination_delay(
+    config_pb: "PersistentQueryConfigMessage", delay_ms: int | None
+) -> None:
+    """Set or remove the ``TerminationDelay`` entry in ``typeSpecificFieldsJson``.
+
+    Args:
+        config_pb (PersistentQueryConfigMessage): Protobuf config object to modify in-place.
+        delay_ms (int | None): Grace period in milliseconds to encode, or None to remove the
+            entry. Other type-specific fields already present are preserved.
+    """
+    # Key the controller reads as the temporary-query auto-delete grace period (ms).
+    raw = config_pb.typeSpecificFieldsJson
+    fields = json.loads(raw) if raw else {}
+    if delay_ms is None:
+        fields.pop("TerminationDelay", None)
+    else:
+        fields["TerminationDelay"] = {"type": "long", "value": str(delay_ms)}
+    config_pb.typeSpecificFieldsJson = json.dumps(fields) if fields else ""
+
+
+def _apply_auto_delete_timeout(
+    config_pb: "PersistentQueryConfigMessage", auto_delete_timeout: int | None
+) -> bool:
+    """Apply the auto-delete timeout to a PQ config's scheduler and ``TerminationDelay``.
+
+    Auto-deletion is driven by the scheduler, so this pairs the scheduler with the grace
+    period as a unit — the single source of truth shared by ``make_pq_config`` and
+    ``update_pq_config``.
+
+    Args:
+        config_pb (PersistentQueryConfigMessage): Protobuf config object to modify in-place.
+        auto_delete_timeout (int | None): Seconds of inactivity before auto-deletion. None
+            leaves the config untouched. 0 installs the permanent continuous scheduler and
+            clears the grace period. A positive integer installs the temporary scheduler and
+            sets the grace period to that many seconds (stored as ``TerminationDelay``
+            milliseconds).
+
+    Returns:
+        bool: True if the config was modified, False when auto_delete_timeout is None.
+
+    Raises:
+        MissingEnterprisePackageError: If the enterprise scheduling generator is unavailable
+            and a temporary scheduler is requested.
+    """
+    if auto_delete_timeout is None:
+        return False
+
+    del config_pb.scheduling[:]
+    if auto_delete_timeout == 0:
+        config_pb.scheduling.extend(_DEFAULT_PERMANENT_CONTINUOUS_SCHEDULING)
+        _set_termination_delay(config_pb, None)
+    else:
+        if GenerateScheduling is None:
+            raise MissingEnterprisePackageError()
+        config_pb.scheduling.extend(
+            GenerateScheduling.generate_temporary_scheduler(
+                expiration_time_minutes=_TEMPORARY_EXPIRATION_MINUTES,
+                queue_name=_TEMPORARY_QUEUE_NAME,
+                auto_delete=True,
+            )
+        )
+        _set_termination_delay(config_pb, auto_delete_timeout * 1000)
+    return True
+
+
+def _apply_pq_config_simple_fields(
+    config_pb: "PersistentQueryConfigMessage",
+    pq_name: str | None,
+    heap_size_gb: float | int | None,
+    configuration_type: str | None,
+    enabled: bool | None,
+    server: str | None,
+    engine: str | None,
+    jvm_profile: str | None,
+    python_virtual_environment: str | None,
+    init_timeout_nanos: int | None,
+) -> bool:
+    """Apply simple (scalar) field updates to a PersistentQueryConfigMessage protobuf.
+
+    Updates only the fields that are not None.
+
+    Args:
+        config_pb (PersistentQueryConfigMessage): Protobuf config object to modify in-place.
+        pq_name (str | None): New PQ name → ``config_pb.name``.
+        heap_size_gb (float | int | None): Worker heap size in GB → ``config_pb.heapSizeGb``.
+        configuration_type (str | None): Config type → ``config_pb.configurationType``.
+        enabled (bool | None): Whether the PQ is enabled → ``config_pb.enabled``.
+        server (str | None): Target server name → ``config_pb.serverName``.
+        engine (str | None): Worker kind/engine type → ``config_pb.workerKind``.
+        jvm_profile (str | None): JVM profile name → ``config_pb.jvmProfile``.
+        python_virtual_environment (str | None): Python venv control → ``config_pb.pythonControl``.
+        init_timeout_nanos (int | None): Initialization timeout in nanoseconds → ``config_pb.timeoutNanos``.
+
+    Returns:
+        bool: True if any field was updated, False if all parameters were None.
+    """
+    has_changes = False
+    if pq_name is not None:
+        config_pb.name = pq_name
+        has_changes = True
+    if heap_size_gb is not None:
+        config_pb.heapSizeGb = heap_size_gb
+        has_changes = True
+    if configuration_type is not None:
+        config_pb.configurationType = configuration_type
+        has_changes = True
+    if enabled is not None:
+        config_pb.enabled = enabled
+        has_changes = True
+    if server is not None:
+        config_pb.serverName = server
+        has_changes = True
+    if engine is not None:
+        config_pb.workerKind = engine
+        has_changes = True
+    if jvm_profile is not None:
+        config_pb.jvmProfile = jvm_profile
+        has_changes = True
+    if python_virtual_environment is not None:
+        config_pb.pythonControl = python_virtual_environment
+        has_changes = True
+    if init_timeout_nanos is not None:
+        config_pb.timeoutNanos = init_timeout_nanos
+        has_changes = True
+    return has_changes
+
+
+def _apply_pq_config_list_fields(
+    config_pb: "PersistentQueryConfigMessage",
+    schedule: list[str] | None,
+    extra_jvm_args: list[str] | None,
+    extra_class_path: list[str] | None,
+    extra_environment_vars: list[str] | None,
+    admin_groups: list[str] | None,
+    viewer_groups: list[str] | None,
+) -> bool:
+    """Apply list (repeated) field updates to a PersistentQueryConfigMessage protobuf.
+
+    Each non-None field fully replaces the existing contents (``del`` + ``extend``), so an
+    empty list clears the field.
+
+    Args:
+        config_pb (PersistentQueryConfigMessage): Protobuf config object to modify in-place.
+        schedule (list[str] | None): Scheduling entries as ``Key=Value`` strings → ``config_pb.scheduling``.
+        extra_jvm_args (list[str] | None): JVM arguments → ``config_pb.extraJvmArguments``.
+        extra_class_path (list[str] | None): Classpath entries → ``config_pb.classPathAdditions``.
+        extra_environment_vars (list[str] | None): Env vars (KEY=VALUE) → ``config_pb.extraEnvironmentVariables``.
+        admin_groups (list[str] | None): Admin group names → ``config_pb.adminGroups``.
+        viewer_groups (list[str] | None): Viewer group names → ``config_pb.viewerGroups``.
+
+    Returns:
+        bool: True if any field was updated, False if all parameters were None.
+    """
+    has_changes = False
+    if schedule is not None:
+        del config_pb.scheduling[:]
+        config_pb.scheduling.extend(schedule)
+        has_changes = True
+    if extra_jvm_args is not None:
+        del config_pb.extraJvmArguments[:]
+        config_pb.extraJvmArguments.extend(extra_jvm_args)
+        has_changes = True
+    if extra_class_path is not None:
+        del config_pb.classPathAdditions[:]
+        config_pb.classPathAdditions.extend(extra_class_path)
+        has_changes = True
+    if extra_environment_vars is not None:
+        del config_pb.extraEnvironmentVariables[:]
+        config_pb.extraEnvironmentVariables.extend(extra_environment_vars)
+        has_changes = True
+    if admin_groups is not None:
+        del config_pb.adminGroups[:]
+        config_pb.adminGroups.extend(admin_groups)
+        has_changes = True
+    if viewer_groups is not None:
+        del config_pb.viewerGroups[:]
+        config_pb.viewerGroups.extend(viewer_groups)
+        has_changes = True
+    return has_changes
+
+
+def validate_pq_config_args(
+    auto_delete_timeout: int | None,
+    schedule: list[str] | None,
+    script_body: str | None,
+    script_path: str | None,
+) -> None:
+    """Validate mutually exclusive PQ configuration arguments.
+
+    Args:
+        auto_delete_timeout (int | None): Auto-delete timeout in seconds.
+        schedule (list[str] | None): Scheduling entries.
+        script_body (str | None): Inline script code.
+        script_path (str | None): Git script path.
+
+    Raises:
+        ValueError: If script_body and script_path are both set, or if auto_delete_timeout
+            and schedule are both set (auto_delete_timeout installs its own scheduler).
+    """
+    if script_body is not None and script_path is not None:
+        raise ValueError(
+            "script_body and script_path are mutually exclusive - specify only one"
+        )
+    if auto_delete_timeout is not None and schedule is not None:
+        raise ValueError(
+            "auto_delete_timeout and schedule are mutually exclusive - "
+            "auto_delete_timeout installs its own scheduler"
+        )
+
+
+def apply_pq_config_fields(
+    config_pb: "PersistentQueryConfigMessage",
+    *,
+    pq_name: str | None,
+    heap_size_gb: float | int | None,
+    programming_language: str | None,
+    script_body: str | None,
+    script_path: str | None,
+    configuration_type: str | None,
+    enabled: bool | None,
+    schedule: list[str] | None,
+    server: str | None,
+    engine: str | None,
+    jvm_profile: str | None,
+    extra_jvm_args: list[str] | None,
+    extra_class_path: list[str] | None,
+    python_virtual_environment: str | None,
+    extra_environment_vars: list[str] | None,
+    init_timeout_nanos: int | None,
+    auto_delete_timeout: int | None,
+    admin_groups: list[str] | None,
+    viewer_groups: list[str] | None,
+    restart_users: str | None,
+    owner: str | None,
+) -> bool:
+    """Apply caller-supplied PQ configuration fields to a protobuf config in place.
+
+    The single field-applier shared by ``make_pq_config`` (create) and ``update_pq_config``
+    (modify). Every field follows a "None means skip" rule. ``auto_delete_timeout`` and
+    ``schedule`` are mutually exclusive (see :func:`validate_pq_config_args`);
+    ``auto_delete_timeout`` installs its own scheduler.
+
+    Args:
+        config_pb (PersistentQueryConfigMessage): Protobuf config object to modify in-place.
+        pq_name (str | None): New PQ name.
+        heap_size_gb (float | int | None): Worker heap size in GB.
+        programming_language (str | None): "Python" or "Groovy" (case-insensitive; normalized).
+        script_body (str | None): Inline script code (oneof with script_path).
+        script_path (str | None): Git script path (oneof with script_body).
+        configuration_type (str | None): Config type (e.g., "Script", "RunAndDone").
+        enabled (bool | None): Whether the PQ is enabled.
+        schedule (list[str] | None): Scheduling entries; replaces existing wholesale.
+        server (str | None): Target server name.
+        engine (str | None): Worker kind/engine type.
+        jvm_profile (str | None): JVM profile name.
+        extra_jvm_args (list[str] | None): JVM arguments; replaces existing.
+        extra_class_path (list[str] | None): Classpath entries; replaces existing.
+        python_virtual_environment (str | None): Python venv control.
+        extra_environment_vars (list[str] | None): Env vars; replaces existing.
+        init_timeout_nanos (int | None): Initialization timeout in nanoseconds.
+        auto_delete_timeout (int | None): Seconds of inactivity before auto-deletion. None
+            skips; 0 makes the PQ permanent; a positive integer makes it temporary, deleted
+            after that many seconds.
+        admin_groups (list[str] | None): Admin groups; replaces existing.
+        viewer_groups (list[str] | None): Viewer groups; replaces existing.
+        restart_users (str | None): Restart-permission enum name (e.g., "RU_ADMIN").
+        owner (str | None): Query owner.
+
+    Returns:
+        bool: True if any field was changed, False if every parameter was None.
+    """
+    has_changes = False
+    if programming_language is not None:
+        config_pb.scriptLanguage = _normalize_programming_language(programming_language)
+        has_changes = True
+    if script_body is not None:
+        config_pb.scriptCode = script_body
+        has_changes = True
+    if script_path is not None:
+        config_pb.scriptPath = script_path
+        has_changes = True
+    if restart_users is not None:
+        config_pb.restartUsers = _convert_restart_users_to_enum(restart_users)
+        has_changes = True
+    if owner is not None:
+        config_pb.owner = owner
+        has_changes = True
+    if _apply_auto_delete_timeout(config_pb, auto_delete_timeout):
+        has_changes = True
+    if _apply_pq_config_simple_fields(
+        config_pb,
+        pq_name,
+        heap_size_gb,
+        configuration_type,
+        enabled,
+        server,
+        engine,
+        jvm_profile,
+        python_virtual_environment,
+        init_timeout_nanos,
+    ):
+        has_changes = True
+    if _apply_pq_config_list_fields(
+        config_pb,
+        schedule,
+        extra_jvm_args,
+        extra_class_path,
+        extra_environment_vars,
+        admin_groups,
+        viewer_groups,
+    ):
+        has_changes = True
+    return has_changes

--- a/src/deephaven_mcp/mcp_systems_server/_tools/pq.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/pq.py
@@ -24,7 +24,6 @@ from pydantic import Field
 from deephaven_mcp._exceptions import (
     InternalError,
     InvalidSessionNameError,
-    MissingEnterprisePackageError,
 )
 from deephaven_mcp.client import (
     PQ_STATES,
@@ -60,7 +59,6 @@ if TYPE_CHECKING:
     )
     from deephaven_enterprise.proto.persistent_query_pb2 import (
         ExportedObjectTypeEnum,
-        PersistentQueryConfigMessage,
         ProcessorConnectionDetailsMessage,
         RestartUsersEnum,
         WorkerProtocolMessage,
@@ -569,74 +567,23 @@ def _format_pq_state(state: CorePlusQueryState | None) -> dict[str, object] | No
     return result
 
 
-def _format_pq_replicas(replicas: list[CorePlusQueryState]) -> list[dict[str, object]]:
-    """Format list of replica PersistentQueryStateMessage objects.
+def _format_pq_states(states: list[CorePlusQueryState]) -> list[dict[str, object]]:
+    """Format a list of PersistentQueryStateMessage objects, dropping None entries.
 
-    Applies _format_pq_state to each replica in the list, filtering out None entries.
-    Replicas are additional running instances of a persistent query for high availability.
+    Used for a PQ's replicas (additional running instances for high availability) and its
+    spares (pre-initialized workers ready to take over if the primary fails); both are lists
+    of states formatted identically.
 
     Args:
-        replicas (list[CorePlusQueryState]): List of CorePlusQueryState wrappers for replica states
+        states (list[CorePlusQueryState]): CorePlusQueryState wrappers to format. None
+            entries are tolerated and dropped from the result.
 
     Returns:
-        list[dict[str, object]]: List of formatted replica state dictionaries (25 fields each),
-            or empty list if no replicas provided
+        list[dict[str, object]]: Formatted state dictionaries (25 fields each) with None
+            entries removed; empty list if no states are provided.
     """
-    if not replicas:
-        return []
-
-    formatted = [
-        _format_pq_state(replica) for replica in replicas if replica is not None
-    ]
+    formatted = [_format_pq_state(state) for state in states]
     return [f for f in formatted if f is not None]
-
-
-def _format_pq_spares(spares: list[CorePlusQueryState]) -> list[dict[str, object]]:
-    """Format list of spare PersistentQueryStateMessage objects.
-
-    Applies _format_pq_state to each spare in the list, filtering out None entries.
-    Spares are pre-initialized worker instances ready to take over if the primary fails.
-
-    Args:
-        spares (list[CorePlusQueryState]): List of CorePlusQueryState wrappers for spare states
-
-    Returns:
-        list[dict[str, object]]: List of formatted spare state dictionaries (25 fields each),
-            or empty list if no spares provided
-    """
-    if not spares:
-        return []
-
-    formatted = [_format_pq_state(spare) for spare in spares if spare is not None]
-    return [f for f in formatted if f is not None]
-
-
-def _normalize_programming_language(language: str) -> str:
-    """Normalize and validate a programming language string for PQ configuration.
-
-    Accepts case-insensitive input and returns the canonical capitalized form
-    expected by the Deephaven Enterprise controller API.
-
-    Args:
-        language (str): Programming language string, case-insensitive
-            (e.g., "python", "Python", "PYTHON", "groovy", "Groovy")
-
-    Returns:
-        str: Canonical form accepted by the controller: "Python" or "Groovy"
-
-    Raises:
-        ValueError: If language is not a case-insensitive match for "Python" or "Groovy"
-    """
-    lang_lower = language.lower()
-    if lang_lower == "python":
-        return "Python"
-    elif lang_lower == "groovy":
-        return "Groovy"
-    else:
-        raise ValueError(
-            f"Invalid programming_language: '{language}'. "
-            "Must be 'Python' or 'Groovy' (case-insensitive)."
-        )
 
 
 async def _setup_batch_pq_operation(
@@ -785,54 +732,6 @@ def _validate_and_parse_pq_ids(
         for pid, serial in zip(pq_ids, serials, strict=True)
     ]
     return (parsed_pqs, system_name, None)
-
-
-def _convert_restart_users_to_enum(
-    restart_users_str: str,
-) -> "RestartUsersEnum.ValueType":
-    """Convert restart_users string to protobuf enum value.
-
-    Args:
-        restart_users_str (str): Restart users enum name (e.g., "RU_ADMIN")
-
-    Returns:
-        RestartUsersEnum.ValueType: Typed protobuf enum value suitable for direct
-            assignment to ``PersistentQueryConfigMessage.restartUsers``. The return
-            type is the protobuf-generated ``NewType('ValueType', int)``, which
-            matches the field's declared stub type so no cast is required at the
-            assignment site.
-
-    Raises:
-        MissingEnterprisePackageError: If RestartUsersEnum is not available (enterprise package not installed)
-        ValueError: If restart_users_str is not a valid enum value
-    """
-    if RestartUsersEnum is None:
-        raise MissingEnterprisePackageError()
-
-    # Convert string name to typed enum value using protobuf enum.
-    #
-    # ``EnumTypeWrapper.Value()`` is declared as untyped in the runtime
-    # ``google.protobuf`` package (no shipped ``.pyi``), so its return is
-    # ``Any``. The deephaven-coreplus-client mypy-protobuf-generated stubs
-    # *do* declare the upstream wrapper as ``_EnumTypeWrapper[ValueType]``,
-    # but resolving that type chain in mypy requires installing
-    # ``types-protobuf``, which in turn fails 100+ pre-existing wrapper
-    # accesses (the broader narrowing fix is out of scope for this change).
-    # The single ``cast`` here pins the type at the exact point upstream
-    # information is lost; the helper's return annotation then propagates
-    # the precise protobuf type to all callers, so no cast or
-    # ``# type: ignore`` is needed at the assignment site.
-    try:
-        return cast(
-            "RestartUsersEnum.ValueType", RestartUsersEnum.Value(restart_users_str)
-        )
-    except ValueError:
-        # Get all valid enum names from protobuf enum using .keys() method
-        valid_values = list(RestartUsersEnum.keys())
-        raise ValueError(
-            f"Invalid restart_users: '{restart_users_str}'. "
-            f"Must be one of: {', '.join(sorted(valid_values))}"
-        ) from None
 
 
 def _pq_state_category(state_name: str) -> str:
@@ -1396,8 +1295,8 @@ async def pq_details(
             "state": state_name,
             "config": _format_pq_config(pq_info.config),
             "state_details": _format_pq_state(pq_info.state),
-            "replicas": _format_pq_replicas(pq_info.replicas),
-            "spares": _format_pq_spares(pq_info.spares),
+            "replicas": _format_pq_states(pq_info.replicas),
+            "spares": _format_pq_states(pq_info.spares),
         }
 
         # Add session_id if running (session_id uses name, not serial)
@@ -1445,25 +1344,27 @@ async def pq_create(
     admin_groups: list[str] | None = None,
     viewer_groups: list[str] | None = None,
     restart_users: str | None = None,
+    owner: str | None = None,
 ) -> dict:
     """MCP Tool: Create a new persistent query on an enterprise system.
 
     Creates a PQ configuration and adds it to the controller.
 
-    Scheduler semantics (three-way, based on ``schedule``):
-        - ``schedule=None`` (default): install the default scheduler and make no further
-          changes. For a *permanent* PQ (``auto_delete_timeout=None``) the default is a
-          continuous scheduler with ``SchedulingDisabled=false`` and
-          ``RestartWhenRunning=Yes``, which causes the controller to begin acquiring a
-          worker immediately after creation (``ACQUIRING_WORKER`` → ``RUNNING``
-          with no explicit ``pq_start`` call). For a *temporary* PQ the default is
-          whatever the controller's temporary scheduling installs.
-        - ``schedule=[]``: the caller is explicitly requesting no scheduling. The
-          scheduling list is cleared; the server decides whether to accept or reject a
-          PQ with no scheduling entries.
+    Scheduler semantics (``auto_delete_timeout`` and ``schedule`` are mutually exclusive —
+    supplying both returns an error, because ``auto_delete_timeout`` installs its own scheduler):
+        - No ``schedule`` and ``auto_delete_timeout`` is ``None`` (default) or ``0``: a
+          continuous (permanent) scheduler with ``SchedulingDisabled=false`` and
+          ``RestartWhenRunning=Yes``, which causes the controller to begin acquiring a worker
+          immediately after creation (``ACQUIRING_WORKER`` → ``RUNNING`` with no explicit
+          ``pq_start`` call).
+        - No ``schedule`` and ``auto_delete_timeout`` is a positive integer: a temporary
+          scheduler that auto-deletes the PQ after that many seconds of inactivity.
         - ``schedule=[...]`` (non-empty list): the caller-supplied list **replaces** the
           scheduling block wholesale. No default keys are merged in — the caller is
           responsible for including ``SchedulerType`` and any other required entries.
+        - ``schedule=[]``: the caller is explicitly requesting no scheduling. The
+          scheduling list is cleared; the server decides whether to accept or reject a
+          PQ with no scheduling entries.
 
     Creating a quiescent PQ (created but not auto-starting):
         Two supported recipes, each with different semantics:
@@ -1496,7 +1397,13 @@ async def pq_create(
       state transition.
     - Returns pq_id and serial number for use with other PQ management tools
     - programming_language is case-insensitive: "Python"/"python" or "Groovy"/"groovy"
-    - auto_delete_timeout=None (default) creates a permanent PQ; set to seconds for auto-deletion
+    - auto_delete_timeout=None (default) or 0 creates a permanent PQ; a positive value creates a
+      temporary PQ deleted after that many seconds of inactivity
+    - auto_delete_timeout installs its own scheduler, so it is mutually exclusive with schedule;
+      supplying both returns an error
+    - owner=None (default) makes the PQ owned by the authenticated user; set it to assign a
+      different owner (e.g. a service account). Setting another user as owner may require
+      server-side permission and is rejected by the controller if you lack it.
     - Specify code via script_body (inline) OR script_path (Git) - specifying both causes error
     - Omit both script_body and script_path to create empty interactive session
     - configuration_type="RunAndDone" for batch jobs that execute once and stop
@@ -1565,10 +1472,11 @@ async def pq_create(
         python_virtual_environment (str | None): Named Python venv for Core+ workers
         extra_environment_vars (list[str] | None): Environment variables as ["KEY=value", ...]
         init_timeout_nanos (int | None): Initialization timeout in nanoseconds
-        auto_delete_timeout (int | None): Seconds of inactivity before auto-deletion. None (default) = permanent
+        auto_delete_timeout (int | None): Seconds of inactivity before auto-deletion. None (default) and 0 = permanent; positive = temporary
         admin_groups (list[str] | None): Groups with admin access
         viewer_groups (list[str] | None): Groups with viewer access
         restart_users (str | None): Who can restart - "RU_ADMIN", "RU_ADMIN_AND_VIEWERS", "RU_VIEWERS_WHEN_DOWN"
+        owner (str | None): User to set as the PQ owner. None (default) leaves the owner as the authenticated user.
 
     Returns:
         dict: Success response. The ``"state"`` field is a fixed placeholder
@@ -1600,11 +1508,18 @@ async def pq_create(
     system_name = "<unknown>"
 
     try:
-        # Early validation: script_body and script_path are mutually exclusive
+        # Early validation: mutually exclusive arguments.
         if script_body is not None and script_path is not None:
             result["error"] = (
                 "script_body and script_path are mutually exclusive. "
                 "Specify one or the other, not both."
+            )
+            result["isError"] = True
+            return result
+        if auto_delete_timeout is not None and schedule is not None:
+            result["error"] = (
+                "auto_delete_timeout and schedule are mutually exclusive. "
+                "auto_delete_timeout installs its own scheduler."
             )
             result["isError"] = True
             return result
@@ -1623,16 +1538,13 @@ async def pq_create(
         # Get controller client
         controller = factory.controller_client
 
-        # Normalize and validate programming language
-        normalized_lang = _normalize_programming_language(programming_language)
-
-        # Create PQ configuration
+        # Create PQ configuration (the client normalizes programming_language)
         pq_config = await controller.make_pq_config(
             name=pq_name,
             heap_size_gb=heap_size_gb,
             script_body=script_body,
             script_path=script_path,
-            programming_language=normalized_lang,
+            programming_language=programming_language,
             configuration_type=configuration_type,
             enabled=enabled,
             schedule=schedule,
@@ -1648,6 +1560,7 @@ async def pq_create(
             admin_groups=admin_groups,
             viewer_groups=viewer_groups,
             restart_users=restart_users,
+            owner=owner,
         )
 
         # Add the PQ to controller
@@ -1922,256 +1835,6 @@ async def pq_delete(
     return result
 
 
-def _apply_pq_config_simple_fields(
-    config_pb: "PersistentQueryConfigMessage",
-    pq_name: str | None,
-    heap_size_gb: float | int | None,
-    configuration_type: str | None,
-    enabled: bool | None,
-    server: str | None,
-    engine: str | None,
-    jvm_profile: str | None,
-    python_virtual_environment: str | None,
-    init_timeout_nanos: int | None,
-) -> bool:
-    """Apply simple (scalar) field updates to PersistentQueryConfigMessage protobuf.
-
-    Updates only the fields that are not None. This helper consolidates the boilerplate
-    for applying individual field modifications, called by
-    :func:`_apply_pq_config_modifications` which is used by ``pq_modify``.
-
-    Args:
-        config_pb (PersistentQueryConfigMessage): Protobuf config object to modify in-place
-        pq_name (str | None): New PQ name → protobuf field: config_pb.name
-        heap_size_gb (float | int | None): Worker heap size in GB → protobuf field: config_pb.heapSizeGb
-        configuration_type (str | None): Config type (e.g., "Script", "RunAndDone") → protobuf field: config_pb.configurationType
-        enabled (bool | None): Whether PQ is enabled → protobuf field: config_pb.enabled
-        server (str | None): Target server name → protobuf field: config_pb.serverName
-        engine (str | None): Worker kind/engine type → protobuf field: config_pb.workerKind
-        jvm_profile (str | None): JVM profile name → protobuf field: config_pb.jvmProfile
-        python_virtual_environment (str | None): Python venv control → protobuf field: config_pb.pythonControl
-        init_timeout_nanos (int | None): Initialization timeout in nanoseconds → protobuf field: config_pb.timeoutNanos
-
-    Returns:
-        bool: True if any changes were made, False if all parameters were None
-
-    Note:
-        This function modifies config_pb in-place. Only non-None parameters trigger updates.
-        See _apply_pq_config_list_fields for list-based field updates (script_code, env_vars, etc.).
-    """
-    has_changes = False
-    if pq_name is not None:
-        config_pb.name = pq_name
-        has_changes = True
-    if heap_size_gb is not None:
-        config_pb.heapSizeGb = heap_size_gb
-        has_changes = True
-    if configuration_type is not None:
-        config_pb.configurationType = configuration_type
-        has_changes = True
-    if enabled is not None:
-        config_pb.enabled = enabled
-        has_changes = True
-    if server is not None:
-        config_pb.serverName = server
-        has_changes = True
-    if engine is not None:
-        config_pb.workerKind = engine
-        has_changes = True
-    if jvm_profile is not None:
-        config_pb.jvmProfile = jvm_profile
-        has_changes = True
-    if python_virtual_environment is not None:
-        config_pb.pythonControl = python_virtual_environment
-        has_changes = True
-    if init_timeout_nanos is not None:
-        config_pb.timeoutNanos = init_timeout_nanos
-        has_changes = True
-    return has_changes
-
-
-def _apply_pq_config_list_fields(
-    config_pb: "PersistentQueryConfigMessage",
-    schedule: list[str] | None,
-    extra_jvm_args: list[str] | None,
-    extra_class_path: list[str] | None,
-    extra_environment_vars: list[str] | None,
-    admin_groups: list[str] | None,
-    viewer_groups: list[str] | None,
-) -> bool:
-    """Apply list (repeated) field updates to PersistentQueryConfigMessage protobuf.
-
-    Updates only the fields that are not None using a del/extend pattern to fully replace
-    existing list contents. This helper consolidates the boilerplate for applying list
-    modifications, called by :func:`_apply_pq_config_modifications` which is used by
-    ``pq_modify``.
-
-    Args:
-        config_pb (PersistentQueryConfigMessage): Protobuf config object to modify in-place
-        schedule (list[str] | None): PQ scheduling entries as ``Key=Value`` strings
-            targeting an Iris scheduler class (e.g., ``SchedulerType=com.illumon.iris.controller.IrisQuerySchedulerDaily``,
-            ``StartTime=08:00:00``). These are not cron expressions. Maps to protobuf
-            field ``config_pb.scheduling``.
-        extra_jvm_args (list[str] | None): Additional JVM arguments → protobuf field: config_pb.extraJvmArguments
-        extra_class_path (list[str] | None): Additional classpath entries → protobuf field: config_pb.classPathAdditions
-        extra_environment_vars (list[str] | None): Additional env vars (KEY=VALUE format) → protobuf field: config_pb.extraEnvironmentVariables
-        admin_groups (list[str] | None): Admin group names → protobuf field: config_pb.adminGroups
-        viewer_groups (list[str] | None): Viewer group names → protobuf field: config_pb.viewerGroups
-
-    Returns:
-        bool: True if any changes were made, False if all parameters were None
-
-    Note:
-        Each field is handled with ``del config_pb.field[:]`` followed by
-        ``config_pb.field.extend(new_list)`` so the existing contents are fully
-        replaced rather than appended to. An empty list therefore clears the field.
-    """
-    has_changes = False
-    if schedule is not None:
-        del config_pb.scheduling[:]
-        config_pb.scheduling.extend(schedule)
-        has_changes = True
-    if extra_jvm_args is not None:
-        del config_pb.extraJvmArguments[:]
-        config_pb.extraJvmArguments.extend(extra_jvm_args)
-        has_changes = True
-    if extra_class_path is not None:
-        del config_pb.classPathAdditions[:]
-        config_pb.classPathAdditions.extend(extra_class_path)
-        has_changes = True
-    if extra_environment_vars is not None:
-        del config_pb.extraEnvironmentVariables[:]
-        config_pb.extraEnvironmentVariables.extend(extra_environment_vars)
-        has_changes = True
-    if admin_groups is not None:
-        del config_pb.adminGroups[:]
-        config_pb.adminGroups.extend(admin_groups)
-        has_changes = True
-    if viewer_groups is not None:
-        del config_pb.viewerGroups[:]
-        config_pb.viewerGroups.extend(viewer_groups)
-        has_changes = True
-    return has_changes
-
-
-def _apply_pq_config_modifications(
-    config_pb: "PersistentQueryConfigMessage",
-    pq_name: str | None,
-    heap_size_gb: float | int | None,
-    script_body: str | None,
-    script_path: str | None,
-    programming_language: str | None,
-    configuration_type: str | None,
-    enabled: bool | None,
-    schedule: list[str] | None,
-    server: str | None,
-    engine: str | None,
-    jvm_profile: str | None,
-    extra_jvm_args: list[str] | None,
-    extra_class_path: list[str] | None,
-    python_virtual_environment: str | None,
-    extra_environment_vars: list[str] | None,
-    init_timeout_nanos: int | None,
-    auto_delete_timeout: int | None,
-    admin_groups: list[str] | None,
-    viewer_groups: list[str] | None,
-    restart_users: str | None,
-) -> bool:
-    """Apply configuration modifications to a PQ protobuf config.
-
-    Modifies the provided config_pb in-place based on the provided parameters.
-    Only non-None parameters are applied.
-
-    Args:
-        config_pb (PersistentQueryConfigMessage): Protobuf config object to modify in-place
-        pq_name (str | None): New PQ name
-        heap_size_gb (float | int | None): New heap size in GB
-        script_body (str | None): New inline script code. Caller must ensure this and
-            script_path are not both non-None.
-        script_path (str | None): New Git script path. Caller must ensure this and
-            script_body are not both non-None.
-        programming_language (str | None): New programming language (case-insensitive
-            "Python" or "Groovy")
-        configuration_type (str | None): New configuration type ("Script" or "RunAndDone")
-        enabled (bool | None): New enabled status
-        schedule (list[str] | None): New schedule list (replaces existing)
-        server (str | None): New server name
-        engine (str | None): New engine/worker kind
-        jvm_profile (str | None): New JVM profile
-        extra_jvm_args (list[str] | None): New extra JVM arguments list (replaces existing)
-        extra_class_path (list[str] | None): New extra classpath list (replaces existing)
-        python_virtual_environment (str | None): New Python venv
-        extra_environment_vars (list[str] | None): New environment variables list
-            (replaces existing)
-        init_timeout_nanos (int | None): New init timeout in nanoseconds
-        auto_delete_timeout (int | None): New auto-delete timeout in seconds
-            (converted to nanoseconds internally; 0 = no expiration)
-        admin_groups (list[str] | None): New admin groups list (replaces existing)
-        viewer_groups (list[str] | None): New viewer groups list (replaces existing)
-        restart_users (str | None): New restart users setting
-
-    Returns:
-        bool: True if any changes were made, False if all parameters were None
-    """
-    has_changes = False
-
-    # Handle programming language with normalization
-    if programming_language is not None:
-        normalized_lang = _normalize_programming_language(programming_language)
-        config_pb.scriptLanguage = normalized_lang
-        has_changes = True
-
-    # Handle script_body and script_path (protobuf oneof scriptData clears the other automatically)
-    if script_body is not None:
-        config_pb.scriptCode = script_body
-        has_changes = True
-    if script_path is not None:
-        config_pb.scriptPath = script_path
-        has_changes = True
-
-    # Handle auto_delete_timeout: convert seconds to nanoseconds
-    if auto_delete_timeout is not None:
-        config_pb.expirationTimeNanos = auto_delete_timeout * 1_000_000_000
-        has_changes = True
-
-    # Handle restart_users: convert string to typed protobuf enum value.
-    # ``_convert_restart_users_to_enum`` returns ``RestartUsersEnum.ValueType``,
-    # which matches the stub-declared type of ``restartUsers`` exactly, so no
-    # cast or suppression is required.
-    if restart_users is not None:
-        config_pb.restartUsers = _convert_restart_users_to_enum(restart_users)
-        has_changes = True
-
-    # Apply simple field updates
-    if _apply_pq_config_simple_fields(
-        config_pb,
-        pq_name,
-        heap_size_gb,
-        configuration_type,
-        enabled,
-        server,
-        engine,
-        jvm_profile,
-        python_virtual_environment,
-        init_timeout_nanos,
-    ):
-        has_changes = True
-
-    # Apply list field updates
-    if _apply_pq_config_list_fields(
-        config_pb,
-        schedule,
-        extra_jvm_args,
-        extra_class_path,
-        extra_environment_vars,
-        admin_groups,
-        viewer_groups,
-    ):
-        has_changes = True
-
-    return has_changes
-
-
 async def pq_modify(
     context: Context,
     pq_id: str,
@@ -2196,6 +1859,7 @@ async def pq_modify(
     admin_groups: list[str] | None = None,
     viewer_groups: list[str] | None = None,
     restart_users: str | None = None,
+    owner: str | None = None,
 ) -> dict:
     """MCP Tool: Modify an existing persistent query configuration.
 
@@ -2203,7 +1867,14 @@ async def pq_modify(
     Only specified (non-None) parameters are updated - all others remain unchanged.
     Changes can be applied to PQs in any state (RUNNING, STOPPED, etc.).
 
-    Scheduler semantics (three-way, based on ``schedule``):
+    Scheduler semantics (``auto_delete_timeout`` and ``schedule`` are mutually exclusive —
+    supplying both returns an error, because ``auto_delete_timeout`` installs its own scheduler;
+    use ``auto_delete_timeout`` to switch a PQ between permanent and temporary, or ``schedule``
+    for a custom scheduler):
+        - ``auto_delete_timeout=0``: installs the continuous (permanent) scheduler and clears
+          the auto-delete grace period. ``auto_delete_timeout=<positive>``: installs the
+          temporary scheduler with that idle timeout. ``auto_delete_timeout=None`` (default):
+          leaves scheduling and auto-delete untouched.
         - ``schedule=None`` (default): the existing scheduling on the PQ is preserved
           unchanged.
         - ``schedule=[]``: the caller is explicitly clearing the scheduling. The PQ's
@@ -2275,10 +1946,11 @@ async def pq_modify(
         python_virtual_environment (str | None): Named Python venv for Core+ workers
         extra_environment_vars (list[str] | None): Environment variables as ["KEY=value", ...] (replaces current)
         init_timeout_nanos (int | None): Initialization timeout in nanoseconds
-        auto_delete_timeout (int | None): Seconds of inactivity before auto-deletion. None = no change, 0 = permanent (no expiration), positive integer = timeout in seconds
+        auto_delete_timeout (int | None): Seconds of inactivity before auto-deletion. None = no change, 0 = permanent (auto-delete disabled), positive integer = timeout in seconds
         admin_groups (list[str] | None): Groups with admin access (replaces current)
         viewer_groups (list[str] | None): Groups with viewer access (replaces current)
         restart_users (str | None): Who can restart - "RU_ADMIN", "RU_ADMIN_AND_VIEWERS", "RU_VIEWERS_WHEN_DOWN"
+        owner (str | None): New query owner. None = no change. Reassigning ownership may require server-side permission.
 
     Returns:
         dict: Success response. The ``"warning"`` field is only present when the PQ is
@@ -2311,11 +1983,18 @@ async def pq_modify(
     system_name = "<unknown>"
 
     try:
-        # Early validation: script_body and script_path are mutually exclusive
+        # Early validation: mutually exclusive arguments.
         if script_body is not None and script_path is not None:
             result["error"] = (
                 "script_body and script_path are mutually exclusive. "
                 "Specify one or the other, not both."
+            )
+            result["isError"] = True
+            return result
+        if auto_delete_timeout is not None and schedule is not None:
+            result["error"] = (
+                "auto_delete_timeout and schedule are mutually exclusive. "
+                "auto_delete_timeout installs its own scheduler."
             )
             result["isError"] = True
             return result
@@ -2361,31 +2040,31 @@ async def pq_modify(
         # Get current PQ info and config
         pq_info = pq_map[serial]
         config = pq_info.config
-        config_pb = config.pb
 
-        # Apply configuration modifications using helper function
-        has_changes = _apply_pq_config_modifications(
-            config_pb,
-            pq_name,
-            heap_size_gb,
-            script_body,
-            script_path,
-            programming_language,
-            configuration_type,
-            enabled,
-            schedule,
-            server,
-            engine,
-            jvm_profile,
-            extra_jvm_args,
-            extra_class_path,
-            python_virtual_environment,
-            extra_environment_vars,
-            init_timeout_nanos,
-            auto_delete_timeout,
-            admin_groups,
-            viewer_groups,
-            restart_users,
+        # Apply configuration modifications via the shared client-layer applier.
+        has_changes = controller.update_pq_config(
+            config,
+            pq_name=pq_name,
+            heap_size_gb=heap_size_gb,
+            script_body=script_body,
+            script_path=script_path,
+            programming_language=programming_language,
+            configuration_type=configuration_type,
+            enabled=enabled,
+            schedule=schedule,
+            server=server,
+            engine=engine,
+            jvm_profile=jvm_profile,
+            extra_jvm_args=extra_jvm_args,
+            extra_class_path=extra_class_path,
+            python_virtual_environment=python_virtual_environment,
+            extra_environment_vars=extra_environment_vars,
+            init_timeout_nanos=init_timeout_nanos,
+            auto_delete_timeout=auto_delete_timeout,
+            admin_groups=admin_groups,
+            viewer_groups=viewer_groups,
+            restart_users=restart_users,
+            owner=owner,
         )
 
         # Only modify if changes were made

--- a/tests/client/test__controller_client.py
+++ b/tests/client/test__controller_client.py
@@ -41,6 +41,26 @@ from deephaven_mcp._exceptions import (
 )
 
 
+@pytest.fixture(scope="session")
+def pq_config_mod():
+    from deephaven_mcp.client import _pq_config
+
+    return _pq_config
+
+
+def _make_config_mock():
+    """Build a MagicMock PQ config protobuf usable by the field appliers.
+
+    ``typeSpecificFieldsJson`` is a real empty string so ``_set_termination_delay``
+    can ``json.loads`` it; ``scheduling`` is a MagicMock that records ``del x[:]``
+    (``__delitem__``) and ``extend`` calls.
+    """
+    config = MagicMock()
+    config.typeSpecificFieldsJson = ""
+    config.scheduling = MagicMock()
+    return config
+
+
 @pytest.fixture
 def dummy_controller_client():
     client = MagicMock()
@@ -431,7 +451,7 @@ async def test_add_query_timeout(coreplus_controller_client, dummy_controller_cl
 async def test_make_pq_config_success(
     coreplus_controller_client, dummy_controller_client, controller_client_mod
 ):
-    dummy_controller_client.make_pq_config.return_value = "config"
+    dummy_controller_client.make_temporary_config.return_value = _make_config_mock()
     # Patch CorePlusQueryConfig to a dummy class for test
     with patch.object(
         controller_client_mod, "CorePlusQueryConfig", autospec=True
@@ -463,15 +483,27 @@ async def test_make_pq_config_mutually_exclusive_scripts(coreplus_controller_cli
 
 @pytest.mark.asyncio
 async def test_make_pq_config_with_all_parameters(
-    coreplus_controller_client, dummy_controller_client, controller_client_mod
+    coreplus_controller_client,
+    dummy_controller_client,
+    controller_client_mod,
+    pq_config_mod,
 ):
-    """Test that all config parameters are applied correctly with script_body."""
-    mock_config = MagicMock()
+    """Test that all config parameters are applied correctly with script_body.
+
+    An explicit ``schedule`` is mutually exclusive with ``auto_delete_timeout``, so it
+    replaces the scheduling block wholesale and the auto-delete path is a no-op. The
+    simple fields are written under their protobuf names (``classPathAdditions``,
+    ``timeoutNanos``, ``pythonControl``), and ``restart_users`` routes through the enum
+    converter (``RestartUsersEnum`` is patched since the Core+ wheel is absent in CI).
+    """
+    mock_config = _make_config_mock()
     dummy_controller_client.make_temporary_config.return_value = mock_config
 
-    with patch.object(
-        controller_client_mod, "CorePlusQueryConfig", autospec=True
-    ) as mock_cfg:
+    with (
+        patch.object(controller_client_mod, "CorePlusQueryConfig", autospec=True),
+        patch.object(pq_config_mod, "RestartUsersEnum") as mock_restart_enum,
+    ):
+        mock_restart_enum.Value.return_value = 1
         await coreplus_controller_client.make_pq_config(
             name="test-pq",
             heap_size_gb=8.0,
@@ -487,21 +519,23 @@ async def test_make_pq_config_with_all_parameters(
             python_virtual_environment="my-venv",
         )
 
-        # Verify all parameters were applied to config
+        # Verify all parameters were applied to config under their protobuf names.
         assert mock_config.scriptLanguage == "Python"
         assert mock_config.scriptCode == "print('hello')"
         assert mock_config.configurationType == "RunAndDone"
         assert mock_config.enabled == False
-        assert mock_config.restartUsers == "RU_ADMIN"
-        mock_config.extraClassPath.extend.assert_called_once_with(
+        # restart_users is converted via the enum (RU_ADMIN -> 1), not stored as a string.
+        mock_restart_enum.Value.assert_called_once_with("RU_ADMIN")
+        assert mock_config.restartUsers == 1
+        mock_config.classPathAdditions.extend.assert_called_once_with(
             ["/opt/libs/custom.jar"]
         )
         mock_config.scheduling.extend.assert_called_once_with(
             ["SchedulerType=Daily", "StartTime=08:00:00"]
         )
-        assert mock_config.initTimeoutNanos == 5000000000
+        assert mock_config.timeoutNanos == 5000000000
         assert mock_config.jvmProfile == "large-memory"
-        assert mock_config.pythonVirtualEnvironment == "my-venv"
+        assert mock_config.pythonControl == "my-venv"
 
 
 @pytest.mark.asyncio
@@ -509,7 +543,7 @@ async def test_make_pq_config_with_script_path(
     coreplus_controller_client, dummy_controller_client, controller_client_mod
 ):
     """Test that script_path parameter is applied correctly."""
-    mock_config = MagicMock()
+    mock_config = _make_config_mock()
     dummy_controller_client.make_temporary_config.return_value = mock_config
 
     with patch.object(
@@ -532,7 +566,7 @@ async def test_make_pq_config_none_defaults_preserve_config(
     coreplus_controller_client, dummy_controller_client, controller_client_mod
 ):
     """Test that None parameters don't override make_temporary_config defaults."""
-    mock_config = MagicMock()
+    mock_config = _make_config_mock()
     # Set up some default values that make_temporary_config would have set
     mock_config.scriptLanguage = "Groovy"
     mock_config.configurationType = "InteractiveConsole"
@@ -558,10 +592,62 @@ async def test_make_pq_config_none_defaults_preserve_config(
 
 @pytest.mark.asyncio
 async def test_make_pq_config_auto_delete_timeout_passed_to_make_temporary_config(
-    coreplus_controller_client, dummy_controller_client, controller_client_mod
+    coreplus_controller_client,
+    dummy_controller_client,
+    controller_client_mod,
+    pq_config_mod,
 ):
-    """Test that auto_delete_timeout is passed to make_temporary_config."""
-    mock_config = MagicMock()
+    """make_temporary_config always receives None for the auto-delete arg.
+
+    Construction of the temporary scheduler now lives in ``_apply_pq_config_fields``,
+    so make_pq_config passes ``None`` as the 7th positional arg and installs the
+    temporary scheduler itself (via the patched ``GenerateScheduling``).
+    """
+    mock_config = _make_config_mock()
+    dummy_controller_client.make_temporary_config.return_value = mock_config
+    temp_scheduler = ["SchedulerType=Temporary", "AutoDelete=true"]
+
+    with (
+        patch.object(controller_client_mod, "CorePlusQueryConfig", autospec=True),
+        patch.object(pq_config_mod, "GenerateScheduling") as mock_gen_scheduling,
+    ):
+        mock_gen_scheduling.generate_temporary_scheduler.return_value = temp_scheduler
+        await coreplus_controller_client.make_pq_config(
+            name="test-pq",
+            heap_size_gb=8.0,
+            auto_delete_timeout=300,  # 5 minutes
+        )
+
+        # make_temporary_config always gets None as the 7th positional arg now.
+        dummy_controller_client.make_temporary_config.assert_called_once()
+        call_args = dummy_controller_client.make_temporary_config.call_args
+        assert call_args[0][6] is None
+
+        # The temporary scheduler from GenerateScheduling replaces the scheduling block,
+        # and TerminationDelay is set to 300s (in ms).
+        mock_config.scheduling.__delitem__.assert_called_once_with(slice(None))
+        mock_config.scheduling.extend.assert_called_once_with(temp_scheduler)
+        import json as _json
+
+        assert _json.loads(mock_config.typeSpecificFieldsJson)["TerminationDelay"] == {
+            "type": "long",
+            "value": "300000",
+        }
+
+
+@pytest.mark.asyncio
+async def test_make_pq_config_auto_delete_timeout_zero_normalized_to_none(
+    coreplus_controller_client,
+    dummy_controller_client,
+    controller_client_mod,
+    pq_config_mod,
+):
+    """Test that auto_delete_timeout=0 keeps make_temporary_config's auto-delete arg None.
+
+    make_temporary_config always gets None now; the permanent (continuous) scheduler is
+    installed by ``_apply_pq_config_fields`` for ``auto_delete_timeout=0``.
+    """
+    mock_config = _make_config_mock()
     dummy_controller_client.make_temporary_config.return_value = mock_config
 
     with patch.object(
@@ -570,14 +656,61 @@ async def test_make_pq_config_auto_delete_timeout_passed_to_make_temporary_confi
         await coreplus_controller_client.make_pq_config(
             name="test-pq",
             heap_size_gb=8.0,
-            auto_delete_timeout=300,  # 5 minutes
+            auto_delete_timeout=0,  # 0 means permanent, same as None
         )
 
-        # Verify auto_delete_timeout was passed to make_temporary_config
+        # make_temporary_config always gets None as the 7th positional arg.
         dummy_controller_client.make_temporary_config.assert_called_once()
         call_args = dummy_controller_client.make_temporary_config.call_args
-        # auto_delete_timeout is the 7th positional arg (after name, heap, server, extra_jvm_args, extra_env_vars, engine)
-        assert call_args[0][6] == 300
+        assert call_args[0][6] is None
+
+        # Permanent: continuous scheduling installed, no TerminationDelay.
+        mock_config.scheduling.__delitem__.assert_called_once_with(slice(None))
+        mock_config.scheduling.extend.assert_called_once_with(
+            pq_config_mod._DEFAULT_PERMANENT_CONTINUOUS_SCHEDULING
+        )
+        assert mock_config.typeSpecificFieldsJson == ""
+
+
+@pytest.mark.asyncio
+async def test_make_pq_config_owner_applied_when_supplied(
+    coreplus_controller_client, dummy_controller_client, controller_client_mod
+):
+    """Test that owner is applied to config when supplied to make_pq_config."""
+    mock_config = _make_config_mock()
+    mock_config.owner = "authenticated-user"  # Default from make_temporary_config
+    dummy_controller_client.make_temporary_config.return_value = mock_config
+
+    with patch.object(
+        controller_client_mod, "CorePlusQueryConfig", autospec=True
+    ) as mock_cfg:
+        await coreplus_controller_client.make_pq_config(
+            name="test-pq",
+            heap_size_gb=8.0,
+            owner="service-account",
+        )
+
+        assert mock_config.owner == "service-account"
+
+
+@pytest.mark.asyncio
+async def test_make_pq_config_owner_untouched_when_omitted(
+    coreplus_controller_client, dummy_controller_client, controller_client_mod
+):
+    """Test that owner is left as the make_temporary_config default when not supplied."""
+    mock_config = _make_config_mock()
+    mock_config.owner = "authenticated-user"  # Default from make_temporary_config
+    dummy_controller_client.make_temporary_config.return_value = mock_config
+
+    with patch.object(
+        controller_client_mod, "CorePlusQueryConfig", autospec=True
+    ) as mock_cfg:
+        await coreplus_controller_client.make_pq_config(
+            name="test-pq",
+            heap_size_gb=8.0,
+        )
+
+        assert mock_config.owner == "authenticated-user"
 
 
 @pytest.mark.asyncio
@@ -585,7 +718,7 @@ async def test_make_pq_config_enabled_true_is_applied(
     coreplus_controller_client, dummy_controller_client, controller_client_mod
 ):
     """Test that enabled=True is explicitly applied to config."""
-    mock_config = MagicMock()
+    mock_config = _make_config_mock()
     mock_config.enabled = False  # Default from make_temporary_config
     dummy_controller_client.make_temporary_config.return_value = mock_config
 
@@ -604,12 +737,14 @@ async def test_make_pq_config_enabled_true_is_applied(
 
 @pytest.mark.asyncio
 async def test_make_pq_config_permanent_query_clears_scheduling(
-    coreplus_controller_client, dummy_controller_client, controller_client_mod
+    coreplus_controller_client,
+    dummy_controller_client,
+    controller_client_mod,
+    pq_config_mod,
 ):
-    """Test that permanent queries (auto_delete_timeout=None) clear temporary scheduling."""
-    mock_config = MagicMock()
-    mock_scheduling = MagicMock()
-    mock_config.scheduling = mock_scheduling
+    """Test that permanent queries (auto_delete_timeout=None) install continuous scheduling."""
+    mock_config = _make_config_mock()
+    mock_scheduling = mock_config.scheduling
     dummy_controller_client.make_temporary_config.return_value = mock_config
 
     with patch.object(
@@ -621,40 +756,55 @@ async def test_make_pq_config_permanent_query_clears_scheduling(
             auto_delete_timeout=None,  # Permanent query
         )
 
-        # Verify make_temporary_config was called with a default timeout (600)
+        # Regression test for #165: permanent queries must pass auto_delete_timeout=None
+        # to make_temporary_config so no TerminationDelay / TemporaryAutoDelete is set;
+        # a non-None placeholder would survive the scheduling replacement and cause the
+        # controller to auto-delete the "permanent" query.
         dummy_controller_client.make_temporary_config.assert_called_once()
         call_args = dummy_controller_client.make_temporary_config.call_args
-        # auto_delete_timeout is the 7th positional arg
-        assert call_args[0][6] == 600  # Default timeout used for creation
+        # auto_delete_timeout is the 7th positional arg, always None now.
+        assert call_args[0][6] is None
 
-        # Verify scheduling was cleared and set to continuous for permanent query
+        # Scheduling cleared and replaced wholesale with the continuous (permanent) block.
         mock_scheduling.__delitem__.assert_called_once_with(slice(None))
-        # Verify all continuous scheduling parameters were appended
-        append_calls = [call[0][0] for call in mock_scheduling.append.call_args_list]
+        mock_scheduling.extend.assert_called_once_with(
+            pq_config_mod._DEFAULT_PERMANENT_CONTINUOUS_SCHEDULING
+        )
+        extended = mock_scheduling.extend.call_args[0][0]
         assert (
             "SchedulerType=com.illumon.iris.controller.IrisQuerySchedulerContinuous"
-            in append_calls
+            in extended
         )
-        assert "StartTime=00:00:00" in append_calls
-        assert "DailyRestart=false" in append_calls
-        assert "SchedulingDisabled=false" in append_calls
+        assert "StartTime=00:00:00" in extended
+        assert "DailyRestart=false" in extended
+        assert "SchedulingDisabled=false" in extended
+        # Permanent → no TerminationDelay.
+        assert mock_config.typeSpecificFieldsJson == ""
 
 
 @pytest.mark.asyncio
 async def test_make_pq_config_temporary_schedule_none_no_default_installed(
-    coreplus_controller_client, dummy_controller_client, controller_client_mod
+    coreplus_controller_client,
+    dummy_controller_client,
+    controller_client_mod,
+    pq_config_mod,
 ):
-    """Temporary PQ (auto_delete_timeout set) with schedule=None: no default override.
+    """Temporary PQ (auto_delete_timeout set) with schedule=None: install temp scheduler.
 
-    The scheduling installed by ``make_temporary_config`` must be preserved — the
-    method must not clear it or append a continuous scheduler.
+    With no explicit schedule, ``auto_delete_timeout`` drives the scheduler: the temporary
+    scheduler from ``GenerateScheduling`` replaces the scheduling block and TerminationDelay
+    is set.
     """
-    mock_config = MagicMock()
-    mock_scheduling = MagicMock()
-    mock_config.scheduling = mock_scheduling
+    mock_config = _make_config_mock()
+    mock_scheduling = mock_config.scheduling
     dummy_controller_client.make_temporary_config.return_value = mock_config
+    temp_scheduler = ["SchedulerType=Temporary"]
 
-    with patch.object(controller_client_mod, "CorePlusQueryConfig", autospec=True):
+    with (
+        patch.object(controller_client_mod, "CorePlusQueryConfig", autospec=True),
+        patch.object(pq_config_mod, "GenerateScheduling") as mock_gen_scheduling,
+    ):
+        mock_gen_scheduling.generate_temporary_scheduler.return_value = temp_scheduler
         await coreplus_controller_client.make_pq_config(
             name="test-pq",
             heap_size_gb=8.0,
@@ -662,24 +812,26 @@ async def test_make_pq_config_temporary_schedule_none_no_default_installed(
             schedule=None,
         )
 
-        # Scheduling must not be cleared and must not be extended.
-        mock_scheduling.__delitem__.assert_not_called()
-        mock_scheduling.extend.assert_not_called()
-        mock_scheduling.append.assert_not_called()
+        # Temporary scheduler installed wholesale; TerminationDelay set.
+        mock_scheduling.__delitem__.assert_called_once_with(slice(None))
+        mock_scheduling.extend.assert_called_once_with(temp_scheduler)
+        mock_gen_scheduling.generate_temporary_scheduler.assert_called_once()
+        import json as _json
+
+        assert "TerminationDelay" in _json.loads(mock_config.typeSpecificFieldsJson)
 
 
 @pytest.mark.asyncio
 async def test_make_pq_config_permanent_schedule_empty_clears_without_default(
     coreplus_controller_client, dummy_controller_client, controller_client_mod
 ):
-    """Permanent PQ with schedule=[]: scheduling must be empty (no default installed).
+    """Permanent PQ with schedule=[]: scheduling cleared, no continuous default installed.
 
-    schedule=[] is an explicit "no scheduling" signal and must override the default
-    continuous scheduler that would otherwise be installed for a permanent PQ.
+    An explicit ``schedule`` (even empty) is mutually exclusive with auto_delete_timeout,
+    so the auto-delete path is a no-op and the list applier clears the block to empty.
     """
-    mock_config = MagicMock()
-    mock_scheduling = MagicMock()
-    mock_config.scheduling = mock_scheduling
+    mock_config = _make_config_mock()
+    mock_scheduling = mock_config.scheduling
     dummy_controller_client.make_temporary_config.return_value = mock_config
 
     with patch.object(controller_client_mod, "CorePlusQueryConfig", autospec=True):
@@ -690,35 +842,30 @@ async def test_make_pq_config_permanent_schedule_empty_clears_without_default(
             schedule=[],  # Explicit "no scheduling"
         )
 
-        # Scheduling was cleared exactly once (for the override).
+        # The list applier cleared the block and extended it with the empty list;
+        # the continuous-default path did not run (no continuous entries).
         mock_scheduling.__delitem__.assert_called_once_with(slice(None))
-        # No default continuous entries were appended.
-        mock_scheduling.append.assert_not_called()
-        # extend([]) is not called because the body skips it for empty override.
-        mock_scheduling.extend.assert_not_called()
+        mock_scheduling.extend.assert_called_once_with([])
+        # No TerminationDelay (auto-delete path was a no-op).
+        assert mock_config.typeSpecificFieldsJson == ""
 
 
 @pytest.mark.asyncio
 async def test_make_pq_config_temporary_schedule_empty_clears(
     coreplus_controller_client, dummy_controller_client, controller_client_mod
 ):
-    """Temporary PQ with schedule=[]: existing temp scheduling must be cleared."""
-    mock_config = MagicMock()
-    mock_scheduling = MagicMock()
-    mock_config.scheduling = mock_scheduling
-    dummy_controller_client.make_temporary_config.return_value = mock_config
+    """Temporary PQ with schedule=[]: auto_delete_timeout and schedule are mutually exclusive.
 
-    with patch.object(controller_client_mod, "CorePlusQueryConfig", autospec=True):
+    Supplying both a positive auto_delete_timeout and any explicit schedule (including the
+    empty list) is rejected up front, because auto_delete_timeout installs its own scheduler.
+    """
+    with pytest.raises(ValueError, match="mutually exclusive"):
         await coreplus_controller_client.make_pq_config(
             name="test-pq",
             heap_size_gb=8.0,
             auto_delete_timeout=300,  # Temporary
-            schedule=[],  # Explicit clear
+            schedule=[],  # Explicit clear — mutually exclusive with auto_delete_timeout
         )
-
-        mock_scheduling.__delitem__.assert_called_once_with(slice(None))
-        mock_scheduling.append.assert_not_called()
-        mock_scheduling.extend.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -760,25 +907,19 @@ async def test_make_pq_config_permanent_schedule_explicit_replaces_default(
 async def test_make_pq_config_temporary_schedule_explicit_replaces_temp(
     coreplus_controller_client, dummy_controller_client, controller_client_mod
 ):
-    """Temporary PQ with a non-empty schedule: caller's list replaces temp scheduling."""
-    mock_config = MagicMock()
-    mock_scheduling = MagicMock()
-    mock_config.scheduling = mock_scheduling
-    dummy_controller_client.make_temporary_config.return_value = mock_config
+    """Temporary PQ with a non-empty schedule: auto_delete_timeout and schedule conflict.
 
+    Supplying both is rejected up front; auto_delete_timeout installs its own scheduler.
+    """
     caller_schedule = ["SchedulerType=Daily", "StartTime=08:00:00"]
 
-    with patch.object(controller_client_mod, "CorePlusQueryConfig", autospec=True):
+    with pytest.raises(ValueError, match="mutually exclusive"):
         await coreplus_controller_client.make_pq_config(
             name="test-pq",
             heap_size_gb=8.0,
             auto_delete_timeout=300,  # Temporary
             schedule=caller_schedule,
         )
-
-        mock_scheduling.__delitem__.assert_called_once_with(slice(None))
-        mock_scheduling.extend.assert_called_once_with(caller_schedule)
-        mock_scheduling.append.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1406,3 +1547,122 @@ async def test_stop_and_wait_passes_zero_when_not_waiting(
 ):
     await coreplus_controller_client.stop_and_wait(42, wait=False)
     dummy_controller_client.stop_and_wait.assert_called_once_with(42, 0)
+
+
+# ===========================================================================
+# update_pq_config tests
+# ===========================================================================
+
+
+def _update_config_wrapper():
+    """A CorePlusQueryConfig-like wrapper whose .pb is a field-applier-ready mock."""
+    wrapper = MagicMock()
+    wrapper.pb = _make_config_mock()
+    return wrapper
+
+
+def test_update_pq_config_all_none_returns_false(coreplus_controller_client):
+    wrapper = _update_config_wrapper()
+    assert coreplus_controller_client.update_pq_config(wrapper) is False
+
+
+def test_update_pq_config_sets_owner(coreplus_controller_client):
+    wrapper = _update_config_wrapper()
+    assert coreplus_controller_client.update_pq_config(wrapper, owner="svc") is True
+    assert wrapper.pb.owner == "svc"
+
+
+def test_update_pq_config_auto_delete_zero_continuous(
+    coreplus_controller_client, pq_config_mod
+):
+    wrapper = _update_config_wrapper()
+    wrapper.pb.typeSpecificFieldsJson = (
+        '{"TerminationDelay": {"type": "long", "value": "1"}}'
+    )
+    assert (
+        coreplus_controller_client.update_pq_config(wrapper, auto_delete_timeout=0)
+        is True
+    )
+    wrapper.pb.scheduling.__delitem__.assert_called_once_with(slice(None))
+    wrapper.pb.scheduling.extend.assert_called_once_with(
+        pq_config_mod._DEFAULT_PERMANENT_CONTINUOUS_SCHEDULING
+    )
+    assert wrapper.pb.typeSpecificFieldsJson == ""
+
+
+def test_update_pq_config_auto_delete_positive_temporary(
+    coreplus_controller_client, pq_config_mod
+):
+    import json
+
+    wrapper = _update_config_wrapper()
+    temp_scheduler = ["SchedulerType=Temporary"]
+    with patch.object(pq_config_mod, "GenerateScheduling") as mock_gen:
+        mock_gen.generate_temporary_scheduler.return_value = temp_scheduler
+        assert (
+            coreplus_controller_client.update_pq_config(
+                wrapper, auto_delete_timeout=120
+            )
+            is True
+        )
+    wrapper.pb.scheduling.extend.assert_called_once_with(temp_scheduler)
+    assert json.loads(wrapper.pb.typeSpecificFieldsJson)["TerminationDelay"] == {
+        "type": "long",
+        "value": "120000",
+    }
+
+
+def test_update_pq_config_reject_auto_delete_and_schedule(coreplus_controller_client):
+    wrapper = _update_config_wrapper()
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        coreplus_controller_client.update_pq_config(
+            wrapper, auto_delete_timeout=60, schedule=["s"]
+        )
+
+
+def test_update_pq_config_reject_script_body_and_path(coreplus_controller_client):
+    wrapper = _update_config_wrapper()
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        coreplus_controller_client.update_pq_config(
+            wrapper, script_body="code", script_path="path"
+        )
+
+
+def test_update_pq_config_restart_users_enum_conversion(
+    coreplus_controller_client, pq_config_mod
+):
+    wrapper = _update_config_wrapper()
+    with patch.object(pq_config_mod, "RestartUsersEnum") as mock_enum:
+        mock_enum.Value.return_value = 3
+        assert (
+            coreplus_controller_client.update_pq_config(
+                wrapper, restart_users="RU_ADMIN"
+            )
+            is True
+        )
+    assert wrapper.pb.restartUsers == 3
+
+
+@pytest.mark.asyncio
+async def test_make_pq_config_restart_users_enum_conversion(
+    coreplus_controller_client,
+    dummy_controller_client,
+    controller_client_mod,
+    pq_config_mod,
+):
+    """Regression: restart_users routes through the enum converter, not raw assignment."""
+    mock_config = _make_config_mock()
+    dummy_controller_client.make_temporary_config.return_value = mock_config
+
+    with (
+        patch.object(controller_client_mod, "CorePlusQueryConfig", autospec=True),
+        patch.object(pq_config_mod, "RestartUsersEnum") as mock_enum,
+    ):
+        mock_enum.Value.return_value = 1
+        await coreplus_controller_client.make_pq_config(
+            name="test-pq",
+            heap_size_gb=8.0,
+            restart_users="RU_ADMIN",
+        )
+        mock_enum.Value.assert_called_once_with("RU_ADMIN")
+        assert mock_config.restartUsers == 1

--- a/tests/client/test__pq_config.py
+++ b/tests/client/test__pq_config.py
@@ -1,0 +1,395 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deephaven_mcp._exceptions import MissingEnterprisePackageError
+from deephaven_mcp.client._pq_config import (
+    _apply_auto_delete_timeout,
+    _apply_pq_config_list_fields,
+    _apply_pq_config_simple_fields,
+    _convert_restart_users_to_enum,
+    _normalize_programming_language,
+    _set_termination_delay,
+    apply_pq_config_fields,
+    validate_pq_config_args,
+)
+
+
+@pytest.fixture(scope="session")
+def pq_config_mod():
+    from deephaven_mcp.client import _pq_config
+
+    return _pq_config
+
+
+# Capture the real protobuf class at collection time. Used by the oneof test
+# (protobuf oneof semantics cannot be exercised with a MagicMock).
+try:
+    from deephaven_enterprise.proto.persistent_query_pb2 import (
+        PersistentQueryConfigMessage as _PQConfigMessage,
+    )
+except Exception:
+    _PQConfigMessage = None
+
+
+def _make_config_mock():
+    """Build a MagicMock PQ config protobuf usable by the field appliers.
+
+    ``typeSpecificFieldsJson`` is a real empty string so ``_set_termination_delay``
+    can ``json.loads`` it; ``scheduling`` is a MagicMock that records ``del x[:]``
+    (``__delitem__``) and ``extend`` calls.
+    """
+    config = MagicMock()
+    config.typeSpecificFieldsJson = ""
+    config.scheduling = MagicMock()
+    return config
+
+
+# ===========================================================================
+# Module-level PQ-config helper tests
+# ===========================================================================
+
+
+def test_normalize_programming_language_python():
+    assert _normalize_programming_language("python") == "Python"
+    assert _normalize_programming_language("PYTHON") == "Python"
+    assert _normalize_programming_language("Python") == "Python"
+
+
+def test_normalize_programming_language_groovy():
+    assert _normalize_programming_language("groovy") == "Groovy"
+    assert _normalize_programming_language("GROOVY") == "Groovy"
+
+
+def test_normalize_programming_language_invalid():
+    with pytest.raises(ValueError, match="Invalid programming_language"):
+        _normalize_programming_language("javascript")
+
+
+def test_convert_restart_users_to_enum_missing_package(pq_config_mod):
+    """RestartUsersEnum is None (enterprise absent) -> MissingEnterprisePackageError."""
+    with patch.object(pq_config_mod, "RestartUsersEnum", None):
+        with pytest.raises(MissingEnterprisePackageError):
+            _convert_restart_users_to_enum("RU_ADMIN")
+
+
+def test_convert_restart_users_to_enum_valid(pq_config_mod):
+    with patch.object(pq_config_mod, "RestartUsersEnum") as mock_enum:
+        mock_enum.Value.return_value = 1
+        assert _convert_restart_users_to_enum("RU_ADMIN") == 1
+        mock_enum.Value.assert_called_once_with("RU_ADMIN")
+
+
+def test_convert_restart_users_to_enum_invalid_name(pq_config_mod):
+    with patch.object(pq_config_mod, "RestartUsersEnum") as mock_enum:
+        mock_enum.Value.side_effect = ValueError("bad")
+        mock_enum.keys.return_value = ["RU_ADMIN", "RU_VIEWERS_WHEN_DOWN"]
+        with pytest.raises(ValueError, match="Invalid restart_users: 'NOPE'"):
+            _convert_restart_users_to_enum("NOPE")
+
+
+def test_set_termination_delay_set_on_empty():
+    config = MagicMock()
+    config.typeSpecificFieldsJson = ""
+    _set_termination_delay(config, 60000)
+
+    assert json.loads(config.typeSpecificFieldsJson) == {
+        "TerminationDelay": {"type": "long", "value": "60000"}
+    }
+
+
+def test_set_termination_delay_preserves_other_keys():
+    config = MagicMock()
+    config.typeSpecificFieldsJson = json.dumps(
+        {"Other": {"type": "string", "value": "keep"}}
+    )
+    _set_termination_delay(config, 5000)
+    decoded = json.loads(config.typeSpecificFieldsJson)
+    assert decoded["Other"] == {"type": "string", "value": "keep"}
+    assert decoded["TerminationDelay"] == {"type": "long", "value": "5000"}
+
+
+def test_set_termination_delay_remove_keeps_others():
+    config = MagicMock()
+    config.typeSpecificFieldsJson = json.dumps(
+        {
+            "TerminationDelay": {"type": "long", "value": "5000"},
+            "Other": {"type": "string", "value": "keep"},
+        }
+    )
+    _set_termination_delay(config, None)
+    assert json.loads(config.typeSpecificFieldsJson) == {
+        "Other": {"type": "string", "value": "keep"}
+    }
+
+
+def test_set_termination_delay_remove_empties_when_only_key():
+    config = MagicMock()
+    config.typeSpecificFieldsJson = json.dumps(
+        {"TerminationDelay": {"type": "long", "value": "5000"}}
+    )
+    _set_termination_delay(config, None)
+    assert config.typeSpecificFieldsJson == ""
+
+
+def test_apply_auto_delete_timeout_none_is_noop():
+    config = MagicMock()
+    config.typeSpecificFieldsJson = "existing"
+    assert _apply_auto_delete_timeout(config, None) is False
+    config.scheduling.__delitem__.assert_not_called()
+    assert config.typeSpecificFieldsJson == "existing"
+
+
+def test_apply_auto_delete_timeout_zero_installs_continuous(pq_config_mod):
+    config = MagicMock()
+    config.typeSpecificFieldsJson = (
+        '{"TerminationDelay": {"type": "long", "value": "1"}}'
+    )
+    assert _apply_auto_delete_timeout(config, 0) is True
+    config.scheduling.__delitem__.assert_called_once_with(slice(None))
+    config.scheduling.extend.assert_called_once_with(
+        pq_config_mod._DEFAULT_PERMANENT_CONTINUOUS_SCHEDULING
+    )
+    # TerminationDelay removed (was the only key) -> empty string.
+    assert config.typeSpecificFieldsJson == ""
+
+
+def test_apply_auto_delete_timeout_positive_installs_temporary(pq_config_mod):
+    config = MagicMock()
+    config.typeSpecificFieldsJson = ""
+    temp_scheduler = ["SchedulerType=Temporary"]
+    with patch.object(pq_config_mod, "GenerateScheduling") as mock_gen:
+        mock_gen.generate_temporary_scheduler.return_value = temp_scheduler
+        assert _apply_auto_delete_timeout(config, 300) is True
+        mock_gen.generate_temporary_scheduler.assert_called_once_with(
+            expiration_time_minutes=pq_config_mod._TEMPORARY_EXPIRATION_MINUTES,
+            queue_name=pq_config_mod._TEMPORARY_QUEUE_NAME,
+            auto_delete=True,
+        )
+    config.scheduling.__delitem__.assert_called_once_with(slice(None))
+    config.scheduling.extend.assert_called_once_with(temp_scheduler)
+    assert json.loads(config.typeSpecificFieldsJson)["TerminationDelay"] == {
+        "type": "long",
+        "value": "300000",
+    }
+
+
+def test_apply_auto_delete_timeout_positive_missing_package(pq_config_mod):
+    config = MagicMock()
+    config.typeSpecificFieldsJson = ""
+    with patch.object(pq_config_mod, "GenerateScheduling", None):
+        with pytest.raises(MissingEnterprisePackageError):
+            _apply_auto_delete_timeout(config, 300)
+
+
+def test_apply_pq_config_simple_fields_all_none():
+    config = MagicMock()
+    assert (
+        _apply_pq_config_simple_fields(
+            config, None, None, None, None, None, None, None, None, None
+        )
+        is False
+    )
+
+
+def test_apply_pq_config_simple_fields_sets_protobuf_names():
+    config = MagicMock()
+    assert (
+        _apply_pq_config_simple_fields(
+            config,
+            "pq",
+            4.0,
+            "Script",
+            True,
+            "srv",
+            "Engine",
+            "profile",
+            "venv",
+            123,
+        )
+        is True
+    )
+    assert config.name == "pq"
+    assert config.heapSizeGb == 4.0
+    assert config.configurationType == "Script"
+    assert config.enabled is True
+    assert config.serverName == "srv"
+    assert config.workerKind == "Engine"
+    assert config.jvmProfile == "profile"
+    # python_virtual_environment maps to pythonControl (NOT pythonVirtualEnvironment).
+    assert config.pythonControl == "venv"
+    # init_timeout_nanos maps to timeoutNanos (NOT initTimeoutNanos).
+    assert config.timeoutNanos == 123
+
+
+def test_apply_pq_config_list_fields_all_none_preserves_existing():
+    config = MagicMock()
+    assert (
+        _apply_pq_config_list_fields(config, None, None, None, None, None, None)
+        is False
+    )
+    config.scheduling.__delitem__.assert_not_called()
+    config.extraJvmArguments.__delitem__.assert_not_called()
+
+
+def test_apply_pq_config_list_fields_empty_clears():
+    config = MagicMock()
+    assert _apply_pq_config_list_fields(config, [], [], [], [], [], []) is True
+    config.scheduling.__delitem__.assert_called_once_with(slice(None))
+    config.scheduling.extend.assert_called_once_with([])
+    config.extraJvmArguments.extend.assert_called_once_with([])
+    config.classPathAdditions.extend.assert_called_once_with([])
+    config.extraEnvironmentVariables.extend.assert_called_once_with([])
+    config.adminGroups.extend.assert_called_once_with([])
+    config.viewerGroups.extend.assert_called_once_with([])
+
+
+def test_apply_pq_config_list_fields_explicit_replaces_each():
+    config = MagicMock()
+    assert (
+        _apply_pq_config_list_fields(
+            config,
+            schedule=["s1"],
+            extra_jvm_args=["-Xmx1g"],
+            extra_class_path=["/jar"],
+            extra_environment_vars=["K=V"],
+            admin_groups=["a"],
+            viewer_groups=["v"],
+        )
+        is True
+    )
+    config.scheduling.extend.assert_called_once_with(["s1"])
+    config.extraJvmArguments.extend.assert_called_once_with(["-Xmx1g"])
+    config.classPathAdditions.extend.assert_called_once_with(["/jar"])
+    config.extraEnvironmentVariables.extend.assert_called_once_with(["K=V"])
+    config.adminGroups.extend.assert_called_once_with(["a"])
+    config.viewerGroups.extend.assert_called_once_with(["v"])
+
+
+def test_validate_pq_config_args_script_conflict():
+    with pytest.raises(ValueError, match="script_body and script_path"):
+        validate_pq_config_args(None, None, "code", "path")
+
+
+def test_validate_pq_config_args_auto_delete_schedule_conflict():
+    with pytest.raises(ValueError, match="auto_delete_timeout and schedule"):
+        validate_pq_config_args(60, ["sched"], None, None)
+
+
+def test_validate_pq_config_args_ok():
+    assert validate_pq_config_args(None, None, "code", None) is None
+    assert validate_pq_config_args(60, None, None, None) is None
+    assert validate_pq_config_args(None, ["sched"], None, None) is None
+
+
+@pytest.mark.skipif(
+    _PQConfigMessage is None, reason="deephaven_enterprise not available"
+)
+def test_apply_pq_config_fields_script_body_oneof():
+    """scriptCode and scriptPath are a protobuf oneof; setting one clears the other."""
+    nones = dict(
+        pq_name=None,
+        heap_size_gb=None,
+        programming_language=None,
+        configuration_type=None,
+        enabled=None,
+        schedule=None,
+        server=None,
+        engine=None,
+        jvm_profile=None,
+        extra_jvm_args=None,
+        extra_class_path=None,
+        python_virtual_environment=None,
+        extra_environment_vars=None,
+        init_timeout_nanos=None,
+        auto_delete_timeout=None,
+        admin_groups=None,
+        viewer_groups=None,
+        restart_users=None,
+        owner=None,
+    )
+
+    pb = _PQConfigMessage()
+    pb.scriptPath = "/old/path.py"
+    assert apply_pq_config_fields(pb, script_body="t = 42", script_path=None, **nones)
+    assert pb.scriptCode == "t = 42"
+    assert pb.scriptPath == ""
+    assert pb.WhichOneof("scriptData") == "scriptCode"
+
+    pb2 = _PQConfigMessage()
+    pb2.scriptCode = "t = None"
+    assert apply_pq_config_fields(
+        pb2, script_body=None, script_path="/new/path.py", **nones
+    )
+    assert pb2.scriptPath == "/new/path.py"
+    assert pb2.scriptCode == ""
+    assert pb2.WhichOneof("scriptData") == "scriptPath"
+
+
+def _all_none_fields_kwargs():
+    return dict(
+        pq_name=None,
+        heap_size_gb=None,
+        programming_language=None,
+        script_body=None,
+        script_path=None,
+        configuration_type=None,
+        enabled=None,
+        schedule=None,
+        server=None,
+        engine=None,
+        jvm_profile=None,
+        extra_jvm_args=None,
+        extra_class_path=None,
+        python_virtual_environment=None,
+        extra_environment_vars=None,
+        init_timeout_nanos=None,
+        auto_delete_timeout=None,
+        admin_groups=None,
+        viewer_groups=None,
+        restart_users=None,
+        owner=None,
+    )
+
+
+def test_apply_pq_config_fields_all_none_returns_false():
+    config = MagicMock()
+    assert apply_pq_config_fields(config, **_all_none_fields_kwargs()) is False
+
+
+def test_apply_pq_config_fields_restart_users_enum_conversion(pq_config_mod):
+    config = MagicMock()
+    kwargs = _all_none_fields_kwargs()
+    kwargs["restart_users"] = "RU_ADMIN"
+    with patch.object(pq_config_mod, "RestartUsersEnum") as mock_enum:
+        mock_enum.Value.return_value = 7
+        assert apply_pq_config_fields(config, **kwargs) is True
+    assert config.restartUsers == 7
+
+
+def test_apply_pq_config_fields_owner():
+    config = MagicMock()
+    kwargs = _all_none_fields_kwargs()
+    kwargs["owner"] = "svc"
+    assert apply_pq_config_fields(config, **kwargs) is True
+    assert config.owner == "svc"
+
+
+def test_apply_pq_config_fields_routes_to_each_applier(pq_config_mod):
+    """programming_language plus the simple/list/auto-delete branches all apply."""
+    config = _make_config_mock()
+    kwargs = _all_none_fields_kwargs()
+    kwargs["programming_language"] = "python"
+    kwargs["heap_size_gb"] = 4.0  # simple-field applier
+    kwargs["extra_class_path"] = ["/jar"]  # list-field applier
+    kwargs["auto_delete_timeout"] = 0  # auto-delete applier (permanent)
+
+    assert apply_pq_config_fields(config, **kwargs) is True
+
+    assert config.scriptLanguage == "Python"
+    assert config.heapSizeGb == 4.0
+    config.classPathAdditions.extend.assert_called_once_with(["/jar"])
+    config.scheduling.extend.assert_called_once_with(
+        pq_config_mod._DEFAULT_PERMANENT_CONTINUOUS_SCHEDULING
+    )

--- a/tests/mcp_systems_server/_tools/test_pq.py
+++ b/tests/mcp_systems_server/_tools/test_pq.py
@@ -4,7 +4,6 @@ Tests for deephaven_mcp.mcp_systems_server._tools.pq.
 
 import asyncio
 import warnings
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -137,17 +136,14 @@ except Exception:
     _PQConfigMessage = None
 from deephaven_mcp.config.schema import PqToolsConfig
 from deephaven_mcp.mcp_systems_server._tools.pq import (
-    _apply_pq_config_list_fields,
-    _apply_pq_config_modifications,
     _format_column_definition,
     _format_connection_details,
     _format_exception_details,
     _format_exported_object_info,
     _format_named_string_list,
     _format_pq_config,
-    _format_pq_replicas,
-    _format_pq_spares,
     _format_pq_state,
+    _format_pq_states,
     _format_table_definition,
     _format_worker_protocol,
     _parse_pq_id,
@@ -1586,181 +1582,57 @@ def test_format_pq_state_with_empty_connection_details():
     }
 
 
-def test_format_pq_replicas_empty():
-    """Test _format_pq_replicas returns empty list for empty input."""
-    result = _format_pq_replicas([])
-    assert result == []
+def _make_mock_state(status_name: str, replica_slot: int) -> MagicMock:
+    """Build a MagicMock CorePlusQueryState with the 25 fields _format_pq_state reads."""
+    mock_state = MagicMock()
+    mock_state.pb.serial = 12345
+    mock_state.pb.version = 1
+    mock_state.status.name = status_name
+    mock_state.pb.initializationStartNanos = 0
+    mock_state.pb.initializationCompleteNanos = 0
+    mock_state.pb.lastUpdateNanos = 0
+    mock_state.pb.dispatcherHost = ""
+    mock_state.pb.tableGroups = []
+    mock_state.pb.scopeTypes = []
+    mock_state.pb.connectionDetails = None
+    mock_state.pb.exceptionDetails = None
+    mock_state.pb.typeSpecificStateJson = ""
+    mock_state.pb.lastAuthenticatedUser = ""
+    mock_state.pb.lastEffectiveUser = ""
+    mock_state.pb.scriptLoaderStateJson = ""
+    mock_state.pb.hasProgress = False
+    mock_state.pb.progressValue = 0
+    mock_state.pb.progressMessage = ""
+    mock_state.pb.engineVersion = ""
+    mock_state.pb.dispatcherPort = 0
+    mock_state.pb.shouldStopNanos = 0
+    mock_state.pb.numFailures = 0
+    mock_state.pb.lastFailureTimeNanos = 0
+    mock_state.pb.replicaSlot = replica_slot
+    mock_state.pb.statusDetails = ""
+    return mock_state
 
 
-def test_format_pq_replicas_with_data():
-    """Test _format_pq_replicas formats replica states correctly."""
-    mock_replica1 = MagicMock()
-    mock_replica1.pb.serial = 12345
-    mock_replica1.pb.version = 1
+def test_format_pq_states_empty():
+    """_format_pq_states returns an empty list for empty input."""
+    assert _format_pq_states([]) == []
 
-    # Set up status using wrapper's status.name property
-    mock_replica1.status.name = "RUNNING"
-    mock_replica1.pb.initializationStartNanos = 1734467100000000000
-    mock_replica1.pb.initializationCompleteNanos = 1734467150000000000
-    mock_replica1.pb.lastUpdateNanos = 1734467200000000000
-    mock_replica1.pb.dispatcherHost = "dispatcher.example.com"
-    mock_replica1.pb.tableGroups = []
-    mock_replica1.pb.scopeTypes = []
-    mock_replica1.pb.connectionDetails = None
-    mock_replica1.pb.exceptionDetails = None
-    mock_replica1.pb.typeSpecificStateJson = ""
-    mock_replica1.pb.lastAuthenticatedUser = ""
-    mock_replica1.pb.lastEffectiveUser = ""
-    mock_replica1.pb.scriptLoaderStateJson = ""
-    mock_replica1.pb.hasProgress = False
-    mock_replica1.pb.progressValue = 0
-    mock_replica1.pb.progressMessage = ""
-    mock_replica1.pb.engineVersion = ""
-    mock_replica1.pb.dispatcherPort = 8080
-    mock_replica1.pb.shouldStopNanos = 0
-    mock_replica1.pb.numFailures = 0
-    mock_replica1.pb.lastFailureTimeNanos = 0
-    mock_replica1.pb.replicaSlot = 1
-    mock_replica1.pb.statusDetails = ""
 
-    result = _format_pq_replicas([mock_replica1])
+def test_format_pq_states_with_data():
+    """_format_pq_states formats each state (25 fields) into a dict."""
+    result = _format_pq_states([_make_mock_state("RUNNING", 1)])
 
     assert len(result) == 1
     assert result[0]["serial"] == 12345
-    assert result[0]["replica_slot"] == 1
     assert result[0]["status"] == "RUNNING"
+    assert result[0]["replica_slot"] == 1
 
 
-def test_format_pq_replicas_filters_none():
-    """Test _format_pq_replicas filters out None entries."""
-    mock_replica = MagicMock()
-    mock_replica.pb.serial = 12345
-    mock_replica.pb.version = 1
-
-    # Set up status using wrapper's status.name property
-    mock_replica.status.name = "RUNNING"
-    mock_replica.pb.initializationStartNanos = 0
-    mock_replica.pb.initializationCompleteNanos = 0
-    mock_replica.pb.lastUpdateNanos = 0
-    mock_replica.pb.dispatcherHost = ""
-    mock_replica.pb.tableGroups = []
-    mock_replica.pb.scopeTypes = []
-    mock_replica.pb.connectionDetails = None
-    mock_replica.pb.exceptionDetails = None
-    mock_replica.pb.typeSpecificStateJson = ""
-    mock_replica.pb.lastAuthenticatedUser = ""
-    mock_replica.pb.lastEffectiveUser = ""
-    mock_replica.pb.scriptLoaderStateJson = ""
-    mock_replica.pb.hasProgress = False
-    mock_replica.pb.progressValue = 0
-    mock_replica.pb.progressMessage = ""
-    mock_replica.pb.engineVersion = ""
-    mock_replica.pb.dispatcherPort = 0
-    mock_replica.pb.shouldStopNanos = 0
-    mock_replica.pb.numFailures = 0
-    mock_replica.pb.lastFailureTimeNanos = 0
-    mock_replica.pb.replicaSlot = 0
-    mock_replica.pb.statusDetails = ""
-    mock_replica.pb.killTime = 0
-    mock_replica.pb.assignedWorkerGroupId = 0
-    mock_replica.pb.configId = ""
-
-    result = _format_pq_replicas([mock_replica, None])
+def test_format_pq_states_filters_none():
+    """_format_pq_states drops None entries from the input."""
+    result = _format_pq_states([_make_mock_state("INITIALIZING", 2), None])
     assert len(result) == 1
-
-
-def test_format_pq_spares_empty():
-    """Test _format_pq_spares returns empty list for empty input."""
-    result = _format_pq_spares([])
-    assert result == []
-
-
-def test_format_pq_spares_with_data():
-    """Test _format_pq_spares formats spare states correctly."""
-    mock_spare = MagicMock()
-    mock_spare.pb.serial = 12345
-    mock_spare.pb.version = 1
-
-    # Set up status using wrapper's status.name property
-    mock_spare.status.name = "INITIALIZING"
-    mock_spare.pb.initializationStartNanos = 1734467150000000000
-    mock_spare.pb.initializationCompleteNanos = 1734467200000000000
-    mock_spare.pb.lastUpdateNanos = 1734467250000000000
-    mock_spare.pb.dispatcherHost = "dispatcher.example.com"
-    mock_spare.pb.tableGroups = []
-    mock_spare.pb.scopeTypes = []
-    mock_spare.pb.connectionDetails = None
-    mock_spare.pb.exceptionDetails = None
-    mock_spare.pb.typeSpecificStateJson = ""
-    mock_spare.pb.lastAuthenticatedUser = ""
-    mock_spare.pb.lastEffectiveUser = ""
-    mock_spare.pb.scriptLoaderStateJson = ""
-    mock_spare.pb.hasProgress = False
-    mock_spare.pb.progressValue = 0
-    mock_spare.pb.progressMessage = ""
-    mock_spare.pb.engineVersion = ""
-    mock_spare.pb.dispatcherPort = 8080
-    mock_spare.pb.shouldStopNanos = 0
-    mock_spare.pb.numFailures = 0
-    mock_spare.pb.lastFailureTimeNanos = 0
-    mock_spare.pb.replicaSlot = 2
-    mock_spare.pb.statusDetails = ""
-
-    result = _format_pq_spares([mock_spare])
-
-    assert len(result) == 1
-    assert result[0]["serial"] == 12345
     assert result[0]["status"] == "INITIALIZING"
-    assert result[0]["replica_slot"] == 2
-
-
-def test_format_pq_spares_filters_none():
-    """Test _format_pq_spares filters out None entries."""
-    mock_spare = MagicMock()
-    mock_spare.pb.serial = 12345
-    mock_spare.pb.version = 1
-
-    # Set up status using wrapper's status.name property
-    mock_spare.status.name = "INITIALIZING"
-    mock_spare.pb.initializationStartNanos = 0
-    mock_spare.pb.initializationCompleteNanos = 0
-    mock_spare.pb.lastUpdateNanos = 0
-    mock_spare.pb.dispatcherHost = ""
-    mock_spare.pb.tableGroups = []
-    mock_spare.pb.scopeTypes = []
-    mock_spare.pb.connectionDetails = None
-    mock_spare.pb.exceptionDetails = None
-    mock_spare.pb.typeSpecificStateJson = ""
-    mock_spare.pb.lastAuthenticatedUser = ""
-    mock_spare.pb.lastEffectiveUser = ""
-    mock_spare.pb.scriptLoaderStateJson = ""
-    mock_spare.pb.hasProgress = False
-    mock_spare.pb.progressValue = 0
-    mock_spare.pb.progressMessage = ""
-    mock_spare.pb.engineVersion = ""
-    mock_spare.pb.dispatcherPort = 0
-    mock_spare.pb.shouldStopNanos = 0
-    mock_spare.pb.numFailures = 0
-    mock_spare.pb.lastFailureTimeNanos = 0
-    mock_spare.pb.replicaSlot = 0
-    mock_spare.pb.statusDetails = ""
-    mock_spare.pb.flightSessionId = ""
-    mock_spare.pb.sessionToken = ""
-    mock_spare.pb.tokenExpirationTime = 0
-    mock_spare.pb.queryInfoJson = ""
-    mock_spare.pb.tempQueryId = 0
-    mock_spare.pb.totalMemoryMB = 0
-    mock_spare.pb.grpcAddress = ""
-    mock_spare.pb.flightAddress = ""
-    mock_spare.pb.httpPort = 0
-    mock_spare.pb.lastActivityTime = 0
-    mock_spare.pb.assignedDispatcherId = 0
-    mock_spare.pb.killTime = 0
-    mock_spare.pb.assignedWorkerGroupId = 0
-    mock_spare.pb.configId = ""
-
-    result = _format_pq_spares([None, mock_spare])
-    assert len(result) == 1
 
 
 @pytest.mark.asyncio
@@ -2223,6 +2095,44 @@ async def test_pq_create_success():
 
 
 @pytest.mark.asyncio
+async def test_pq_create_forwards_owner():
+    """Test pq_create forwards the owner parameter to make_pq_config."""
+    mock_session_registry = MagicMock(spec=EnterpriseSessionRegistry)
+    mock_session_registry.system_name = _TEST_SYSTEM_NAME
+    mock_factory_manager = MagicMock()
+    mock_factory = MagicMock()
+    mock_controller = MagicMock()
+
+    mock_session_registry.factory_manager = mock_factory_manager
+    mock_factory_manager.get = AsyncMock(return_value=mock_factory)
+    mock_factory.controller_client = mock_controller
+
+    mock_config = MagicMock()
+    mock_config.pb = MagicMock()
+    mock_controller.make_pq_config = AsyncMock(return_value=mock_config)
+    mock_controller.add_query = AsyncMock(return_value=12345)
+
+    context = MockContext(
+        {
+            "config_manager": MagicMock(),
+            "registry": mock_session_registry,
+        }
+    )
+
+    result = await pq_create(
+        context,
+        _TEST_SYSTEM_NAME,
+        pq_name="new-pq",
+        heap_size_gb=8.0,
+        owner="service-account",
+    )
+
+    assert result["success"] is True
+    mock_controller.make_pq_config.assert_called_once()
+    assert mock_controller.make_pq_config.call_args.kwargs["owner"] == "service-account"
+
+
+@pytest.mark.asyncio
 async def test_pq_create_success_groovy():
     """Test successful PQ creation with Groovy programming language."""
     mock_session_registry = MagicMock(spec=EnterpriseSessionRegistry)
@@ -2277,6 +2187,13 @@ async def test_pq_create_invalid_language():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    # pq_create now passes programming_language raw to make_pq_config, which normalizes
+    # and validates it; an invalid value raises ValueError.
+    mock_controller.make_pq_config = AsyncMock(
+        side_effect=ValueError(
+            "Invalid programming_language: 'JavaScript'. Must be 'Python' or 'Groovy' (case-insensitive)."
+        )
+    )
 
     context = MockContext(
         {
@@ -2740,6 +2657,7 @@ async def test_pq_modify_success():
 
     # Mock controller methods - map() returns dict of {serial: pq_info}
     mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
+    mock_controller.update_pq_config.return_value = True
     mock_controller.modify_query = AsyncMock()
 
     context = MockContext(
@@ -2767,15 +2685,18 @@ async def test_pq_modify_success():
     assert "warning" in result
     assert "pq_restart" in result["warning"]
 
-    # Verify modify_query was called with the existing config (now modified) and restart=False
+    # Verify pq_modify delegated to update_pq_config with the existing config and
+    # the heap_size_gb keyword, and that modify_query was called with the same config.
+    mock_controller.update_pq_config.assert_called_once()
+    update_args = mock_controller.update_pq_config.call_args
+    assert update_args[0][0] == current_pq_info.config
+    assert update_args.kwargs["heap_size_gb"] == 16.0
     mock_controller.modify_query.assert_called_once()
     call_args = mock_controller.modify_query.call_args
     assert (
         call_args[0][0] == current_pq_info.config
     )  # First positional arg is the config
     assert call_args[1]["restart"] is False
-    # Verify heap was actually modified in the existing config
-    assert current_pq_info.config.pb.heapSizeGb == 16.0
 
 
 @pytest.mark.asyncio
@@ -2796,6 +2717,7 @@ async def test_pq_modify_with_restart():
     current_pq_info = create_mock_pq_info(12345, "analytics", "STOPPED", 8.0)
 
     mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
+    mock_controller.update_pq_config.return_value = True
     mock_controller.modify_query = AsyncMock()
 
     context = MockContext(
@@ -2804,6 +2726,10 @@ async def test_pq_modify_with_restart():
             "registry": mock_session_registry,
         }
     )
+
+    # pq_modify reports the name from config.pb.name; set it so the response reflects
+    # the rename that update_pq_config (mocked here) would have applied.
+    current_pq_info.config.pb.name = "analytics_renamed"
 
     result = await pq_modify(
         context,
@@ -2819,12 +2745,15 @@ async def test_pq_modify_with_restart():
     assert result["restarted"] is True
     assert "restarted" in result["message"]
 
-    # Verify modify_query was called with existing config and restart=True
+    # Verify pq_modify delegated to update_pq_config with the pq_name keyword, and
+    # that modify_query was called with the same config and restart=True.
+    mock_controller.update_pq_config.assert_called_once()
+    update_args = mock_controller.update_pq_config.call_args
+    assert update_args[0][0] == current_pq_info.config
+    assert update_args.kwargs["pq_name"] == "analytics_renamed"
     call_args = mock_controller.modify_query.call_args
     assert call_args[0][0] == current_pq_info.config  # Existing config was passed
     assert call_args[1]["restart"] is True
-    # Verify name was actually modified in the existing config
-    assert current_pq_info.config.pb.name == "analytics_renamed"
     # pq_name is not runtime-affecting, so no warning even on a running PQ
     assert "warning" not in result
 
@@ -2992,6 +2921,7 @@ async def test_pq_modify_script_path():
     # Mock current PQ info
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
     mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
+    mock_controller.update_pq_config.return_value = True
     mock_controller.modify_query = AsyncMock()
 
     context = MockContext(
@@ -3010,137 +2940,11 @@ async def test_pq_modify_script_path():
 
     # Verify success
     assert result["success"] is True
-    # Verify script_path was set and script_body cleared
-    assert current_pq_info.config.pb.scriptPath == "/path/to/script.py"
-    assert current_pq_info.config.pb.scriptCode == ""
-
-
-@pytest.mark.skipif(
-    _PQConfigMessage is None, reason="deephaven_enterprise not available"
-)
-def test_apply_pq_config_modifications_script_body_oneof():
-    """Verify script_body/script_path oneof semantics using real protobuf objects.
-
-    scriptCode and scriptPath are in a protobuf 'oneof scriptData' group: setting one
-    must clear the other. This test uses a real PersistentQueryConfigMessage (not MagicMock)
-    to confirm the fix for Bug 2, where explicit '= ""' assignments were re-activating
-    the wrong oneof field and silently nullifying the intended value.
-    """
-    nones = [None] * 16  # remaining args: programming_language through restart_users
-
-    # Case 1: setting script_body should preserve scriptCode, clear scriptPath
-    pb = _PQConfigMessage()
-    pb.scriptPath = "/old/path.py"
-    _apply_pq_config_modifications(pb, None, None, "t = 42", None, *nones)
-    assert pb.scriptCode == "t = 42", "scriptCode should be set to the provided value"
-    assert pb.scriptPath == "", "scriptPath should be cleared by the oneof"
-    assert pb.WhichOneof("scriptData") == "scriptCode"
-
-    # Case 2: setting script_path should preserve scriptPath, clear scriptCode
-    pb2 = _PQConfigMessage()
-    pb2.scriptCode = "t = None"
-    _apply_pq_config_modifications(pb2, None, None, None, "/new/path.py", *nones)
-    assert (
-        pb2.scriptPath == "/new/path.py"
-    ), "scriptPath should be set to the provided value"
-    assert pb2.scriptCode == "", "scriptCode should be cleared by the oneof"
-    assert pb2.WhichOneof("scriptData") == "scriptPath"
-
-
-@pytest.mark.skipif(
-    _PQConfigMessage is None, reason="deephaven_enterprise not available"
-)
-def test_apply_pq_config_list_fields_schedule_none_preserves_existing():
-    """schedule=None must leave the existing scheduling field untouched."""
-    pb = _PQConfigMessage()
-    pb.scheduling.extend(
-        [
-            "SchedulerType=com.illumon.iris.controller.IrisQuerySchedulerContinuous",
-            "TimeZone=America/New_York",
-            "SchedulingDisabled=false",
-        ]
-    )
-    existing = list(pb.scheduling)
-
-    has_changes = _apply_pq_config_list_fields(
-        pb,
-        schedule=None,
-        extra_jvm_args=None,
-        extra_class_path=None,
-        extra_environment_vars=None,
-        admin_groups=None,
-        viewer_groups=None,
-    )
-
-    assert has_changes is False
-    assert list(pb.scheduling) == existing
-
-
-@pytest.mark.skipif(
-    _PQConfigMessage is None, reason="deephaven_enterprise not available"
-)
-def test_apply_pq_config_list_fields_schedule_empty_clears():
-    """schedule=[] must clear the existing scheduling field entirely."""
-    pb = _PQConfigMessage()
-    pb.scheduling.extend(
-        [
-            "SchedulerType=com.illumon.iris.controller.IrisQuerySchedulerContinuous",
-            "SchedulingDisabled=false",
-        ]
-    )
-
-    has_changes = _apply_pq_config_list_fields(
-        pb,
-        schedule=[],
-        extra_jvm_args=None,
-        extra_class_path=None,
-        extra_environment_vars=None,
-        admin_groups=None,
-        viewer_groups=None,
-    )
-
-    assert has_changes is True
-    assert list(pb.scheduling) == []
-
-
-@pytest.mark.skipif(
-    _PQConfigMessage is None, reason="deephaven_enterprise not available"
-)
-def test_apply_pq_config_list_fields_schedule_explicit_replaces_wholesale():
-    """schedule=[...] must replace the existing scheduling block wholesale.
-
-    No existing entries may survive; the caller's list is authoritative.
-    """
-    pb = _PQConfigMessage()
-    pb.scheduling.extend(
-        [
-            "SchedulerType=com.illumon.iris.controller.IrisQuerySchedulerContinuous",
-            "StartTime=00:00:00",
-            "TimeZone=America/New_York",
-            "SchedulingDisabled=false",
-            "RestartWhenRunning=Yes",
-        ]
-    )
-    caller_schedule = [
-        "SchedulerType=com.illumon.iris.controller.IrisQuerySchedulerDaily",
-        "StartTime=09:00:00",
-        "StopTime=17:00:00",
-        "SchedulingDisabled=true",
-    ]
-
-    has_changes = _apply_pq_config_list_fields(
-        pb,
-        schedule=caller_schedule,
-        extra_jvm_args=None,
-        extra_class_path=None,
-        extra_environment_vars=None,
-        admin_groups=None,
-        viewer_groups=None,
-    )
-
-    assert has_changes is True
-    # Exactly the caller's list; no leftover entries from the previous scheduling.
-    assert list(pb.scheduling) == caller_schedule
+    # Verify pq_modify forwarded script_path (and a None script_body) to update_pq_config
+    mock_controller.update_pq_config.assert_called_once()
+    update_kwargs = mock_controller.update_pq_config.call_args.kwargs
+    assert update_kwargs["script_path"] == "/path/to/script.py"
+    assert update_kwargs["script_body"] is None
 
 
 @pytest.mark.asyncio
@@ -3274,6 +3078,10 @@ async def test_pq_modify_invalid_language():
     # Mock current PQ info
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
     mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
+    # update_pq_config validates programming_language; an invalid value raises ValueError.
+    mock_controller.update_pq_config.side_effect = ValueError(
+        "Invalid programming_language: 'JavaScript'. Must be 'Python' or 'Groovy' (case-insensitive)."
+    )
 
     context = MockContext(
         {
@@ -3310,6 +3118,8 @@ async def test_pq_modify_no_changes():
     # Mock current PQ info
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
     mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
+    # No parameters supplied → update_pq_config reports no changes.
+    mock_controller.update_pq_config.return_value = False
 
     context = MockContext(
         {
@@ -3334,20 +3144,13 @@ async def test_pq_modify_no_changes():
 
 
 @pytest.mark.asyncio
-@patch("deephaven_mcp.mcp_systems_server._tools.pq.RestartUsersEnum")
-async def test_pq_modify_all_parameters(mock_restart_enum):
-    """Test pq_modify with all parameters to achieve full coverage.
+async def test_pq_modify_all_parameters():
+    """Test pq_modify forwards every parameter to update_pq_config.
 
-    The test passes ``restart_users="RU_ADMIN"``, which routes through
-    :func:`_convert_restart_users_to_enum`. That helper raises
-    :class:`MissingEnterprisePackageError` when ``RestartUsersEnum`` is
-    ``None`` (the default in environments without the Core+ wheel), so
-    we mock it here to keep this test independent of installation state
-    and of any other test that patches ``RestartUsersEnum`` to ``None``.
+    Construction and mutation of the protobuf now live in the client layer's
+    ``update_pq_config``; pq_modify is thin orchestration. This test verifies the
+    full keyword fan-out to the delegated call.
     """
-    # ``RU_ADMIN`` should resolve to the numeric enum value the
-    # assertions below expect (``1``).
-    mock_restart_enum.Value.return_value = 1
     mock_session_registry = MagicMock(spec=EnterpriseSessionRegistry)
     mock_session_registry.system_name = _TEST_SYSTEM_NAME
     mock_factory_manager = MagicMock()
@@ -3362,7 +3165,11 @@ async def test_pq_modify_all_parameters(mock_restart_enum):
     # Mock current PQ info
     current_pq_info = create_mock_pq_info(12345, "old_name", "RUNNING", 8.0)
     mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
+    mock_controller.update_pq_config.return_value = True
     mock_controller.modify_query = AsyncMock()
+
+    # pq_modify reports config.pb.name; reflect the rename update_pq_config would apply.
+    current_pq_info.config.pb.name = "new_name"
 
     context = MockContext(
         {
@@ -3380,7 +3187,6 @@ async def test_pq_modify_all_parameters(mock_restart_enum):
         programming_language="Python",
         configuration_type="Script",
         enabled=False,
-        schedule=["0 0 * * *"],
         server="server1",
         engine="DeephavenCommunity",
         jvm_profile="default",
@@ -3400,28 +3206,28 @@ async def test_pq_modify_all_parameters(mock_restart_enum):
     assert result["success"] is True
     assert result["name"] == "new_name"
 
-    # Verify all fields were modified
-    config_pb = current_pq_info.config.pb
-    assert config_pb.name == "new_name"
-    assert config_pb.scriptCode == "print('test')"
-    assert config_pb.scriptPath == ""
-    assert config_pb.scriptLanguage == "Python"
-    assert config_pb.configurationType == "Script"
-    assert config_pb.enabled is False
-    assert list(config_pb.scheduling) == ["0 0 * * *"]
-    assert config_pb.serverName == "server1"
-    assert config_pb.workerKind == "DeephavenCommunity"
-    assert config_pb.jvmProfile == "default"
-    assert list(config_pb.extraJvmArguments) == ["-Xmx4g"]
-    assert list(config_pb.classPathAdditions) == ["/path/to/lib.jar"]
-    assert config_pb.pythonControl == "/path/to/venv"
-    assert list(config_pb.extraEnvironmentVariables) == ["VAR1=value1"]
-    assert config_pb.timeoutNanos == 60000000000
-    assert config_pb.expirationTimeNanos == 3600000000000  # 3600 seconds * 1e9
-    assert list(config_pb.adminGroups) == ["admins"]
-    assert list(config_pb.viewerGroups) == ["viewers"]
-    # restart_users should be converted to numeric enum value (1 = RU_ADMIN)
-    assert config_pb.restartUsers == 1
+    # Verify every parameter was forwarded to update_pq_config.
+    mock_controller.update_pq_config.assert_called_once()
+    update_call = mock_controller.update_pq_config.call_args
+    assert update_call[0][0] == current_pq_info.config
+    kwargs = update_call.kwargs
+    assert kwargs["pq_name"] == "new_name"
+    assert kwargs["script_body"] == "print('test')"
+    assert kwargs["programming_language"] == "Python"
+    assert kwargs["configuration_type"] == "Script"
+    assert kwargs["enabled"] is False
+    assert kwargs["server"] == "server1"
+    assert kwargs["engine"] == "DeephavenCommunity"
+    assert kwargs["jvm_profile"] == "default"
+    assert kwargs["extra_jvm_args"] == ["-Xmx4g"]
+    assert kwargs["extra_class_path"] == ["/path/to/lib.jar"]
+    assert kwargs["python_virtual_environment"] == "/path/to/venv"
+    assert kwargs["extra_environment_vars"] == ["VAR1=value1"]
+    assert kwargs["init_timeout_nanos"] == 60000000000
+    assert kwargs["auto_delete_timeout"] == 3600
+    assert kwargs["admin_groups"] == ["admins"]
+    assert kwargs["viewer_groups"] == ["viewers"]
+    assert kwargs["restart_users"] == "RU_ADMIN"
     mock_controller.modify_query.assert_called_once()
 
 
@@ -3439,12 +3245,10 @@ async def test_pq_modify_clear_auto_delete_timeout():
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
 
-    # Mock current PQ info with existing timeout
+    # Mock current PQ info
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
-    current_pq_info.config.pb.expirationTimeNanos = (
-        3600000000000  # Currently has 1 hour timeout
-    )
     mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
+    mock_controller.update_pq_config.return_value = True
     mock_controller.modify_query = AsyncMock()
 
     context = MockContext(
@@ -3454,7 +3258,7 @@ async def test_pq_modify_clear_auto_delete_timeout():
         }
     )
 
-    # Call with auto_delete_timeout=0 to clear expiration (make permanent)
+    # Call with auto_delete_timeout=0 to clear the timeout (make permanent)
     result = await pq_modify(
         context,
         pq_id="system:12345",
@@ -3466,18 +3270,63 @@ async def test_pq_modify_clear_auto_delete_timeout():
     assert result["success"] is True
     assert result["message"] == "PQ 'analytics' modified successfully"
 
-    # Verify modify_query was called
+    # Verify modify_query was called and auto_delete_timeout=0 was forwarded
     mock_controller.modify_query.assert_called_once()
-
-    # Verify expirationTimeNanos was set to 0 (permanent)
-    config_pb = current_pq_info.config.pb
-    assert config_pb.expirationTimeNanos == 0
+    mock_controller.update_pq_config.assert_called_once()
+    assert mock_controller.update_pq_config.call_args.kwargs["auto_delete_timeout"] == 0
 
 
 @pytest.mark.asyncio
-@patch("deephaven_mcp.mcp_systems_server._tools.pq.RestartUsersEnum", None)
+async def test_pq_modify_set_owner():
+    """Test pq_modify sets config_pb.owner when owner is supplied."""
+    mock_session_registry = MagicMock(spec=EnterpriseSessionRegistry)
+    mock_session_registry.system_name = _TEST_SYSTEM_NAME
+    mock_factory_manager = MagicMock()
+    mock_factory = MagicMock()
+    mock_controller = MagicMock()
+
+    mock_session_registry.factory_manager = mock_factory_manager
+    mock_factory_manager.get = AsyncMock(return_value=mock_factory)
+    mock_factory.controller_client = mock_controller
+
+    current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
+    current_pq_info.config.pb.owner = "authenticated-user"
+    mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
+    mock_controller.update_pq_config.return_value = True
+    mock_controller.modify_query = AsyncMock()
+
+    context = MockContext(
+        {
+            "config_manager": MagicMock(),
+            "registry": mock_session_registry,
+        }
+    )
+
+    result = await pq_modify(
+        context,
+        pq_id="system:12345",
+        owner="service-account",
+        restart=False,
+    )
+
+    assert result["success"] is True
+    mock_controller.modify_query.assert_called_once()
+    mock_controller.update_pq_config.assert_called_once()
+    assert (
+        mock_controller.update_pq_config.call_args.kwargs["owner"] == "service-account"
+    )
+
+
+@pytest.mark.asyncio
 async def test_pq_modify_restart_users_enum_not_available():
-    """Test pq_modify when RestartUsersEnum is None (enterprise package not installed)."""
+    """Test pq_modify surfaces MissingEnterprisePackageError from update_pq_config.
+
+    The restart_users enum conversion now lives in the client layer; when the Core+
+    package is absent, update_pq_config raises MissingEnterprisePackageError, which
+    pq_modify reports as an error response.
+    """
+    from deephaven_mcp._exceptions import MissingEnterprisePackageError
+
     mock_session_registry = MagicMock(spec=EnterpriseSessionRegistry)
     mock_session_registry.system_name = _TEST_SYSTEM_NAME
     mock_factory_manager = MagicMock()
@@ -3492,6 +3341,7 @@ async def test_pq_modify_restart_users_enum_not_available():
     # Mock current PQ info
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
     mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
+    mock_controller.update_pq_config.side_effect = MissingEnterprisePackageError()
 
     context = MockContext(
         {
@@ -3512,18 +3362,12 @@ async def test_pq_modify_restart_users_enum_not_available():
 
 
 @pytest.mark.asyncio
-@patch("deephaven_mcp.mcp_systems_server._tools.pq.RestartUsersEnum")
-async def test_pq_modify_invalid_restart_users_value(mock_restart_enum):
-    """Test pq_modify with invalid restart_users value to cover ValueError path."""
-    # Mock RestartUsersEnum.Value() to raise ValueError for invalid value
-    mock_restart_enum.Value.side_effect = ValueError("unknown enum value")
-    mock_restart_enum.keys.return_value = [
-        "RU_ADMIN",
-        "RU_ADMIN_AND_VIEWERS",
-        "RU_VIEWERS_WHEN_DOWN",
-        "RU_UNSPECIFIED",
-    ]
+async def test_pq_modify_invalid_restart_users_value():
+    """Test pq_modify surfaces a ValueError from update_pq_config for a bad restart_users.
 
+    The enum conversion now lives in update_pq_config; an unknown name raises ValueError,
+    which pq_modify reports as an error response.
+    """
     mock_session_registry = MagicMock(spec=EnterpriseSessionRegistry)
     mock_session_registry.system_name = _TEST_SYSTEM_NAME
     mock_factory_manager = MagicMock()
@@ -3538,6 +3382,9 @@ async def test_pq_modify_invalid_restart_users_value(mock_restart_enum):
     # Mock current PQ info
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
     mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
+    mock_controller.update_pq_config.side_effect = ValueError(
+        "Invalid restart_users: 'INVALID_VALUE'. Must be one of: RU_ADMIN"
+    )
 
     context = MockContext(
         {
@@ -4916,6 +4763,81 @@ async def test_pq_create_script_body_and_path_mutually_exclusive():
     assert result["success"] is False
     assert "mutually exclusive" in result["error"]
     assert result["isError"] is True
+
+
+@pytest.mark.asyncio
+async def test_pq_create_auto_delete_and_schedule_mutually_exclusive():
+    """pq_create rejects both auto_delete_timeout and schedule, before calling make_pq_config."""
+    mock_session_registry = MagicMock(spec=EnterpriseSessionRegistry)
+    mock_session_registry.system_name = _TEST_SYSTEM_NAME
+    mock_factory_manager = MagicMock()
+    mock_factory = MagicMock()
+    mock_controller = MagicMock()
+
+    mock_session_registry.factory_manager = mock_factory_manager
+    mock_factory_manager.get = AsyncMock(return_value=mock_factory)
+    mock_factory.controller_client = mock_controller
+    mock_controller.make_pq_config = AsyncMock()
+
+    context = MockContext(
+        {
+            "config_manager": MagicMock(),
+            "registry": mock_session_registry,
+        }
+    )
+
+    result = await pq_create(
+        context,
+        _TEST_SYSTEM_NAME,
+        pq_name="test-pq",
+        heap_size_gb=8.0,
+        auto_delete_timeout=60,
+        schedule=[
+            "SchedulerType=com.illumon.iris.controller.IrisQuerySchedulerContinuous"
+        ],
+    )
+
+    assert result["success"] is False
+    assert "mutually exclusive" in result["error"]
+    assert result["isError"] is True
+    # Early validation must short-circuit before delegating to the controller.
+    mock_controller.make_pq_config.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pq_modify_auto_delete_and_schedule_mutually_exclusive():
+    """pq_modify rejects both auto_delete_timeout and schedule, before calling update_pq_config."""
+    mock_session_registry = MagicMock(spec=EnterpriseSessionRegistry)
+    mock_session_registry.system_name = _TEST_SYSTEM_NAME
+    mock_factory_manager = MagicMock()
+    mock_factory = MagicMock()
+    mock_controller = MagicMock()
+
+    mock_session_registry.factory_manager = mock_factory_manager
+    mock_factory_manager.get = AsyncMock(return_value=mock_factory)
+    mock_factory.controller_client = mock_controller
+
+    context = MockContext(
+        {
+            "config_manager": MagicMock(),
+            "registry": mock_session_registry,
+        }
+    )
+
+    result = await pq_modify(
+        context,
+        pq_id="system:12345",
+        auto_delete_timeout=60,
+        schedule=[
+            "SchedulerType=com.illumon.iris.controller.IrisQuerySchedulerContinuous"
+        ],
+    )
+
+    assert result["success"] is False
+    assert "mutually exclusive" in result["error"]
+    assert result["isError"] is True
+    # Early validation must short-circuit before delegating to the controller.
+    mock_controller.update_pq_config.assert_not_called()
 
 
 # Note: The legacy ``MCP_TIMEOUT_WARNING_THRESHOLD`` /


### PR DESCRIPTION
Refactored persistent query configuration field application logic from `_controller_client.py` into a new `_pq_config.py` module. Moved `_apply_pq_config_parameters` and default scheduling constants to the new module as `apply_pq_config_fields` and related helpers. Updated `make_pq_config` to use the extracted functions and added `owner` parameter. Improved scheduler semantics documentation to clarify mutual exclusivity of `auto_delete_

Allow MCP pq_create and pq_modify to specify owner Fixes #164
Fixes Fix MCP pq_create auto deletion of PQs after 10 minutes Fixes #165