### PR TITLE
feat: Build pyapp binaries

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -20,7 +20,7 @@ Conventions:
 | `_cli-help-standards` | The content contract for `dh-mcp` CLI help: required help sections, `build_help` usage, plain-text/no-RST rule, the no-rewrap marker, single-source `OutputSpec` output schema, and the three-surface consistency rule (`docs/CLI.md`, `--help`, introspect). |
 | `_cli-tool-wrapping` | Conventions for `dh-mcp` runtime commands that wrap MCP tools: the four wrapper categories, the shared `_wrapping` helpers, type scoping via `--system`/id/group-doc (never subgroups), and the `wraps_tool` schema-drift contract. |
 | `_configuration-conventions` | Canonical reference for the project's config model: JSON5 + Pydantic v2 + `${env:VAR}` / `${file:PATH}` templating; no ad-hoc env reads or `DEFAULT_FOO` constants. |
-| `_documentation-roles` | Defines the role (audience and scope) of every top-level markdown document; loaded by `docs-improve` and `docs-accuracy` to keep edits in-scope and prevent content drift. |
+| `_documentation-roles` | Defines the role (audience and scope) of every top-level markdown document; loaded by the docs workflows (`docs-improve`, `docs-accuracy`) and `cli-command-add` to keep edits in-scope and prevent content drift. |
 | `_logging-standards` | Logger instantiation, `[module:function] Action: details` message format, log levels, sensitive-data rules, redaction-aware Pydantic model logging. |
 | `_markdown-documentation-standards` | Markdown formatting: JSON/JSON5 code block requirements, placeholder formatting, headings, links, tables, prose conventions. |
 | `_mcp-module-organization` | Module placement and design patterns for MCP tool modules under `src/deephaven_mcp/mcp_systems_server/_tools/`. |

--- a/.agents/skills/_documentation-roles/SKILL.md
+++ b/.agents/skills/_documentation-roles/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: _documentation-roles
-description: Defines the role (audience and scope) of every top-level markdown document in this project — invoked by `docs-improve` and `docs-accuracy` to keep edits in-scope and prevent content drift between documents
+description: Defines the role (audience and scope) of every top-level markdown document in this project — loaded by the docs and CLI-authoring workflows to keep edits in-scope and prevent content drift between documents
 user-invocable: false
 ---
 
 # Documentation Roles
 
-Every top-level markdown file in this repository has a single, intentional role. Edits must respect that role. This skill is the canonical source of truth for those roles; `docs-improve` and `docs-accuracy` load it before making changes.
+Every top-level markdown file in this repository has a single, intentional role. Edits must respect that role. This skill is the canonical source of truth for those roles; the docs workflows (`docs-improve`, `docs-accuracy`) and `cli-command-add` load it before making changes.
 
 ## Roles
 
