### PR TITLE
fix: Restrict MCP CLI dependency version to avoid compatibility issues with MCP 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "aiohttp>=3.11.18",         # Async HTTP client (stress testing, SSE)
     "httpx>=0.24.0",            # HTTP client
     # MCP protocol and orchestration
-    "mcp[cli]>=1.12.0",          # CLI and fastmcp server
+    "mcp[cli]>=1.12.0,<2",       # CLI and fastmcp server; MCP 2.x removed mcp.server.fastmcp
     "mcp-proxy",                # SSE/Streamable-HTTP proxy support
     # Deephaven integration
     "pydeephaven>=0.39",      # Deephaven Python API

--- a/src/deephaven_mcp/formatters/_yaml.py
+++ b/src/deephaven_mcp/formatters/_yaml.py
@@ -1,7 +1,7 @@
 """YAML formatter for PyArrow tables."""
 
 import pyarrow as pa
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 
 def format_yaml(arrow_table: pa.Table) -> str:


### PR DESCRIPTION
This pull request makes a small but important change to the dependency specification in `pyproject.toml`. The version constraint for the `mcp[cli]` package has been updated to prevent installation of incompatible major versions.

* The `mcp[cli]` dependency is now restricted to versions `>=1.12.0,<2` to avoid breaking changes introduced in MCP 2.x, which removed `mcp.server.fastmcp`.…s with MCP 2.x