@@ -19,6 +19,7 @@ Every top-level markdown file in this repository has a single, intentional role.
 | `docs/UV.md` | developer new to `uv` | Generic `uv` crash course. | Project-specific commands, project env vars, project tests, project install lines. |
 | `docs/CLI.md` | operator + AI agent using the local `dh-mcp` CLI | Full `dh-mcp` reference: command surface (noun-verb tree), global flags, env-var bindings, exit codes, `error_code` registry, output modes (`human` / `json` / `yaml`), examples, shell completion, `dh-mcp introspect` agent self-discovery. | Server-side configuration (lives in `CONFIGURATION.md`); developer/contributor mechanics (lives in `DEVELOPER_GUIDE.md`); environment variables consumed by the server processes (those live in `ENV.md`; CLI-specific env vars stay here). |
 | `docs/DEVELOPER_GUIDE.md` | contributor | Everything a developer working *on* the project needs. Catch-all. | Per-tool reference (parameters, returns, examples) — see [Tool reference is owned by code](#tool-reference-is-owned-by-code). |
+| `docs/STANDALONE_BINARIES.md` | anyone building, installing, or deploying the standalone binaries (not just contributors) | **Self-contained, end-to-end**: installing a prebuilt binary (download, extract, point an AI tool at it) and building/releasing them (prerequisites including the Rust/PyApp setup needed to build, build commands, output artifacts, supported platforms, the CI release workflow). README's install section is a one-line pointer here, not a parallel copy. | Project-maintainer minutiae (e.g. bumping pinned-version source constants); server configuration schema (lives in `CONFIGURATION.md`, linked); per-tool reference (lives in code docstrings). |
 | `docs/design/*.md` | contributor / architect | Design rationale for a subsystem — the *why* behind a structural decision (trade-offs weighed, chosen approach, invariants). One file per subsystem; e.g. `docs/design/CLI_TOOL_WRAPPING.md`. | Per-command / per-API reference (lives in `docs/CLI.md` or the code); step-by-step contributor workflow (lives in `DEVELOPER_GUIDE.md`). |
 | `AGENTS.md` | AI agent | Agent process rules. Not human documentation; **no TOC**. | Anything intended for humans. |
 

--- a/.github/workflows/build-pyapp.yml
+++ b/.github/workflows/build-pyapp.yml
@@ -1,0 +1,137 @@
+# Build standalone PyApp binaries for the deephaven-mcp console scripts
+# across the supported native platforms.
+#
+# Each matrix entry runs on a native runner for its target architecture so that
+# uv can install platform-specific wheels (numba, deephaven-server,
+# deephaven-coreplus-client, ...) into the embedded Python distribution.
+# Cross-compilation is not supported by `scripts/build_pyapp.py`.
+#
+# Produced artifacts (per target):
+#   dist/pyapp/<target>/dh-mcp-systems-server[.exe]
+#   dist/pyapp/<target>/dh-mcp[.exe]
+#   dist/pyapp/deephaven-mcp-pyapp-<version>-<target>.{tar.gz,zip}
+#
+# Binary filenames are identical across architectures; the target alias is
+# encoded only in the directory and archive names so documentation can refer
+# to them by a single canonical name.
+#
+# The embedded Python version comes from `[tool.pyapp].python-version` in
+# pyproject.toml; the optional workflow_dispatch input overrides it. When the
+# workflow runs in response to a `v*` tag push, every built archive is attached
+# to the Release.
+
+name: Build PyApp Binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      python-version:
+        description: "Override the embedded CPython version (blank = [tool.pyapp].python-version)"
+        required: false
+        default: ""
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write # required for uploading release assets on tag pushes
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x86_64
+            runner: ubuntu-latest
+          - target: linux-aarch64
+            runner: ubuntu-24.04-arm
+          - target: macos-aarch64
+            runner: macos-14
+          - target: windows-x86_64
+            runner: windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # setuptools_scm needs full history + tags to derive the version.
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ matrix.target }}-${{ hashFiles('.github/workflows/build-pyapp.yml') }}
+          restore-keys: cargo-${{ matrix.target }}-
+
+      - name: Build PyApp binaries
+        shell: bash
+        env:
+          PYTHON_VERSION: ${{ inputs.python-version }}
+        run: |
+          set -euo pipefail
+          # The build always targets the host; ${{ matrix.target }} only picks the runner
+          # and names the artifact. A wrong-arch runner surfaces at artifact upload below.
+          if [ -n "${PYTHON_VERSION}" ]; then
+            uv run --no-project scripts/build_pyapp.py --python-version "${PYTHON_VERSION}"
+          else
+            uv run --no-project scripts/build_pyapp.py
+          fi
+
+      - name: Smoke-test binaries offline
+        shell: bash
+        # Point every network egress path at a dead local address so any attempt to
+        # download (a Python distribution, dependency wheels, ...) fails immediately.
+        # The runner is ephemeral, so this is a cold first run: it proves the binary is
+        # genuinely self-contained and never touches the network. A regression that
+        # reintroduced a first-run install would fail here instead of passing silently.
+        env:
+          HTTP_PROXY: http://127.0.0.1:1
+          HTTPS_PROXY: http://127.0.0.1:1
+          ALL_PROXY: http://127.0.0.1:1
+          PIP_INDEX_URL: http://127.0.0.1:1
+          UV_INDEX_URL: http://127.0.0.1:1
+        run: |
+          set -euo pipefail
+          dir="dist/pyapp/${{ matrix.target }}"
+          suffix=""
+          if [[ "${{ matrix.target }}" == windows-* ]]; then
+            suffix=".exe"
+          fi
+          # First run unpacks the embedded distribution; --help and introspect both boot
+          # the embedded interpreter and import the entry point without any configuration.
+          "${dir}/dh-mcp-systems-server${suffix}" --help
+          "${dir}/dh-mcp${suffix}" --help
+          "${dir}/dh-mcp${suffix}" introspect > /dev/null
+
+      - name: Upload distribution archive
+        # The archive bundles both binaries. Short retention keeps Actions
+        # artifact storage small; on tag builds the same archive is attached to
+        # the GitHub Release below (which has its own storage).
+        uses: actions/upload-artifact@v4
+        with:
+          name: pyapp-archive-${{ matrix.target }}
+          path: |
+            dist/pyapp/deephaven-mcp-pyapp-*-${{ matrix.target }}.tar.gz
+            dist/pyapp/deephaven-mcp-pyapp-*-${{ matrix.target }}.zip
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Attach archive to release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/pyapp/deephaven-mcp-pyapp-*-${{ matrix.target }}.tar.gz
+            dist/pyapp/deephaven-mcp-pyapp-*-${{ matrix.target }}.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,3 +61,8 @@ Apply `_python-coding-practices` rule 16 before using version-gated syntax (PEP 
 ## Python Code
 
 Before writing or editing Python source under `src/` or `tests/` — including docstring-only edits — load `_python-coding-practices` and apply its rules. The most-violated are rule 12 (docstrings describe *what*, not *why*; no rationale, API-symmetry, or cross-call-site narrative) and rule 14 (every field on a field-bearing value class — a Pydantic schema, `@dataclass`, or `NamedTuple` — carries a per-field PEP 257 trailing docstring, never a class-level `Attributes:` block; see `Runtime` in `cli/_runtime.py`). Enums are different: they bind per-member metadata via `__new__`, not field docstrings — see `ErrorCode` in `cli/_errors.py`.
+
+## Build & Distribution
+
+- **Wheels**: built and published to PyPI by CI on `v*` tag pushes (`.github/workflows/publish-wheels.yml`); the dependency list is authoritative in `pyproject.toml`.
+- **Standalone binaries (PyApp)**: self-contained, offline, no-Python executables (`dh-mcp-systems-server`, `dh-mcp`) built per-platform via `uv run scripts/build_pyapp.py` and released by `.github/workflows/build-pyapp.yml`. See `docs/STANDALONE_BINARIES.md` for the full procedure.

--- a/README.md
+++ b/README.md
@@ -654,6 +654,10 @@ python3.12 -m venv .venv
 
 When using a venv, use the full path to executables (e.g., `.venv/bin/dh-mcp-systems-server`).
 
+#### Alternative: Standalone binaries (no Python required)
+
+If you do not have Python (or `uv`), download a prebuilt **standalone binary** — a single self-contained executable that embeds its own Python interpreter and all dependencies and runs fully offline. Get the archive for your platform from the [GitHub Releases page](https://github.com/deephaven/deephaven-mcp/releases). See [`docs/STANDALONE_BINARIES.md`](docs/STANDALONE_BINARIES.md) for the full install steps.
+
 ---
 
 ## Configuration

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -78,6 +78,7 @@ This repository houses the Python-based [Model Context Protocol (MCP)](https://m
       - [Script References](#script-references)
     - [Dependencies](#dependencies)
     - [Versioning](#versioning)
+    - [Standalone Binaries (PyApp)](#standalone-binaries-pyapp)
     - [Docker Compose](#docker-compose)
     - [Performance Testing](#performance-testing)
       - [MCP Docs Server Stress Testing](#mcp-docs-server-stress-testing)
@@ -1002,6 +1003,7 @@ The project includes several utility scripts to help with development and testin
 | [`../scripts/mcp_docs_test_client.py`](../scripts/mcp_docs_test_client.py) | Tests the Docs Server chat functionality | `uv run scripts/mcp_docs_test_client.py --prompt "What is Deephaven?"` |
 | [`../scripts/mcp_docs_stress_test.py`](../scripts/mcp_docs_stress_test.py) | In-process concurrent load test of the `docs_chat` tool | `uv run scripts/mcp_docs_stress_test.py` |
 | [`../scripts/mcp_docs_stress_http.py`](../scripts/mcp_docs_stress_http.py) | Stress tests the streamable-HTTP endpoint with concurrent connections | `uv run scripts/mcp_docs_stress_http.py --url "http://localhost:8001/mcp"` |
+| [`../scripts/build_pyapp.py`](../scripts/build_pyapp.py) | Builds standalone, self-contained binaries via PyApp (see [`STANDALONE_BINARIES.md`](STANDALONE_BINARIES.md)) | `uv run scripts/build_pyapp.py` |
 | [`../bin/precommit.sh`](../bin/precommit.sh) | Runs pre-commit code quality checks | `bin/precommit.sh` |
 
 ### Dependencies
@@ -1016,6 +1018,10 @@ These dependencies are automatically installed when using `pip install -e .` or 
 ### Versioning
 
 This package uses [setuptools-scm](https://github.com/pypa/setuptools_scm) for dynamic versioning based on git tags. Version information is automatically generated during the build process and stored in `src/deephaven_mcp/_version.py`. This file should not be manually edited or tracked in version control.
+
+### Standalone Binaries (PyApp)
+
+Self-contained, offline native binaries (no Python required at runtime) are built with [PyApp](https://ofek.dev/pyapp/). See [`STANDALONE_BINARIES.md`](STANDALONE_BINARIES.md).
 
 ### Docker Compose
 

--- a/docs/STANDALONE_BINARIES.md
+++ b/docs/STANDALONE_BINARIES.md
@@ -1,0 +1,98 @@
+# Standalone Binaries (PyApp)
+
+> **Project repository:** [https://github.com/deephaven/deephaven-mcp](https://github.com/deephaven/deephaven-mcp)
+
+Standalone binaries let you run deephaven-mcp **without installing Python**. Each one is a single self-contained executable that bundles its own Python interpreter and every dependency, packaged with [PyApp](https://ofek.dev/pyapp/). It needs **no network access at any point** — not even the first run, which simply unpacks the bundle once into a per-user cache (a few seconds); later launches are fast.
+
+## Install and run
+
+1. **Download** the archive for your platform from the [GitHub Releases page](https://github.com/deephaven/deephaven-mcp/releases):
+
+   | Platform | Archive |
+   |----------|---------|
+   | Linux (x86_64) | `deephaven-mcp-pyapp-<version>-linux-x86_64.tar.gz` |
+   | Linux (arm64) | `deephaven-mcp-pyapp-<version>-linux-aarch64.tar.gz` |
+   | macOS (Apple Silicon) | `deephaven-mcp-pyapp-<version>-macos-aarch64.tar.gz` |
+   | Windows (x86_64) | `deephaven-mcp-pyapp-<version>-windows-x86_64.zip` |
+
+2. **Extract it onto your `PATH`.** Each archive holds both executables, flat with no leading directory:
+
+   ```bash
+   tar -xzf deephaven-mcp-pyapp-*-macos-aarch64.tar.gz -C ~/.local/bin
+   ```
+
+   On Windows, unzip the `.zip` and put the `.exe` files in a directory on your `PATH`.
+
+3. **Point your AI tool** at the extracted `dh-mcp-systems-server` (use its absolute path if it is not on your `PATH`). The first launch unpacks the embedded distribution, so it may take a few seconds; later launches are fast.
+
+That is the whole install — there is nothing else to set up. Configuration is identical to any other install: the binary reads the same config directory and accepts the same flags as a `dh-mcp-systems-server` installed via `uv` or `pip`. See [`CONFIGURATION.md`](CONFIGURATION.md).
+
+## What's included
+
+Each archive contains two executables:
+
+| Binary | What it is |
+|--------|------------|
+| `dh-mcp-systems-server` | The MCP server your AI tool connects to |
+| `dh-mcp` | The local CLI |
+
+The docs server (`dh-mcp-docs-server`) is **not** distributed this way — it runs as a hosted service.
+
+> **Note:** Each binary is large (roughly 400+ MB) because it bundles a complete Python runtime plus all dependencies, including Community Core and Enterprise (Core+) support.
+
+## Build it yourself
+
+The published releases cover the platforms listed below. Build your own only when you need a platform that is not published, a different Python version, or your own distribution, using the build script [`scripts/build_pyapp.py`](../scripts/build_pyapp.py).
+
+### Prerequisites
+
+- [`uv`](https://docs.astral.sh/uv/) on your `PATH` — it builds the package and downloads the relocatable CPython that gets embedded.
+- A **Rust toolchain** with `cargo` on your `PATH` — PyApp compiles a Rust launcher into each binary. Install it with the one-line script from [rustup.rs](https://rustup.rs).
+- Network access **while building**, to download the Python runtime, the project's dependencies, and PyApp. (The finished binaries need no network.)
+
+### Build
+
+```bash
+# Build both binaries for the current platform into dist/pyapp/<target>/
+uv run scripts/build_pyapp.py
+
+# Build only the systems server
+uv run scripts/build_pyapp.py --binaries dh-mcp-systems-server
+
+# Embed a specific CPython version
+uv run scripts/build_pyapp.py --python-version 3.13
+```
+
+The embedded Python version and the set of binaries are configured in `[tool.pyapp]` of [`pyproject.toml`](../pyproject.toml) (`python-version` and `binaries`); the entry points come from `[project.scripts]`. `--python-version` and `--binaries` override those for a one-off build. Run `uv run scripts/build_pyapp.py --help` for the full option list.
+
+The build writes, under `dist/pyapp/`:
+
+```text
+dist/pyapp/
+├── <target>/
+│   ├── dh-mcp-systems-server[.exe]
+│   └── dh-mcp[.exe]
+└── deephaven-mcp-pyapp-<version>-<target>.{tar.gz,zip}
+```
+
+The flat archive (`.tar.gz` on Unix, `.zip` on Windows) is the thing you distribute — extract it exactly as the [install steps](#install-and-run) describe.
+
+### Supported platforms
+
+Builds run **natively per platform** — there is no cross-compilation, because the build bundles platform-specific compiled packages (numba, deephaven-server, deephaven-coreplus-client, ...). To produce a binary for a platform, run the build on a machine of that architecture.
+
+| Target | Build on |
+|--------|----------|
+| `linux-x86_64` | Linux x86_64 |
+| `linux-aarch64` | Linux arm64 |
+| `macos-aarch64` | macOS (Apple Silicon) |
+| `windows-x86_64` | Windows x86_64 |
+
+The build always targets the machine it runs on (it auto-detects the platform). Running it on an Intel Mac, for example, produces a `macos-x86_64` build, though that platform is not part of the published set.
+
+## Releasing
+
+Releases are produced by the [`build-pyapp.yml`](../.github/workflows/build-pyapp.yml) GitHub Actions workflow, which builds every supported platform on native runners and verifies each binary starts **with the network blocked** (proving it is self-contained) before publishing:
+
+- **Push a `v*` tag** — the workflow builds all platforms and attaches the distribution archives to the matching GitHub Release.
+- **Run it manually** (`workflow_dispatch`) — builds on demand and uploads the archives as workflow artifacts, so you can check a build before tagging.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,11 @@ dh-mcp = "deephaven_mcp.cli._main:main"
 dh-mcp-systems-server = "deephaven_mcp.mcp_systems_server.server:main"
 dh-mcp-docs-server = "deephaven_mcp.mcp_docs_server.main:main"
 
+[tool.pyapp]
+python-version = "3.12"
+pyapp-version = "0.29.0"
+binaries = ["dh-mcp-systems-server", "dh-mcp"]
+
 [tool.uv]
 package = true
 

--- a/scripts/build_pyapp.py
+++ b/scripts/build_pyapp.py
@@ -1,0 +1,730 @@
+#!/usr/bin/env python3
+"""Build standalone, fully self-contained binaries for deephaven-mcp console scripts.
+
+Each binary embeds a relocatable CPython together with the ``deephaven-mcp`` wheel and
+every dependency, so it runs with no Python install and no network access — on the very
+first launch, on a machine that has never seen the project.
+
+The design follows from one fact about how PyApp works (verified against its
+``build.rs``/``distribution.rs`` source): a PyApp binary embeds a Python distribution and
+*one* project wheel, and on first run it ``pip install``s that wheel — fetching the wheel's
+dependencies from a network index at that moment. PyApp cannot embed the dependency wheels.
+The only way to make the binary need no network is to set ``PYAPP_SKIP_INSTALL`` and hand
+PyApp a distribution whose ``site-packages`` *already* contains the project and all of its
+dependencies. Producing that pre-populated distribution is what this script does:
+
+1. ``uv build`` the wheel.
+2. ``uv python install`` a managed, relocatable CPython, install the wheel and its
+   dependencies into it with ``uv pip install``, and archive the tree.
+3. ``cargo install pyapp`` once per console script, embedding that distribution with
+   ``PYAPP_DISTRIBUTION_PATH`` + ``PYAPP_SKIP_INSTALL`` + ``PYAPP_FULL_ISOLATION``.
+
+Build settings live in ``[tool.pyapp]`` of ``pyproject.toml`` (``python-version``,
+``pyapp-version``, ``binaries``); each binary's entry point comes from
+``[project.scripts]``. Cross-compilation is unsupported (step 2 installs
+platform-specific wheels), so a build always targets the host machine.
+
+Requirements: ``uv`` and a Rust toolchain (``cargo``) on ``PATH``, plus build-time
+network access. Run ``uv run scripts/build_pyapp.py --help`` for options.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tarfile
+import tomllib
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+_LOGGER = logging.getLogger("build_pyapp")
+
+_OS_ALIASES = {"Linux": "linux", "Darwin": "macos", "Windows": "windows"}
+_ARCH_ALIASES = {
+    "x86_64": "x86_64",
+    "amd64": "x86_64",
+    "aarch64": "aarch64",
+    "arm64": "aarch64",
+}
+
+
+# --- Low-level helpers -------------------------------------------------------------------
+
+
+def run(cmd: list[str], *, env: dict[str, str] | None = None) -> None:
+    """Run a subprocess command, streaming its output, and raise on failure.
+
+    Args:
+        cmd (list[str]): The command argv to execute.
+        env (dict[str, str] | None): Environment for the child process, or ``None`` to
+            inherit the current environment.
+
+    Raises:
+        subprocess.CalledProcessError: If the command exits non-zero.
+    """
+    _LOGGER.info(f"[run] $ {' '.join(cmd)}")
+    # ``cmd`` is a list (no ``shell=True``), which prevents shell injection; ``S603`` is
+    # bandit's generic subprocess warning.
+    subprocess.run(cmd, env=env, check=True, text=True)  # noqa: S603
+
+
+def _write_tar_gz(src_dir: Path, dest: Path) -> None:
+    """Write the contents of ``src_dir`` into ``dest`` as a flat ``.tar.gz``.
+
+    Args:
+        src_dir (Path): Directory whose entries are archived (no wrapping directory).
+        dest (Path): Output archive path; overwritten if present.
+    """
+    dest.unlink(missing_ok=True)
+    with tarfile.open(dest, "w:gz") as tf:
+        for item in sorted(src_dir.iterdir()):
+            tf.add(item, arcname=item.name)
+
+
+def _write_zip(src_dir: Path, dest: Path) -> None:
+    """Write the contents of ``src_dir`` into ``dest`` as a flat ``.zip``.
+
+    Args:
+        src_dir (Path): Directory whose entries are archived (no wrapping directory).
+        dest (Path): Output archive path; overwritten if present.
+    """
+    dest.unlink(missing_ok=True)
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as zf:
+        for item in sorted(src_dir.iterdir()):
+            zf.write(item, arcname=item.name)
+
+
+# --- Value types -------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PythonVersion:
+    """A requested CPython version (e.g. ``3.12`` or ``3.12.13``)."""
+
+    requested: str
+    """The version string as configured and passed to ``uv python install``."""
+
+    @property
+    def minor(self) -> str:
+        """The ``major.minor`` prefix of :attr:`requested` (e.g. ``3.12``)."""
+        return ".".join(self.requested.split(".")[:2])
+
+
+@dataclass(frozen=True)
+class Host:
+    """The platform being built for (always the runner; cross-compilation is unsupported)."""
+
+    alias: str
+    """Short platform name used in output directory and archive names (e.g. ``macos-aarch64``)."""
+
+    is_windows: bool
+    """Whether this host is Windows (selects executable suffix, distribution paths, archive format)."""
+
+    @classmethod
+    def detect(cls) -> Host:
+        """Return the :class:`Host` for the current machine.
+
+        Returns:
+            Host: The detected host.
+
+        Raises:
+            SystemExit: If the platform or architecture is unsupported.
+        """
+        system = platform.system()
+        machine = platform.machine().lower()
+        os_alias = _OS_ALIASES.get(system)
+        arch_alias = _ARCH_ALIASES.get(machine)
+        if os_alias is None or arch_alias is None:
+            raise SystemExit(
+                f"[build_pyapp] Unsupported host platform: {system}/{machine}"
+            )
+        return cls(alias=f"{os_alias}-{arch_alias}", is_windows=os_alias == "windows")
+
+    @property
+    def exe_suffix(self) -> str:
+        """Suffix for executables: ``.exe`` on Windows, else empty."""
+        return ".exe" if self.is_windows else ""
+
+    @property
+    def python_exe_rel(self) -> str:
+        """Relative path to the interpreter inside the distribution."""
+        return "python.exe" if self.is_windows else "bin/python3"
+
+    def site_packages_rel(self, version: PythonVersion) -> str:
+        """Return the ``site-packages`` path relative to the distribution root.
+
+        Args:
+            version (PythonVersion): The embedded Python version.
+
+        Returns:
+            str: The relative ``site-packages`` path for this host.
+        """
+        return (
+            "Lib/site-packages"
+            if self.is_windows
+            else f"lib/python{version.minor}/site-packages"
+        )
+
+    def archive(self, src_dir: Path, dest_stem: Path) -> Path:
+        """Archive ``src_dir`` flat in this host's native shipping format.
+
+        Writes a ``.zip`` on Windows and a ``.tar.gz`` elsewhere, storing the directory's
+        entries flat (no wrapping directory).
+
+        Args:
+            src_dir (Path): Directory whose contents are archived.
+            dest_stem (Path): Output path without an extension; the format-specific
+                extension is appended.
+
+        Returns:
+            Path: The created archive.
+        """
+        if self.is_windows:
+            dest = dest_stem.with_name(dest_stem.name + ".zip")
+            _write_zip(src_dir, dest)
+        else:
+            dest = dest_stem.with_name(dest_stem.name + ".tar.gz")
+            _write_tar_gz(src_dir, dest)
+        return dest
+
+
+@dataclass(frozen=True)
+class BuildConfig:
+    """Build settings read from ``[tool.pyapp]`` in ``pyproject.toml``."""
+
+    project_name: str
+    """Distribution name (``[project].name``), used as ``PYAPP_PROJECT_NAME``."""
+
+    python_version: str
+    """CPython version to embed (e.g. ``3.12``)."""
+
+    pyapp_version: str
+    """PyApp crate version to compile (e.g. ``0.29.0``)."""
+
+    binaries: dict[str, str]
+    """Binary name -> entry point (``PYAPP_EXEC_SPEC``), resolved from ``[project.scripts]``."""
+
+    @classmethod
+    def from_pyproject(cls, repo_root: Path) -> BuildConfig:
+        """Read the ``[tool.pyapp]`` build settings from ``pyproject.toml``.
+
+        ``binaries`` lists the console scripts to ship; each one's entry point is taken
+        from ``[project.scripts]`` (whose ``module:function`` value is PyApp's
+        ``EXEC_SPEC``).
+
+        Args:
+            repo_root (Path): Repository root containing ``pyproject.toml``.
+
+        Returns:
+            BuildConfig: The parsed build settings.
+
+        Raises:
+            SystemExit: If ``[tool.pyapp].binaries`` is empty or names a script missing
+                from ``[project.scripts]``.
+        """
+        with open(repo_root / "pyproject.toml", "rb") as f:
+            data = tomllib.load(f)
+        project = data.get("project", {})
+        pyapp = data.get("tool", {}).get("pyapp", {})
+        scripts = project.get("scripts", {})
+        names = pyapp.get("binaries")
+        if not names:
+            raise SystemExit(
+                "[build_pyapp] pyproject.toml [tool.pyapp].binaries is empty"
+            )
+        missing = [name for name in names if name not in scripts]
+        if missing:
+            raise SystemExit(
+                f"[build_pyapp] [tool.pyapp].binaries not in [project.scripts]: {missing}"
+            )
+        return cls(
+            project_name=project["name"],
+            python_version=pyapp["python-version"],
+            pyapp_version=pyapp["pyapp-version"],
+            binaries={name: scripts[name] for name in names},
+        )
+
+
+# --- Build steps -------------------------------------------------------------------------
+
+
+def build_wheel(repo_root: Path, out_dir: Path) -> Path:
+    """Build the ``deephaven-mcp`` wheel into ``out_dir``.
+
+    Args:
+        repo_root (Path): Repository root to build from.
+        out_dir (Path): Directory to write the wheel into; created if absent.
+
+    Returns:
+        Path: The built wheel.
+
+    Raises:
+        SystemExit: If no wheel is produced.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    run(["uv", "build", "--wheel", str(repo_root), "--out-dir", str(out_dir)])
+    wheels = sorted(out_dir.glob("deephaven_mcp-*.whl"))
+    if not wheels:
+        raise SystemExit(f"[build_pyapp] No wheel produced under {out_dir}")
+    return wheels[-1]
+
+
+def project_version_from_wheel(wheel_path: Path) -> str:
+    """Return the ``deephaven-mcp`` version parsed from a wheel filename.
+
+    Args:
+        wheel_path (Path): Path to a ``deephaven_mcp-<version>-...`` wheel.
+
+    Returns:
+        str: The version segment of the wheel filename.
+
+    Raises:
+        SystemExit: If the filename does not start with the expected prefix.
+    """
+    # PEP 427 wheel name: {distribution}-{version}-...; stripping the known distribution
+    # prefix yields the version up to the next '-'.
+    prefix = "deephaven_mcp-"
+    name = wheel_path.name
+    if not name.startswith(prefix):
+        raise SystemExit(f"[build_pyapp] Unexpected wheel name: {name}")
+    return name[len(prefix) :].split("-", 1)[0]
+
+
+def install_python(version: PythonVersion, install_dir: Path) -> Path:
+    """Download a managed CPython into ``install_dir`` and return its tree root.
+
+    The interpreter is always a managed python-build-standalone download pinned to
+    ``version`` — ``--managed-python`` keeps uv from ever selecting the system Python — so
+    the result is a complete, relocatable interpreter + standard library suitable for
+    embedding.
+
+    Args:
+        version (PythonVersion): CPython version to install.
+        install_dir (Path): Throwaway directory to install into; recreated each call.
+
+    Returns:
+        Path: The distribution root (the ``cpython-<full-version>-<platform>`` directory).
+
+    Raises:
+        SystemExit: If uv does not produce exactly one matching interpreter.
+    """
+    # Start from an empty directory so the post-install discovery below is unambiguous.
+    if install_dir.exists():
+        shutil.rmtree(install_dir)
+
+    # Download a managed CPython pinned to the configured version. --managed-python keeps
+    # uv from ever falling back to the system Python; --no-bin skips launcher shims.
+    run(
+        [
+            "uv",
+            "python",
+            "install",
+            "--managed-python",
+            "--no-bin",
+            "--install-dir",
+            str(install_dir),
+            version.requested,
+        ]
+    )
+
+    # uv lays the interpreter out as cpython-<full-version>-<platform>/; matching a patch
+    # digit skips the cpython-<minor>-<platform>/ alias. The freshly-cleaned directory
+    # must hold exactly one such tree -- any other count means uv behaved unexpectedly.
+    installs = sorted(
+        p for p in install_dir.glob(f"cpython-{version.minor}.*") if p.is_dir()
+    )
+    if len(installs) != 1:
+        raise SystemExit(
+            f"[build_pyapp] expected exactly one cpython-{version.minor}.* install under "
+            f"{install_dir}, found {[p.name for p in installs]}"
+        )
+    return installs[0]
+
+
+def install_project(
+    dist_root: Path, host: Host, version: PythonVersion, wheel_path: Path
+) -> None:
+    """Install the project wheel and all dependencies into a distribution.
+
+    Args:
+        dist_root (Path): Distribution root from :func:`install_python`.
+        host (Host): Target host (selects interpreter and site-packages paths).
+        version (PythonVersion): The embedded Python version.
+        wheel_path (Path): The ``deephaven-mcp`` wheel to install.
+    """
+    # uv stamps its managed interpreters with a PEP 668 EXTERNALLY-MANAGED marker to stop
+    # callers from mutating the shared install. This tree is a private, disposable copy we
+    # are deliberately turning into a distribution, so remove the marker (it sits in the
+    # stdlib dir, the parent of site-packages); uv then installs with --system and no
+    # --break-system-packages override.
+    marker = (
+        dist_root / Path(host.site_packages_rel(version)).parent / "EXTERNALLY-MANAGED"
+    )
+    marker.unlink(missing_ok=True)
+    run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(dist_root / host.python_exe_rel),
+            "--system",
+            str(wheel_path),
+        ]
+    )
+
+
+def archive_distribution(dist_root: Path, archive_path: Path) -> Path:
+    """Archive a distribution tree flat into ``archive_path`` as a ``.tar.gz``.
+
+    Always a ``.tar.gz`` regardless of host — PyApp reads tar.gz distributions on every
+    platform. The archive's top level is the distribution root itself (``bin/``, ``lib/``,
+    ...) with no wrapping directory, so PyApp's ``DISTRIBUTION_PYTHON_PATH`` /
+    ``SITE_PACKAGES_PATH`` (relative to the unpack root) resolve directly and
+    ``PYAPP_DISTRIBUTION_PATH_PREFIX`` is not needed.
+
+    Args:
+        dist_root (Path): Distribution root to archive.
+        archive_path (Path): Output ``.tar.gz`` path; overwritten if present.
+
+    Returns:
+        Path: ``archive_path``.
+    """
+    _LOGGER.info(f"[archive] Writing distribution to {archive_path}")
+    _write_tar_gz(dist_root, archive_path)
+    return archive_path
+
+
+def build_distribution(
+    version: PythonVersion, host: Host, wheel_path: Path, work_dir: Path
+) -> Path:
+    """Build a self-contained, pre-populated Python distribution and archive it.
+
+    Produces the artifact PyApp embeds: a relocatable CPython whose ``site-packages``
+    already contains the project and every dependency, so PyApp runs it under
+    ``PYAPP_SKIP_INSTALL`` with no network. A ``uv venv`` cannot be used here — its
+    ``bin/python`` is a symlink to an external base interpreter and its tree omits the
+    standard library, so an embedded venv dangles on a clean machine.
+
+    Args:
+        version (PythonVersion): CPython version to embed.
+        host (Host): Target host.
+        wheel_path (Path): The ``deephaven-mcp`` wheel to install.
+        work_dir (Path): Scratch directory for the interpreter and the archive.
+
+    Returns:
+        Path: The distribution ``.tar.gz``.
+    """
+    dist_root = install_python(version, work_dir / "py")
+    install_project(dist_root, host, version, wheel_path)
+    return archive_distribution(dist_root, work_dir / "distribution.tar.gz")
+
+
+def pyapp_build_env(
+    *,
+    exec_spec: str,
+    project_name: str,
+    project_version: str,
+    distribution_archive: Path,
+    host: Host,
+    version: PythonVersion,
+) -> dict[str, str]:
+    """Return the ``PYAPP_*`` build variables that encode the offline contract.
+
+    Together these tell PyApp to embed the pre-populated distribution and run it without
+    any install or download.
+
+    Args:
+        exec_spec (str): The ``module:function`` entry point the binary runs.
+        project_name (str): Distribution name (``PYAPP_PROJECT_NAME``).
+        project_version (str): Project version (``PYAPP_PROJECT_VERSION``).
+        distribution_archive (Path): The pre-populated distribution archive to embed.
+        host (Host): Target host (selects interpreter and site-packages paths).
+        version (PythonVersion): The embedded Python version.
+
+    Returns:
+        dict[str, str]: Environment overrides to pass to ``cargo install pyapp``.
+    """
+    return {
+        # build.rs reads the project identity from these even under SKIP_INSTALL, and
+        # panics without them when no PYAPP_PROJECT_PATH wheel is embedded.
+        "PYAPP_PROJECT_NAME": project_name,
+        "PYAPP_PROJECT_VERSION": project_version,
+        "PYAPP_EXEC_SPEC": exec_spec,
+        # A local distribution path implicitly enables embedding.
+        "PYAPP_DISTRIBUTION_PATH": str(distribution_archive.resolve()),
+        # Required for a custom distribution: PyApp's built-in default paths apply only to
+        # distributions it downloads itself, and build.rs panics without these.
+        "PYAPP_DISTRIBUTION_PYTHON_PATH": host.python_exe_rel,
+        "PYAPP_DISTRIBUTION_SITE_PACKAGES_PATH": host.site_packages_rel(version),
+        # Skip the first-run pip install (the deps are already present), and run from a
+        # full copy of the distribution rather than a virtualenv so its site-packages deps
+        # are importable (without FULL_ISOLATION PyApp builds a venv lacking them, causing
+        # ModuleNotFoundError; verified empirically).
+        "PYAPP_SKIP_INSTALL": "true",
+        "PYAPP_FULL_ISOLATION": "true",
+    }
+
+
+def build_binary(
+    *,
+    binary_name: str,
+    exec_spec: str,
+    project_name: str,
+    project_version: str,
+    version: PythonVersion,
+    pyapp_version: str,
+    distribution_archive: Path,
+    host: Host,
+    work_dir: Path,
+    output_dir: Path,
+) -> Path:
+    """Compile one PyApp binary with the distribution embedded.
+
+    Args:
+        binary_name (str): Output binary name (e.g. ``dh-mcp``).
+        exec_spec (str): The ``module:function`` entry point.
+        project_name (str): Distribution name (``PYAPP_PROJECT_NAME``).
+        project_version (str): Project version (``PYAPP_PROJECT_VERSION``).
+        version (PythonVersion): The embedded Python version.
+        pyapp_version (str): PyApp crate version to compile.
+        distribution_archive (Path): Pre-populated distribution to embed.
+        host (Host): Target host.
+        work_dir (Path): Scratch directory for the cargo install root.
+        output_dir (Path): Directory the finished binary is copied into.
+
+    Returns:
+        Path: The finished binary under ``output_dir``.
+
+    Raises:
+        SystemExit: If cargo does not produce the expected binary.
+    """
+    cargo_root = work_dir / f"pyapp-{binary_name}"
+    if cargo_root.exists():
+        shutil.rmtree(cargo_root)
+
+    env = os.environ.copy()
+    env.update(
+        pyapp_build_env(
+            exec_spec=exec_spec,
+            project_name=project_name,
+            project_version=project_version,
+            distribution_archive=distribution_archive,
+            host=host,
+            version=version,
+        )
+    )
+
+    run(
+        [
+            "cargo",
+            "install",
+            "pyapp",
+            "--version",
+            pyapp_version,
+            "--force",
+            "--locked",
+            "--root",
+            str(cargo_root),
+        ],
+        env=env,
+    )
+
+    produced = cargo_root / "bin" / ("pyapp" + host.exe_suffix)
+    if not produced.exists():
+        raise SystemExit(f"[build_pyapp] cargo did not produce {produced}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    final = output_dir / f"{binary_name}{host.exe_suffix}"
+    shutil.copy2(produced, final)  # copy2 preserves the executable mode
+    _LOGGER.info(f"[build_binary] Wrote {final}")
+    return final
+
+
+def package_archive(
+    output_dir: Path, base_output_dir: Path, project_version: str, host: Host
+) -> Path:
+    """Bundle the host's binaries into one flat distribution archive.
+
+    Args:
+        output_dir (Path): Directory holding the built binaries.
+        base_output_dir (Path): Directory to write the archive into.
+        project_version (str): Version used in the archive name.
+        host (Host): Target host (selects archive format and name).
+
+    Returns:
+        Path: The written archive.
+    """
+    basename = f"deephaven-mcp-pyapp-{project_version}-{host.alias}"
+    archive = host.archive(output_dir, base_output_dir / basename)
+    _LOGGER.info(f"[package] Wrote distribution archive: {archive}")
+    return archive
+
+
+# --- Orchestration -----------------------------------------------------------------------
+
+
+def select_binaries(config: BuildConfig, requested: list[str] | None) -> dict[str, str]:
+    """Return the binary -> entry-point map to build, applying an optional subset.
+
+    Args:
+        config (BuildConfig): The parsed build settings.
+        requested (list[str] | None): Subset of binary names to build, or ``None`` for all.
+
+    Returns:
+        dict[str, str]: The selected binary -> entry-point mapping.
+
+    Raises:
+        SystemExit: If ``requested`` names a binary absent from ``[tool.pyapp].binaries``.
+    """
+    if requested is None:
+        return config.binaries
+    unknown = [name for name in requested if name not in config.binaries]
+    if unknown:
+        raise SystemExit(
+            f"[build_pyapp] --binaries {unknown} not in [tool.pyapp].binaries "
+            f"{list(config.binaries)}"
+        )
+    return {name: config.binaries[name] for name in requested}
+
+
+def run_build(
+    repo_root: Path,
+    host: Host,
+    config: BuildConfig,
+    version: PythonVersion,
+    binaries: dict[str, str],
+    *,
+    keep_work: bool,
+) -> list[Path]:
+    """Build the wheel and distribution, compile each binary, and package the result.
+
+    Args:
+        repo_root (Path): Repository root to build from.
+        host (Host): Target host.
+        config (BuildConfig): The parsed build settings.
+        version (PythonVersion): CPython version to embed.
+        binaries (dict[str, str]): Binary -> entry-point mapping to build.
+        keep_work (bool): If true, leave the scratch ``build/pyapp`` directory in place.
+
+    Returns:
+        list[Path]: The finished binaries.
+    """
+    work_dir = (repo_root / "build" / "pyapp").resolve()
+    base_output_dir = (repo_root / "dist" / "pyapp").resolve()
+    output_dir = base_output_dir / host.alias
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    wheel_path = build_wheel(repo_root, work_dir / "wheel")
+    project_version = project_version_from_wheel(wheel_path)
+    _LOGGER.info(f"[build] Built wheel for {config.project_name} {project_version}")
+
+    distribution_archive = build_distribution(version, host, wheel_path, work_dir)
+
+    produced = [
+        build_binary(
+            binary_name=name,
+            exec_spec=exec_spec,
+            project_name=config.project_name,
+            project_version=project_version,
+            version=version,
+            pyapp_version=config.pyapp_version,
+            distribution_archive=distribution_archive,
+            host=host,
+            work_dir=work_dir,
+            output_dir=output_dir,
+        )
+        for name, exec_spec in binaries.items()
+    ]
+
+    package_archive(output_dir, base_output_dir, project_version, host)
+
+    # Keep the scratch tree on failure (it never reaches here) so debugging artifacts
+    # survive; only a clean run removes it.
+    if not keep_work:
+        shutil.rmtree(work_dir, ignore_errors=True)
+    return produced
+
+
+# --- Command-line interface --------------------------------------------------------------
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Args:
+        argv (list[str] | None): Arguments to parse, or ``None`` to use ``sys.argv``.
+
+    Returns:
+        argparse.Namespace: The parsed arguments.
+    """
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--python-version",
+        default=None,
+        help="Override the embedded CPython version (default: [tool.pyapp].python-version).",
+    )
+    parser.add_argument(
+        "--binaries",
+        nargs="+",
+        default=None,
+        metavar="NAME",
+        help="Subset of [tool.pyapp].binaries to build (default: all).",
+    )
+    parser.add_argument(
+        "--keep-work",
+        action="store_true",
+        help="Do not delete the work directory on success.",
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", help="Enable debug logging."
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Build the requested PyApp binaries for the host platform.
+
+    Args:
+        argv (list[str] | None): Command-line arguments, or ``None`` for ``sys.argv``.
+
+    Returns:
+        int: Process exit code (``0`` on success).
+
+    Raises:
+        SystemExit: On an unsupported host or an unknown ``--binaries`` selection.
+    """
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    repo_root = Path(__file__).resolve().parent.parent
+    host = Host.detect()
+    config = BuildConfig.from_pyproject(repo_root)
+    binaries = select_binaries(config, args.binaries)
+    version = PythonVersion(args.python_version or config.python_version)
+
+    _LOGGER.info(
+        f"[main] Building {host.alias} with embedded Python {version.requested}"
+    )
+    produced = run_build(
+        repo_root, host, config, version, binaries, keep_work=args.keep_work
+    )
+
+    _LOGGER.info("[main] Build complete. Produced binaries:")
+    for path in produced:
+        _LOGGER.info(f"  - {path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This pull request introduces first-class support for building, distributing, and documenting standalone, self-contained binaries for the project using PyApp. Users can now run the core CLI and server components without installing Python or any dependencies. The changes include a new build workflow, user-facing documentation, and updates throughout the repo to reference and explain the new distribution method.

**Standalone binary support and documentation:**

* Added `docs/STANDALONE_BINARIES.md` with comprehensive instructions for installing, using, and building the new standalone binaries, including platform coverage, archive formats, and build prerequisites.
* Updated the main `README.md` to mention standalone binaries as an alternative to Python/venv installs, with a pointer to the new documentation.
* Added a section to `docs/DEVELOPER_GUIDE.md` and its table of contents about standalone binaries, including build instructions and script references. [[1]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092R81) [[2]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092R1022-R1025) [[3]](diffhunk://#diff-c8cc1c768f65228fb71f3c6b7aeb9fa144b4b65e8cf514a7e1f10e4bd1077092R1006)

**Build system and configuration:**

* Introduced `.github/workflows/build-pyapp.yml`, a cross-platform GitHub Actions workflow that builds, tests (including offline smoke tests), and attaches standalone binary archives to releases for all supported platforms.
* Added a `[tool.pyapp]` section to `pyproject.toml` specifying the embedded Python version, PyApp version, and which binaries to build.

**Skill and documentation role updates:**

* Updated `_documentation-roles` skill and its documentation to cover the new `docs/STANDALONE_BINARIES.md` file, and clarified which workflows load this skill for docs and CLI authoring. [[1]](diffhunk://#diff-2391db23050f66b7c9eebe16cde9fd74fdf71e2525e2d06eca13d082c0ca9728L3-R9) [[2]](diffhunk://#diff-2391db23050f66b7c9eebe16cde9fd74fdf71e2525e2d06eca13d082c0ca9728R22) [[3]](diffhunk://#diff-fd51f581d1d76ca7ee06c4b285fbc4eede3db5aa4eac874d7cce8b6d29b7d414L23-R23)

**Other references:**

* Updated `AGENTS.md` to document the new build and distribution process for both wheels and standalone binaries.