### PR TITLE
feat(cli): redact secrets in config output unless --reveal-secrets

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,8 +56,8 @@ process. Please direct reports to the listed parties instead.
   Deephaven MCP defect.
 - **Documented credential-disclosure behavior** — e.g. the plaintext
   session token `security.credential_retrieval_mode` returns. Its
-  default, `dynamic_only`, covers only sessions this server minted a
-  token for at the caller's request; widening it to reach
+  default, `dynamic_only`, covers every session this server launched at
+  runtime, whichever client created it; widening it to reach
   operator-authored static credentials is an explicit opt-in. Both are
   deliberate, documented choices, not defects.
 - **Third-party MCP clients** — Claude Desktop, Cursor, VS Code Copilot,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,9 +54,11 @@ process. Please direct reports to the listed parties instead.
 - **Customer infrastructure misconfiguration** — open reverse proxies,
   weak network ACLs, exposed credentials in your own environment. Not a
   Deephaven MCP defect.
-- **Documented security opt-ins** — e.g. plaintext session tokens
-  returned when `security.credential_retrieval_mode` is set to anything
-  other than `none`. These are deliberate, documented, off-by-default
-  choices, not defects.
+- **Documented credential-disclosure behavior** — e.g. the plaintext
+  session token `security.credential_retrieval_mode` returns. Its
+  default, `dynamic_only`, covers only sessions this server minted a
+  token for at the caller's request; widening it to reach
+  operator-authored static credentials is an explicit opt-in. Both are
+  deliberate, documented choices, not defects.
 - **Third-party MCP clients** — Claude Desktop, Cursor, VS Code Copilot,
   Windsurf, etc. Report those to the vendor.

--- a/config-samples/ai/config/community/settings.json
+++ b/config-samples/ai/config/community/settings.json
@@ -1,6 +1,6 @@
 {
   "security": {
-    "credential_retrieval_mode": "none"
+    "credential_retrieval_mode": "dynamic_only"
   },
   "session_creation": {
     "max_concurrent_sessions": 1,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -502,11 +502,14 @@ exits `3`.
 `session_community_credentials` tool, whose output contains a
 **plaintext auth token by design**. Retrieval is gated by
 `community.settings.security.credential_retrieval_mode`
-(default `dynamic_only`, which permits sessions created by
-`session create` but withholds statically configured credentials);
+(default `dynamic_only`, which permits every dynamically launched
+session — whichever client created it — but withholds statically
+configured credentials);
 when refused — or the session is missing or not a Community session —
 they exit `3`. `session open` additionally keeps the token out of its
-output unless `--reveal-secrets` is passed. All session verbs exit `0` on
+output unless `--reveal-secrets` is passed — including on the
+`browser_launch_failed` path, where the URL offered for manual opening
+is the token-free one. All session verbs exit `0` on
 success, `2` on client-side/daemon failure, and `3` when the wrapped
 tool reports an error.
 
@@ -1137,7 +1140,7 @@ registry programmatically via `dhcli agents errors` (or the
 | `mutually_exclusive_options`  | Two or more options that cannot be combined were supplied together. |
 | `file_read_failed`            | A local file passed on the command line could not be read.          |
 | `option_not_applicable`       | An option/argument is invalid for the selected `--system` type (an inapplicable option, or a missing required one such as a Community session name). |
-| `browser_launch_failed`       | `dhcli session open` / `system open` could not launch a browser; the URL is included in the error message to open manually. |
+| `browser_launch_failed`       | `dhcli session open` / `system open` could not launch a browser; the URL is included in the error message to open manually. For `session open` that URL omits the auth token unless `--reveal-secrets` was passed — use `dhcli session url` for one that logs in. |
 | `system_not_found`            | `dhcli system url/open NAME` named an Enterprise system that is not configured (`community` included — it has no web console). |
 | `context_not_set`             | A session/system/PQ id was omitted and no sticky context supplies one. Pass it explicitly, run `dhcli context set KEY VALUE`, or check `dhcli context show`. `--no-context` / `cli.context.enabled=false` disables the sticky-context fallback step, making this code more likely, not less. |
 | `config_invalid`              | The configuration tree failed validation.                          |

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -401,10 +401,13 @@ a terminal; `--yes` skips the question, and with no terminal they
 proceed unprompted.
 
 `session credentials`, `session url`, and `session open` are the quiet
-case: they destroy nothing, so nothing confirms them, but each returns a
-URL carrying a live auth token for whatever session was named. Aim one
-at a session you were not given and you have disclosed that session's
-credentials.
+case: they destroy nothing, so nothing confirms them, but each fetches a
+live auth token for whatever session was named. Aim one at a session you
+were not given and you have disclosed that session's credentials.
+`credentials` and `url` print the token — that is what they are for.
+`session open` hands it to the browser instead and keeps it out of
+stdout unless you pass `--reveal-secrets`, the same opt-in `config get`
+uses.
 
 ### `dhcli daemon`
 
@@ -415,7 +418,7 @@ credentials.
 | `status`   | Reports the daemon's `state` (`running`/`stopped`/`crashed`) and a human `message`. Includes a `daemon` object — the running daemon's registry entry, redacted: `pid`, `create_time_ns`, `process_name`, `host`, `port`, redacted `psk`, `started_at`, `config_dir`, `server_name`, and a `build_identity` sub-object with `version`, `venv`, `fingerprint` — **only when running**, and always includes `paths` (config, runtime, registry, log). Read-only: a `crashed` entry is reported, not cleaned up — use `start` or `repair`. Exits 0 in all three states. |
 | `restart`  | `stop` then `start` in one shot; returns the same `{state, message, daemon, paths}` envelope as `start`. |
 | `repair`   | Recovers from a corrupt `daemon.json` by moving it aside to `daemon.json.corrupt-<UTC>` so a fresh `start` can write a clean registry. Refuses while a live daemon is still registered (`daemon_registry_live`). |
-| `logs`     | Tails `daemon.log`. `-n/--lines N` controls the initial tail (default 100); `-f/--follow` follows the file (Ctrl-C to exit); `--path` prints the absolute log-file path and exits (works even if the daemon has never started). |
+| `logs`     | Tails `daemon.log`. `-n/--lines N` controls the initial tail (default 100); `-f/--follow` follows the file (Ctrl-C to exit); `--path` prints the absolute log-file path and exits (works even if the daemon has never started). Auto-generated session tokens appear in the output in plaintext (see [`docs/SECURITY.md`](SECURITY.md#secret-handling)). |
 
 ### `dhcli tool`
 
@@ -498,9 +501,12 @@ exits `3`.
 `credentials`, `url`, and `open` are Community-only and share the
 `session_community_credentials` tool, whose output contains a
 **plaintext auth token by design**. Retrieval is gated by
-`security.credential_retrieval_mode` in `community/settings.json`
-(default `none`); when disabled — or the session is missing or not a
-Community session — they exit `3`. All session verbs exit `0` on
+`community.settings.security.credential_retrieval_mode`
+(default `dynamic_only`, which permits sessions created by
+`session create` but withholds statically configured credentials);
+when refused — or the session is missing or not a Community session —
+they exit `3`. `session open` additionally keeps the token out of its
+output unless `--reveal-secrets` is passed. All session verbs exit `0` on
 success, `2` on client-side/daemon failure, and `3` when the wrapped
 tool reports an error.
 
@@ -514,7 +520,7 @@ dhcli session exec community:community:dev --script 'print(1)'
 cat job.py | dhcli session exec community:community:dev --script-path -
 dhcli session pip-list community:community:dev
 dhcli session delete community:community:dev
-dhcli session open community:community:dev --print
+dhcli session open community:community:dev --print --reveal-secrets
 ```
 
 ### `dhcli system`
@@ -717,7 +723,7 @@ The `source` each key reports is one of:
 |------------|--------------------------------------------------------------------------------------|
 | `file`     | The key holds a value in `context.json`, and the fallback is on, so an omitted argument will use it. |
 | `unset`    | The key holds no value; a command that omits the argument exits `2` (`context_not_set`). |
-| `disabled` | The fallback is off (`--no-context`, or `cli.json`'s `context.enabled: false`), so no command will consult the context. `value` still shows what is stored. |
+| `disabled` | The fallback is off (`--no-context`, or `cli.context.enabled` set to `false`), so no command will consult the context. `value` still shows what is stored. |
 
 `set` and `unset` write to `context.json` even when the fallback is off,
 printing a one-line warning on stderr.
@@ -734,7 +740,7 @@ share an id, but setting one never changes another. The `create` and
 | `session delete` / `pq delete`| clears `session` and `pq` when either pointed at a deleted id |
 
 Disable the fallback for one invocation with `--no-context`, or
-permanently via `cli.json`'s `context.enabled` (see the `context.*`
+permanently via `cli.context.enabled` (see the `context.*`
 configuration table above).
 
 The two flags govern opposite directions and are easy to confuse:
@@ -754,8 +760,8 @@ show` first whenever you intend to omit an id and are not certain what
 the context holds. Every consequential verb repeats this warning in its
 own `--help` and `--agents` output.
 
-By default dhcli acts on the context without asking. Set `cli.json`'s
-`context.confirm_destructive` to `true` to be asked first:
+By default dhcli acts on the context without asking. Set
+`cli.context.confirm_destructive` to `true` to be asked first:
 
 ```text
 Run script in session 'community:community:dev' (from sticky context)? [y/N]
@@ -795,7 +801,7 @@ dhcli context unset --all
 ### `dhcli docs`
 
 Queries the Deephaven documentation MCP server. These verbs connect
-**directly** to the docs server configured as `docs.url` in `cli.json`
+**directly** to the docs server named by `cli.docs.url`
 (default: the Deephaven-hosted production docs server at
 `https://deephaven-mcp-docs-prod.dhc-demo.deephaven.io/mcp`) — the local
 daemon is not involved and is never started.
@@ -847,7 +853,7 @@ contain dots. File boundaries surface only in `config files`.
 | `validate`  | Confirms the configuration is valid; exits `0`, or `2` with `config_invalid` if any file is malformed. A zero-system tree is valid (the no-systems invariant is enforced only where a system is required, not by this check). Validation runs before every command body, so this is CI-friendly. |
 | `files`     | Lists every configuration file: logical path, absolute file path, exists, valid, first validation error, template-resolution warnings. Works even when the configuration is broken or empty — the first command to run when diagnosing configuration problems. |
 | `init`      | Creates a working configuration in one step: afterwards `dhcli session create dev` starts a local Deephaven worker, with no Docker and nothing further to install. Asks no questions and contacts no server, so it is safe to script or run from an agent. Will not touch a configuration that is already there — if `community/settings.json` exists it stops with `already_exists` and changes nothing, so use `config set` to adjust an existing file. To use a Deephaven server you already run, or an Enterprise system, use `session add` / `system add` instead. |
-| `get [PATH]` | Prints the raw on-disk value at `PATH` (or the whole tree when omitted): a JSON object for a subtree, the bare scalar for a leaf. Works on a broken or partial tree and shows raw values with templating refs unresolved — unlike `show`, which prints the validated, template-resolved view. |
+| `get [PATH]` | Prints the raw on-disk value at `PATH` (or the whole tree when omitted): a JSON object for a subtree, the bare scalar for a leaf. Works on a broken or partial tree and shows raw values with templating refs unresolved — unlike `show`, which prints the validated, template-resolved view. Secrets are `[REDACTED]` unless `--reveal-secrets` is passed, which additionally warns on stderr naming how many values it disclosed. |
 | `set ASSIGNMENT...` | Sets one or more fields via `PATH=VALUE` tokens (VALUE parsed as JSON first, falling back to a plain string). Intermediate objects are created as needed; a `PATH` naming a whole file takes a JSON object that **replaces** the file's contents (assignment, not a merge). Assignments spanning multiple files are validated first, then each file is written atomically, with the already-written files rolled back if a later write fails (per-file atomic with batch rollback, not cross-file atomic: a concurrent reader may briefly see a partial multi-file update). Cannot create a new session/system (use `session/system add`); refuses to rewrite a file with JSON5-only syntax (`config_not_rewritable` — use `config edit` instead). |
 | `unset PATH...` | Removes one or more fields, reverting each to its schema default. Cannot unset a whole file (use `session/system remove`); same JSON5-rewrite refusal as `set`. |
 | `keys [PATH]` | Lists every settable logical path below `PATH` (or the whole tree), with type and description — the discovery companion to `get`/`set`. Not exhaustive by design: a discriminated union (e.g. `auth.credentials`) and an open/free-form object (e.g. `session_arguments`) each collapse to a single `object` entry, so their variant- or user-chosen children (such as `auth.credentials.token`) are not listed even though `config set` accepts them. A whole file (its logical path; run `config files`) is likewise omitted. |
@@ -871,9 +877,8 @@ type is checked when the server resolves the ref.
 
 Every `config` verb except `show` and `validate` operates on the raw
 files without loading the runtime, and so honors the root
-`-o/--output` flag and `DHCLI_OUTPUT` but not `cli.json`'s
-`output.format` (the file may be the thing being inspected or
-repaired).
+`-o/--output` flag and `DHCLI_OUTPUT` but not `cli.output.format`
+(the configuration may be the thing being inspected or repaired).
 
 ### `dhcli agents`
 
@@ -886,8 +891,8 @@ root `-o/--output` flag and `DHCLI_OUTPUT` (`human`, `json`,
 `json`** — compact single-line JSON; pass `-o json-pretty` for
 indented JSON or `-o human` for terminal-friendly output. Both run
 without a valid configuration tree, so they work even when `config
-validate` fails; that same bypass means they cannot read `cli.json`'s
-`output.format` (use `-o`/`DHCLI_OUTPUT` instead).
+validate` fails; that same bypass means they cannot read
+`cli.output.format` (use `-o`/`DHCLI_OUTPUT` instead).
 
 Which surface to use:
 
@@ -1019,13 +1024,13 @@ variable the project reads, with the reasoning for each.
 | `--config-dir PATH` |                      | Override the configuration directory. No per-subdir env var; use `DH_AI_DATA_DIR` to move both `config/` and `runtime/` together. |
 | `--runtime-dir PATH`|                      | Override the runtime directory (where `daemon.json` lives). No per-subdir env var.   |
 |                     | `DH_AI_DATA_DIR`    | Override the **user-data root**; `config/` and `runtime/` resolve under it. |
-| `-o`, `--output`    | `DHCLI_OUTPUT`      | One of `human`, `json`, `json-pretty`, `yaml`. Overrides `cli.json`'s `output.format`. |
-| `--timeout SECS`    |                      | Per-request timeout. Overrides `cli.json`'s `request.timeouts.default_seconds` (and `docs.timeouts.request_seconds` for the `docs` commands). |
+| `-o`, `--output`    | `DHCLI_OUTPUT`      | One of `human`, `json`, `json-pretty`, `yaml`. Overrides `cli.output.format`. |
+| `--timeout SECS`    |                      | Per-request timeout. Overrides `cli.request.timeouts.default_seconds` (and `cli.docs.timeouts.request_seconds` for the `docs` commands). |
 | `--agents`          |                      | Print the command's machine-readable description, tuned for AI agents, and exit (the machine twin of `--help`); available on every command. Honors the `-o`/`DHCLI_OUTPUT` mode, compact `json` by default. On the root, emits the summary tree; `dhcli agents tree` prints the whole surface. |
 | `-v`, `--verbose`   |                      | Increase logging verbosity (`-v`=INFO, `-vv`=DEBUG). Mutually exclusive with `-q`.   |
 | `-q`, `--quiet`     |                      | Suppress non-error logging (root logger at ERROR). Mutually exclusive with `-v`.     |
 | `--no-auto-start`   |                      | Fail rather than spawn a daemon when none is running.                                |
-| `--no-context`      |                      | Disable the sticky context for this invocation: when a session, system, or PQ id is omitted, the command fails with `context_not_set` instead of falling back to `context.json`. Overrides `cli.json`'s `context.enabled`. Governs only the read. See [`dhcli context`](#dhcli-context) below. |
+| `--no-context`      |                      | Disable the sticky context for this invocation: when a session, system, or PQ id is omitted, the command fails with `context_not_set` instead of falling back to the stored context. Overrides `cli.context.enabled`. Governs only the read. See [`dhcli context`](#dhcli-context) below. |
 | `--no-input`        |                      | Never prompt interactively; a command missing a required value fails with a structured `missing_required_option` error naming the flag to supply. Prompting is already disabled when stdin is not a TTY. |
 | `--version`         |                      | Print the package version and exit.                                                  |
 
@@ -1044,12 +1049,12 @@ verbatim).
 ## Output modes
 
 Every verb honors `-o/--output`, selecting how its result is rendered. The mode
-is resolved per invocation: `-o/--output` flag → `DHCLI_OUTPUT` → `cli.json`'s
-`output.format` (default `json`). The CLI is **machine-first** (primarily driven
-by AI agents), so the default is `json`; for human-readable output, pass
-`-o human`, set `DHCLI_OUTPUT=human`, or set `output.format: "human"` in
-`cli.json`. `dhcli agents`, the `--agents` flag, and error output run
-without the validated config, so they skip the `cli.json` step — use
+is resolved per invocation: `-o/--output` flag → `DHCLI_OUTPUT` →
+`cli.output.format` (default `json`). The CLI is **machine-first** (primarily
+driven by AI agents), so the default is `json`; for human-readable output, pass
+`-o human`, set `DHCLI_OUTPUT=human`, or run `dhcli config set
+cli.output.format=human`. `dhcli agents`, the `--agents` flag, and error output
+run without the validated config, so they skip the configured step — use
 `-o`/`DHCLI_OUTPUT` for those (so `DHCLI_OUTPUT=human` is the most complete way
 to get human output everywhere).
 
@@ -1121,9 +1126,9 @@ registry programmatically via `dhcli agents errors` (or the
 | `daemon_client_error`         | A client-side daemon-management failure (signal denied, etc.).     |
 | `daemon_registry_corrupt`     | `daemon.json` exists but cannot be parsed. Recover with `dhcli daemon repair`. |
 | `daemon_registry_live`        | `dhcli daemon repair` refused to move `daemon.json` aside because a live daemon is still registered; run `dhcli daemon stop` first. |
-| `daemon_reuse_refused`        | The running daemon is a different build than the CLI (version, venv, or source fingerprint differs) and `daemon.reuse` resolved to `refuse`. Run `dhcli daemon restart`, or adjust `daemon.reuse` in `cli.json`. |
+| `daemon_reuse_refused`        | The running daemon is a different build than the CLI (version, venv, or source fingerprint differs) and `cli.daemon.reuse` resolved to `refuse`. Run `dhcli daemon restart` to replace it, or adjust `cli.daemon.reuse`. |
 | `mcp_request_failed`          | The MCP transport reported an error (connect, parse, server failure). |
-| `mcp_request_timeout`         | The MCP request timed out. The server may still finish processing the request — if the operation changes state, verify the result before retrying. Allow more time with `--timeout`, or raise the timeout in `cli.json`: `request.timeouts.default_seconds` (`docs.timeouts.request_seconds` for the `docs` commands). |
+| `mcp_request_timeout`         | The MCP request timed out. The server may still finish processing the request — if the operation changes state, verify the result before retrying. Allow more time with `--timeout`, or raise `cli.request.timeouts.default_seconds` (`cli.docs.timeouts.request_seconds` for the `docs` commands). |
 | `tool_not_found`              | `dhcli tool show/call` referenced an unknown tool name.           |
 | `tool_returned_error`         | The invoked tool returned `isError=true`. Exit code `3`.           |
 | `arg_parse_error`             | A `key=value` token (`--arg`, `--env`, `--session-arg`) was malformed. |
@@ -1134,7 +1139,7 @@ registry programmatically via `dhcli agents errors` (or the
 | `option_not_applicable`       | An option/argument is invalid for the selected `--system` type (an inapplicable option, or a missing required one such as a Community session name). |
 | `browser_launch_failed`       | `dhcli session open` / `system open` could not launch a browser; the URL is included in the error message to open manually. |
 | `system_not_found`            | `dhcli system url/open NAME` named an Enterprise system that is not configured (`community` included — it has no web console). |
-| `context_not_set`             | A session/system/PQ id was omitted and no sticky context supplies one. Pass it explicitly, run `dhcli context set KEY VALUE`, or check `dhcli context show`. `--no-context` / `cli.json`'s `context.enabled=false` disables the `context.json` fallback step, making this code more likely, not less. |
+| `context_not_set`             | A session/system/PQ id was omitted and no sticky context supplies one. Pass it explicitly, run `dhcli context set KEY VALUE`, or check `dhcli context show`. `--no-context` / `cli.context.enabled=false` disables the sticky-context fallback step, making this code more likely, not less. |
 | `config_invalid`              | The configuration tree failed validation.                          |
 | `no_systems_configured`       | A system-dependent verb (`system`, `session`, `table`, `catalog`, `pq`, `tool`) ran against a valid tree that declares no system (no community session file, no `session_creation` block, no enterprise system file); the daemon serves systems, so acquiring one is refused. (The systems server likewise refuses to start on a zero-system tree.) The discovery verbs `system list` / `session list` are exempt — they return an empty list with this guidance on stderr instead of exiting non-zero. Add one (`dhcli config session add`, `dhcli config system add`, or `dhcli config init`), or check that `--config-dir` / `DH_AI_DATA_DIR` points at the intended directory. |
 | `config_path_invalid`         | A configuration path argument is malformed or does not name a known location. Run `dhcli config files` to list files and `dhcli config keys` to list settable paths. |
@@ -1198,8 +1203,8 @@ sudo chown -R $USER ~/.deephaven/ai/runtime
 
 **`No daemon is running and auto-start is disabled.`**
 
-You set `daemon.auto_start: false` in `cli.json`. Run `dhcli
-daemon start` explicitly, or flip the config back to `true`.
+You set `cli.daemon.auto_start` to `false`. Run `dhcli daemon start`
+explicitly, or run `dhcli config set cli.daemon.auto_start=true`.
 
 **Build mismatch (`daemon_reuse_refused`).**
 
@@ -1213,7 +1218,7 @@ than silently driving a stale daemon. Replace it:
 dhcli daemon restart   # stop the stale daemon and spawn a fresh one
 ```
 
-To relax the policy per field, set `daemon.reuse` in `cli.json`
+To relax the policy per field, set `cli.daemon.reuse`
 (see the `daemon.*` configuration table above). For parallel
 development across multiple checkouts, give each its own daemon by pointing
 `DH_AI_DATA_DIR` at a per-worktree directory (e.g.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -222,7 +222,7 @@ to the schema-level defaults shown below.
 
 | Field                                  | Type   | Default  | Description                                                |
 | -------------------------------------- | ------ | -------- | ---------------------------------------------------------- |
-| `security.credential_retrieval_mode`   | enum   | `"dynamic_only"` | One of `none` / `dynamic_only` / `static_only` / `all`. The default returns credentials for sessions this server created dynamically — the caller already caused them to exist — while withholding operator-authored static credentials. The wrapping `security` block may be omitted, which is equivalent to writing it empty; it may not be `null`. |
+| `security.credential_retrieval_mode`   | enum   | `"dynamic_only"` | One of `none` / `dynamic_only` / `static_only` / `all`. The default returns credentials for every session this server launched dynamically — the check is the session's origin, not which client created it, and it includes sessions created with an explicit `auth_token` — while withholding operator-authored static credentials. The wrapping `security` block may be omitted, which is equivalent to writing it empty; it may not be `null`. |
 | `session_creation.max_concurrent_sessions` | int \| null | `5` | Hard cap on concurrent dynamic sessions. `null` disables the cap (unbounded). |
 | `session_creation.defaults`            | object | —        | Per-session defaults (see next table).                     |
 | `timeouts`                             | object | `{}` (all defaults) | All operator-tunable durations, grouped under `client` and `eviction`. See next two tables. |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -222,7 +222,7 @@ to the schema-level defaults shown below.
 
 | Field                                  | Type   | Default  | Description                                                |
 | -------------------------------------- | ------ | -------- | ---------------------------------------------------------- |
-| `security.credential_retrieval_mode`   | enum   | `"none"` | One of `none` / `dynamic_only` / `static_only` / `all`. The wrapping `security` block is itself optional; omitting it is equivalent to `"none"`. |
+| `security.credential_retrieval_mode`   | enum   | `"dynamic_only"` | One of `none` / `dynamic_only` / `static_only` / `all`. The default returns credentials for sessions this server created dynamically — the caller already caused them to exist — while withholding operator-authored static credentials. The wrapping `security` block may be omitted, which is equivalent to writing it empty; it may not be `null`. |
 | `session_creation.max_concurrent_sessions` | int \| null | `5` | Hard cap on concurrent dynamic sessions. `null` disables the cap (unbounded). |
 | `session_creation.defaults`            | object | —        | Per-session defaults (see next table).                     |
 | `timeouts`                             | object | `{}` (all defaults) | All operator-tunable durations, grouped under `client` and `eviction`. See next two tables. |

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -215,7 +215,7 @@ The on-disk configuration tree, every file's schema, the `${env:}` / `${file:}` 
 
 #### Community session security and creation
 
-The optional `security.credential_retrieval_mode` knob in `community/settings.json` (enum `none` / `dynamic_only` / `static_only` / `all`, default `none`) controls whether the `session_community_credentials` tool may return plaintext session tokens. The enum, its default, and the security implications are owned by [`docs/CONFIGURATION.md`](CONFIGURATION.md#communitysettingsjson) and [`docs/SECURITY.md`](SECURITY.md#hardening-checklist); the eviction/timeout knobs live in the same CONFIGURATION.md section. The notes below cover only operational behavior not captured by the schema.
+The `security.credential_retrieval_mode` knob in `community/settings.json` (enum `none` / `dynamic_only` / `static_only` / `all`, default `dynamic_only`) controls whether the `session_community_credentials` tool may return plaintext session tokens. The enum, its default, and the security implications are owned by [`docs/CONFIGURATION.md`](CONFIGURATION.md#communitysettingsjson) and [`docs/SECURITY.md`](SECURITY.md#hardening-checklist); the eviction/timeout knobs live in the same CONFIGURATION.md section. The notes below cover only operational behavior not captured by the schema.
 
 ##### Dynamic session launch prerequisites
 
@@ -226,9 +226,9 @@ The optional `security.credential_retrieval_mode` knob in `community/settings.js
 
 ##### Retrieving session credentials
 
-When `credential_retrieval_mode` is not `none`, the `session_community_credentials` tool returns a community session's browser connection details, including a plaintext `auth_token`; every retrieval is logged. Run `dhcli tool show session_community_credentials` for the exact return shape.
+When `credential_retrieval_mode` permits the session's kind, the `session_community_credentials` tool returns a community session's browser connection details, including a plaintext `auth_token`; every retrieval is logged. Run `dhcli tool show session_community_credentials` for the exact return shape. The default `dynamic_only` covers sessions created through `session_community_create` but withholds statically configured credentials.
 
-When the mode is `none`, those details are still printed to the server console when a dynamic session is created (similar to how Jupyter prints a notebook token):
+Even when the mode refuses retrieval, an auto-generated token is still printed to the server console when a dynamic session is created (similar to how Jupyter prints a notebook token):
 
 ```text
 ======================================================================

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -124,10 +124,12 @@ anything beyond the local process group.
       Windows: place the directory under the current user profile
       (`%APPDATA%/Deephaven/ai/config/` satisfies this). The startup
       audit aborts otherwise.
-- [ ] **Leave `security.credential_retrieval_mode` at `null` /
-      `"none"`** unless AI agents specifically need to read community
-      session tokens. Other modes return plaintext tokens to the
-      caller of the `session_community_credentials` MCP tool.
+- [ ] **Set `security.credential_retrieval_mode` to `"none"`** if AI
+      agents must never read community session tokens. The default,
+      `"dynamic_only"`, returns only tokens this server minted for
+      sessions the caller created; `"static_only"` and `"all"` also hand
+      operator-authored credentials to the caller of the
+      `session_community_credentials` MCP tool.
 - [ ] **Keep the runtime directory private.** The `dhcli` daemon's
       registry (`<runtime_dir>/daemon/daemon.json`) holds a live PSK in
       plaintext. The defaults are owner-only; do not point
@@ -266,9 +268,26 @@ do **not** accept a `tls` block — the upstream Enterprise
   the `dhcli session credentials` / `session url` / `session open`
   verbs that wrap it, return a **plaintext auth token** and a URL
   containing it. All are gated by
-  `security.credential_retrieval_mode` (default `none`, which refuses
-  them); every retrieval is logged. Treat the output like a password:
-  a session URL pasted into a chat log grants access to that session.
+  `security.credential_retrieval_mode` (default `dynamic_only`, which
+  covers sessions the caller created but withholds operator-authored
+  static credentials); every retrieval is logged. Treat the output like
+  a password: a session URL pasted into a chat log grants access to
+  that session.
+- **Inspecting configuration.** Both read verbs redact secret values by
+  default; `dhcli config get --reveal-secrets` is the only way to print
+  one, and it warns on stderr naming how many it disclosed. A field
+  holding only a `${env:NAME}` / `${file:PATH}` reference is never
+  redacted, so `[REDACTED]` specifically means a **literal** secret is
+  stored in that file. Two gaps: `dhcli config edit` opens the file
+  verbatim, and redaction is schema-guided, so a secret placed in a
+  free-form map (`environment_vars`, `session_arguments`) is not
+  recognized as one.
+- **`daemon.log` holds auto-generated session tokens.** A session
+  created without an explicit auth token gets one minted by the server
+  and logged with a ready-to-use `?psk=<token>` URL — the only place
+  that token is surfaced. `dhcli daemon logs` prints it unredacted, so
+  review that output before sharing it; the file is protected only by
+  the `0700` daemon directory around it.
 
 ## Rotation
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -283,8 +283,10 @@ do **not** accept a `tls` block — the upstream Enterprise
   default; `dhcli config get --reveal-secrets` is the only way to print
   one, and it warns on stderr naming how many it disclosed. A field
   holding only a `${env:NAME}` / `${file:PATH}` reference is shown as
-  written, so a whole-value `[REDACTED]` means a **literal** secret is
-  stored in that file. A reference with a fallback keeps its variable
+  written, so a whole-value `[REDACTED]` means the field holds an
+  **on-disk value** rather than a bare reference — usually a literal
+  secret, though redaction fails closed, so an invalid value (a number,
+  `null`) at a secret field is replaced too. A reference with a fallback keeps its variable
   name but loses the literal (`${env:NAME:-[REDACTED]}`), since the
   fallback is itself a stored secret. Two gaps: `dhcli config edit` opens the file
   verbatim, and redaction is schema-guided, so a secret placed in a

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -126,9 +126,11 @@ anything beyond the local process group.
       audit aborts otherwise.
 - [ ] **Set `security.credential_retrieval_mode` to `"none"`** if AI
       agents must never read community session tokens. The default,
-      `"dynamic_only"`, returns only tokens this server minted for
-      sessions the caller created; `"static_only"` and `"all"` also hand
-      operator-authored credentials to the caller of the
+      `"dynamic_only"`, returns the token for any session this server
+      launched at runtime — the check is the session's origin, not which
+      client created it, so one agent can read the token of a session
+      another agent created. `"static_only"` and `"all"` additionally
+      hand operator-authored credentials to the caller of the
       `session_community_credentials` MCP tool.
 - [ ] **Keep the runtime directory private.** The `dhcli` daemon's
       registry (`<runtime_dir>/daemon/daemon.json`) holds a live PSK in
@@ -269,25 +271,33 @@ do **not** accept a `tls` block — the upstream Enterprise
   verbs that wrap it, return a **plaintext auth token** and a URL
   containing it. All are gated by
   `security.credential_retrieval_mode` (default `dynamic_only`, which
-  covers sessions the caller created but withholds operator-authored
-  static credentials); every retrieval is logged. Treat the output like
-  a password: a session URL pasted into a chat log grants access to
-  that session.
+  covers every dynamically launched session — whichever client created
+  it — but withholds operator-authored static credentials); every
+  retrieval is logged. `session open` is the exception that does not
+  print the token: it hands the authenticated URL to the browser and
+  reports the token-free one, on success and on launch failure alike,
+  unless `--reveal-secrets` is passed. Treat the output like a
+  password: a session URL pasted into a chat log grants access to that
+  session.
 - **Inspecting configuration.** Both read verbs redact secret values by
   default; `dhcli config get --reveal-secrets` is the only way to print
   one, and it warns on stderr naming how many it disclosed. A field
-  holding only a `${env:NAME}` / `${file:PATH}` reference is never
-  redacted, so `[REDACTED]` specifically means a **literal** secret is
-  stored in that file. Two gaps: `dhcli config edit` opens the file
+  holding only a `${env:NAME}` / `${file:PATH}` reference is shown as
+  written, so a whole-value `[REDACTED]` means a **literal** secret is
+  stored in that file. A reference with a fallback keeps its variable
+  name but loses the literal (`${env:NAME:-[REDACTED]}`), since the
+  fallback is itself a stored secret. Two gaps: `dhcli config edit` opens the file
   verbatim, and redaction is schema-guided, so a secret placed in a
   free-form map (`environment_vars`, `session_arguments`) is not
   recognized as one.
 - **`daemon.log` holds auto-generated session tokens.** A session
   created without an explicit auth token gets one minted by the server
-  and logged with a ready-to-use `?psk=<token>` URL — the only place
-  that token is surfaced. `dhcli daemon logs` prints it unredacted, so
-  review that output before sharing it; the file is protected only by
-  the `0700` daemon directory around it.
+  and logged with a ready-to-use `?psk=<token>` URL. `dhcli daemon logs`
+  prints it unredacted, so review that output before sharing it; the
+  file is protected only by the `0700` daemon directory around it. The
+  log is not the only route to that token — under the default
+  `dynamic_only` mode, `session_community_credentials` and its CLI
+  wrappers return it too.
 
 ## Rotation
 

--- a/scripts/convert_config_v1_to_v2.py
+++ b/scripts/convert_config_v1_to_v2.py
@@ -585,7 +585,10 @@ def _convert_community_settings(
         community_security = security.get("community")
         if isinstance(community_security, dict):
             mode = community_security.get("credential_retrieval_mode")
-            if mode and mode != "none":
+            if mode:
+                # Carry the mode over verbatim, including "none". Omitting
+                # it would now inherit the "dynamic_only" schema default
+                # and silently widen the posture the v1 file asked for.
                 settings["security"] = {"credential_retrieval_mode": mode}
             _warn_unknown(
                 community_security,

--- a/src/deephaven_mcp/cli/_browser.py
+++ b/src/deephaven_mcp/cli/_browser.py
@@ -9,30 +9,48 @@ import webbrowser
 from deephaven_mcp.cli._errors import CliError, ErrorCode
 
 
-def launch_browser(url: str) -> bool:
+def launch_browser(
+    url: str, *, manual_url: str | None = None, hint: str | None = None
+) -> bool:
     """Open ``url`` in the user's default web browser.
 
     Args:
-        url (str): The URL to open.
+        url (str): The URL to open. Handed to the browser as given.
+        manual_url (str | None): URL to name in the failure message
+            instead of ``url``. Lets a caller keep a credential out of
+            stderr while still opening a working URL — ``dhcli session
+            open`` passes the token-free base URL unless
+            ``--reveal-secrets`` was given. Defaults to ``url``.
+        hint (str | None): Sentence inserted *before* the URL, for
+            recovery guidance a generic helper cannot know (e.g. where
+            to obtain an authenticated URL when ``manual_url``
+            deliberately omits the token). Pass ``None`` when
+            ``manual_url`` is the URL actually opened, so the message
+            does not describe a difference that does not exist.
 
     Returns:
         bool: ``True`` when a browser was launched.
 
     Raises:
         CliError: When no browser could be launched (exit 2,
-            ``browser_launch_failed``). The message includes ``url`` so it
-            can be opened manually.
+            ``browser_launch_failed``). The message names ``manual_url``
+            so it can be opened by hand, and always *ends* with it --
+            trailing prose after a URL gets swept into the link by
+            terminal and chat autolinkers, corrupting a copy-paste.
     """
+    shown = url if manual_url is None else manual_url
+    guidance = f"{hint} " if hint else ""
     try:
         launched = webbrowser.open(url)
     except webbrowser.Error as exc:
         raise CliError(
-            f"Could not launch a browser ({exc}). Open this URL manually: {url}",
+            f"Could not launch a browser ({exc}). "
+            f"{guidance}Open this URL manually: {shown}",
             code=ErrorCode.BROWSER_LAUNCH_FAILED,
         ) from exc
     if not launched:
         raise CliError(
-            f"No usable browser was found. Open this URL manually: {url}",
+            f"No usable browser was found. {guidance}Open this URL manually: {shown}",
             code=ErrorCode.BROWSER_LAUNCH_FAILED,
         )
     return launched

--- a/src/deephaven_mcp/cli/_commands/_wrapping.py
+++ b/src/deephaven_mcp/cli/_commands/_wrapping.py
@@ -128,8 +128,11 @@ def reveal_secrets_option(f: Any) -> Any:
         is_flag=True,
         default=False,
         help=(
-            "Include plaintext secret values in the output instead of "
-            "[REDACTED]. Treat the result like a password."
+            "Include plaintext secret values in the output. Without this "
+            "flag each command withholds them in whatever way suits its "
+            "output: 'config get' prints [REDACTED], 'session open' "
+            "reports the URL without its auth token. Treat the result "
+            "like a password."
         ),
     )(f)
 

--- a/src/deephaven_mcp/cli/_commands/_wrapping.py
+++ b/src/deephaven_mcp/cli/_commands/_wrapping.py
@@ -112,6 +112,28 @@ _ACQUIRE_ERROR_CODES: tuple[ErrorCode, ...] = (
 """Error codes the shared acquire + tool-call flow can raise."""
 
 
+def reveal_secrets_option(f: Any) -> Any:
+    """Attach the shared ``--reveal-secrets`` option to a command.
+
+    One flag spelling and one wording for every verb that can emit a
+    plaintext secret but is not *for* emitting one, so the opt-in cannot
+    drift between them. A verb whose entire output is a credential
+    (``session credentials``, ``session url``) takes no such flag: there
+    the disclosure is the request, gated by
+    ``community.settings.security.credential_retrieval_mode`` instead.
+    """
+    return click.option(
+        "--reveal-secrets",
+        "reveal_secrets",
+        is_flag=True,
+        default=False,
+        help=(
+            "Include plaintext secret values in the output instead of "
+            "[REDACTED]. Treat the result like a password."
+        ),
+    )(f)
+
+
 def yes_option(f: Any) -> Any:
     """Attach the shared ``--yes`` option to a destructive command.
 
@@ -133,8 +155,8 @@ def yes_option(f: Any) -> Any:
         default=False,
         help=(
             "Skip the confirmation asked when the target comes from the "
-            "sticky context (only asked when cli.json's "
-            "context.confirm_destructive is true). The confirmation is "
+            "sticky context (only asked when the configured "
+            "cli.context.confirm_destructive is true). The confirmation is "
             "skipped anyway when prompting is unavailable — stdin is not a "
             "TTY, or --no-input was given — so a non-interactive caller is "
             "never protected by it and must pass the target explicitly."

--- a/src/deephaven_mcp/cli/_commands/agents.py
+++ b/src/deephaven_mcp/cli/_commands/agents.py
@@ -67,8 +67,8 @@ def agents() -> None:
     rest of the CLI — compact single-line json; pass '-o json-pretty'
     for indented json or '-o human' for terminal-friendly output. The
     group runs without a valid configuration tree, so it works even
-    when 'config validate' fails — which is also why it cannot read
-    cli.json's output.format (use -o/DHCLI_OUTPUT instead).
+    when 'config validate' fails — which is also why it cannot read the
+    configured cli.output.format (use -o/DHCLI_OUTPUT instead).
     """
 
 

--- a/src/deephaven_mcp/cli/_commands/config.py
+++ b/src/deephaven_mcp/cli/_commands/config.py
@@ -40,7 +40,10 @@ from deephaven_mcp._platform.fsutil import AdvisoryFileLock
 from deephaven_mcp._pydantic import dump_redacted
 from deephaven_mcp.cli._async import run_async
 from deephaven_mcp.cli._command import HelpfulCommand, HelpfulGroup
-from deephaven_mcp.cli._commands._wrapping import parse_key_value
+from deephaven_mcp.cli._commands._wrapping import (
+    parse_key_value,
+    reveal_secrets_option,
+)
 from deephaven_mcp.cli._echo import echo_payload, echo_payload_no_runtime
 from deephaven_mcp.cli._errors import CliError, ErrorCode, ExitCode
 from deephaven_mcp.cli._help import (
@@ -67,6 +70,7 @@ from deephaven_mcp.config._logical_paths import (
     ConfigSection,
     resolve_path,
 )
+from deephaven_mcp.config._redact_raw import redact_raw
 from deephaven_mcp.config._settable_fields import settable_fields
 from deephaven_mcp.config._store import ConfigStore
 
@@ -240,6 +244,22 @@ def _warn_restart_hint() -> None:
     click.echo(
         "note: if a daemon is running, it keeps the configuration it loaded; "
         "run 'dhcli daemon stop' so the next command picks up this change.",
+        err=True,
+    )
+
+
+def _warn_revealed_secrets(count: int) -> None:
+    """Warn on stderr that plaintext secrets were written to stdout.
+
+    Args:
+        count (int): How many secret values were revealed. Callers only
+            invoke this when it is non-zero.
+    """
+    plural = "" if count == 1 else "s"
+    click.echo(
+        f"warning: --reveal-secrets wrote {count} plaintext secret value{plural} "
+        "to stdout; treat this output like a password and keep it out of logs, "
+        "shell history, and shared transcripts.",
         err=True,
     )
 
@@ -486,8 +506,8 @@ def config() -> None:
     every change is schema-validated before an atomic write. Every
     verb except 'show' and 'validate' operates on the raw files
     without loading the runtime, and so honors the root -o/--output
-    flag and DHCLI_OUTPUT but not cli.json's output.format (the file
-    may be the thing being inspected or repaired).
+    flag and DHCLI_OUTPUT but not the configured cli.output.format (the
+    configuration may be the thing being inspected or repaired).
     """
 
 
@@ -495,7 +515,7 @@ _OUTPUT_SHOW = OutputSpec(
     "text",
     note=(
         "The resolved, post-merge configuration, secret-bearing fields "
-        "redacted to ***. With no PATH: a JSON object with 'config_dir' plus "
+        "redacted to [REDACTED]. With no PATH: a JSON object with 'config_dir' plus "
         "'cli' and, when present, 'server'/'community'/'enterprise'. With a "
         "PATH: the value at that path — a JSON object for a subtree or the "
         "bare scalar for a leaf (mirroring 'config get', but resolved rather "
@@ -527,7 +547,7 @@ _OUTPUT_VALIDATE = OutputSpec(
         summary="Print the resolved configuration with secrets redacted.",
         description=(
             "Shows the post-merge view used at runtime. Secret-bearing "
-            "fields (passwords, API keys) are replaced with *** via "
+            "fields (passwords, API keys) are replaced with [REDACTED] via "
             "the schema's redaction hooks. Requires a valid configuration "
             "tree; 'dhcli config get' works on a partial or invalid one "
             "and shows the raw on-disk values instead."
@@ -638,7 +658,10 @@ _OUTPUT_GET = OutputSpec(
         "The raw value at PATH (or the whole tree when PATH is omitted): a "
         "JSON object for a subtree, or the bare scalar for a leaf. "
         "Templating refs ('${env:VAR}') are shown unexpanded — this is the "
-        "on-disk view, not the resolved one ('dhcli config show')."
+        "on-disk view, not the resolved one ('dhcli config show') — and are "
+        "never redacted, since a ref names a secret rather than being one. "
+        "Keys are preserved; only secret values become [REDACTED], unless "
+        "--reveal-secrets is passed."
     ),
 )
 
@@ -656,7 +679,8 @@ _OUTPUT_GET = OutputSpec(
             "configuration tree, assembled from every file. A PATH at a "
             "section (e.g. 'community') aggregates every file under it; a "
             "PATH at or below a file (e.g. 'cli.output.format') reads just "
-            "that file."
+            "that file. Secret values are redacted by default; pass "
+            "--reveal-secrets to print them."
         ),
         arguments=(
             HelpEntry(
@@ -673,6 +697,7 @@ _OUTPUT_GET = OutputSpec(
             "$ dhcli config get",
             "$ dhcli config get community.settings",
             "$ dhcli -o human config get cli.output.format",
+            "$ dhcli -o human config get server.psk --reveal-secrets",
         ),
         see_also=(
             "dhcli config keys",
@@ -690,32 +715,69 @@ _OUTPUT_GET = OutputSpec(
     needs_runtime=False,
 )
 @click.argument("path", required=False, default=None)
+@reveal_secrets_option
 @click.pass_context
 @run_async
-async def config_get(ctx: click.Context, path: str | None) -> None:
+async def config_get(
+    ctx: click.Context, path: str | None, reveal_secrets: bool
+) -> None:
     """Print the raw configuration at a logical path."""
     spec = _authoring_spec(ctx)
     store = _store_from_spec(spec)
     resolved = _resolve_logical_path(path)
     match resolved:
         case ConfigFieldLocation() as target:
-            echo_payload_no_runtime(ctx, _read_field(store, target))
+            payload, secrets = _read_field(store, target, reveal=reveal_secrets)
         case ConfigSection() as section:
-            echo_payload_no_runtime(ctx, _read_section_tree(store, section))
+            payload, secrets = _read_section_tree(store, section, reveal=reveal_secrets)
         case _:
             assert_never(resolved)
+    if reveal_secrets and secrets:
+        _warn_revealed_secrets(secrets)
+    echo_payload_no_runtime(ctx, payload)
 
 
-def _read_field(store: ConfigStore, target: ConfigFieldLocation) -> Any:
+def _redacted(
+    kind: ConfigFileKind, value: Any, *, at: FieldPath, reveal: bool
+) -> tuple[Any, int]:
+    """Redact one file's raw value, counting the secrets it holds.
+
+    The schema walk runs in both modes: under ``reveal`` its redacted
+    output is discarded but its count is what the stderr warning
+    reports, so the count means the same thing either way.
+
+    Args:
+        kind (ConfigFileKind): The file kind whose schema locates the
+            secret-bearing fields.
+        value (Any): The raw on-disk value.
+        at (FieldPath): Where ``value`` sits within the file.
+        reveal (bool): Return ``value`` unchanged when ``True``.
+
+    Returns:
+        tuple[Any, int]: The value to print, and how many secret values
+            it holds. A scalar secret field holding only a templating
+            ref is not counted, because printing it discloses nothing.
+    """
+    outcome = redact_raw(kind, value, at=at)
+    return (value if reveal else outcome.value), outcome.count
+
+
+def _read_field(
+    store: ConfigStore, target: ConfigFieldLocation, *, reveal: bool
+) -> tuple[Any, int]:
     """Return the raw value at ``target`` (whole file or one field).
 
     Args:
         store (ConfigStore): The bound configuration store.
         target (ConfigFieldLocation): The file, plus the field within it
             (:attr:`FieldPath.ROOT` for the whole file).
+        reveal (bool): Leave secret values in plaintext instead of
+            redacting them.
 
     Returns:
-        Any: The raw on-disk value, templating refs unexpanded.
+        tuple[Any, int]: The raw on-disk value with templating refs
+            unexpanded (secrets redacted unless ``reveal``), and how
+            many secret values it holds.
 
     Raises:
         CliError: With ``not_found`` when the file or field is absent,
@@ -732,26 +794,36 @@ def _read_field(store: ConfigStore, target: ConfigFieldLocation) -> Any:
     except ConfigurationError as exc:
         raise _map_config_error(exc) from exc
     try:
-        return get_field(raw.data, target.field_path)
+        value = get_field(raw.data, target.field_path)
     except ConfigurationPathError as exc:
         raise _map_config_error(exc) from exc
+    return _redacted(target.kind, value, at=target.field_path, reveal=reveal)
 
 
-def _read_section_tree(store: ConfigStore, section: ConfigSection) -> dict[str, Any]:
+def _read_section_tree(
+    store: ConfigStore, section: ConfigSection, *, reveal: bool
+) -> tuple[dict[str, Any], int]:
     """Aggregate every existing file below ``section`` into one tree.
+
+    Each file is redacted against its own kind's schema before being
+    merged, so one aggregate view spans several schemas correctly.
 
     Args:
         store (ConfigStore): The bound configuration store.
         section (ConfigSection): The section to aggregate.
+        reveal (bool): Leave secret values in plaintext instead of
+            redacting them.
 
     Returns:
-        dict[str, Any]: The raw on-disk data of each existing file,
-            nested at its logical path relative to the section.
+        tuple[dict[str, Any], int]: The raw on-disk data of each
+            existing file nested at its logical path relative to the
+            section, and how many secret values the tree holds.
 
     Raises:
         CliError: With ``config_invalid`` when a file cannot be parsed.
     """
     tree: dict[str, Any] = {}
+    secrets = 0
     for target in section.files(store.config_dir):
         file_path = store.path_of(target)
         if not file_path.is_file():
@@ -760,10 +832,12 @@ def _read_section_tree(store: ConfigStore, section: ConfigSection) -> dict[str, 
             raw = store.read(target)
         except ConfigurationError as exc:
             raise _map_config_error(exc) from exc
-        tree = set_field(
-            tree, target.logical_path.remove_prefix(section.prefix), raw.data
+        value, count = _redacted(
+            target.kind, raw.data, at=FieldPath.ROOT, reveal=reveal
         )
-    return tree
+        secrets += count
+        tree = set_field(tree, target.logical_path.remove_prefix(section.prefix), value)
+    return tree, secrets
 
 
 # ---------------------------------------------------------------------------
@@ -856,9 +930,8 @@ _OUTPUT_SET = OutputSpec(
             "already-written files rolled back if a later one fails. 'set' "
             "edits an existing entity — it cannot create a "
             "new session or system (use 'config session/system add' for "
-            "that); unnamed files (cli.json, server.json, "
-            "community/settings.json, enterprise/settings.json) are "
-            "created on first write."
+            "that); the unnamed sections (cli, server, community.settings, "
+            "enterprise.settings) are created on first write."
         ),
         arguments=(
             HelpEntry(

--- a/src/deephaven_mcp/cli/_commands/context.py
+++ b/src/deephaven_mcp/cli/_commands/context.py
@@ -49,7 +49,7 @@ def context() -> None:
     Three keys are tracked: 'session', 'system', and 'pq'. Commands that
     take a session, system, or PQ id fall back to the matching key when
     the argument is omitted, resolved in order: the explicit argument,
-    then context.json. Setting one key with 'context set' never affects
+    then the stored context. Setting one key with 'context set' never affects
     another, but 'session create' and 'pq create' set every key that
     describes the new resource, and the delete verbs clear every key
     that pointed at the deleted one.
@@ -57,11 +57,10 @@ def context() -> None:
     The context is the one input a command's own command line does not
     show, so check it with 'context show' before running anything
     consequential: acting on an unintended context executes or
-    destroys in the wrong worker or system. Set cli.json's
-    context.confirm_destructive to be asked to confirm first (see
-    'dhcli config show'), disable the fallback for one invocation with
-    --no-context, or turn it off entirely via cli.json's
-    context.enabled.
+    destroys in the wrong worker or system. Set
+    cli.context.confirm_destructive to be asked to confirm first,
+    disable the fallback for one invocation with --no-context, or turn
+    it off entirely by setting cli.context.enabled to false.
     """
 
 
@@ -119,8 +118,8 @@ def _warn_if_disabled(runtime: Runtime) -> None:
         return
     render_warning(
         "Context fallback is disabled, so this value will not be used until "
-        "it is re-enabled: drop --no-context, or set context.enabled to true "
-        "in cli.json.",
+        "it is re-enabled: drop --no-context, or run "
+        "'dhcli config set cli.context.enabled=true'.",
         output=runtime.config.cli.output.format,
     )
 
@@ -133,11 +132,11 @@ _OUTPUT_CONTEXT = OutputSpec(
         OutputField("pq", "object", "{value, source} for the sticky PQ id."),
     ),
     note=(
-        "'value' is always what is stored in context.json, and 'source' "
-        "says whether it is in effect: 'file' (stored and active), "
-        "'unset' (nothing stored), or 'disabled' (fallback off via "
-        "--no-context or cli.json's context.enabled, so nothing is "
-        "consulted regardless of what is stored)."
+        "'value' is always what is stored, and 'source' says whether it is "
+        "in effect: 'file' (stored and active), 'unset' (nothing stored), "
+        "or 'disabled' (fallback off via --no-context or "
+        "cli.context.enabled, so nothing is consulted regardless of what "
+        "is stored)."
     ),
 )
 
@@ -156,8 +155,8 @@ _OUTPUT_CONTEXT = OutputSpec(
             "'session', 'system', and 'pq' if a command omitted its id, and "
             "whether it is in effect: 'file' when stored and active, "
             "'unset' when nothing is stored, or 'disabled' when the "
-            "fallback is switched off (--no-context, or cli.json's "
-            "context.enabled) — in which case the stored value is still "
+            "fallback is switched off (--no-context, or "
+            "cli.context.enabled) — in which case the stored value is still "
             "reported, but nothing will consult it. Run this before a "
             "destructive command whose id you intend to omit — the sticky "
             "target is not shown on the command line, and acting on an "

--- a/src/deephaven_mcp/cli/_commands/docs.py
+++ b/src/deephaven_mcp/cli/_commands/docs.py
@@ -35,16 +35,16 @@ from deephaven_mcp.cli._mcp_client import (
 )
 from deephaven_mcp.cli._runtime import Runtime
 
-_DOCS_TIMEOUT_SETTING = "docs.timeouts.request_seconds"
-"""Dotted ``cli.json`` key for the docs request timeout, named in error hints."""
+_DOCS_TIMEOUT_SETTING = "cli.docs.timeouts.request_seconds"
+"""Logical config path for the docs request timeout, named in error hints."""
 
 
 @click.group(cls=HelpfulGroup)
 def docs() -> None:
     """Query the Deephaven documentation MCP server.
 
-    These commands talk directly to the docs MCP server configured as
-    'docs.url' in cli.json (default: the Deephaven-hosted production
+    These commands talk directly to the docs MCP server named by the
+    configured cli.docs.url (default: the Deephaven-hosted production
     docs server) — the local daemon is not involved and is never
     started. 'ask' sends a one-shot question to the documentation
     assistant; 'status' checks that the configured server is reachable.
@@ -109,7 +109,7 @@ async def _call_docs_tool(
             f"initialize). The server may still finish processing the "
             f"request — if the operation changes state, verify the "
             f"result before retrying. To allow more time, pass --timeout "
-            f"or raise {_DOCS_TIMEOUT_SETTING} in cli.json.",
+            f"or raise {_DOCS_TIMEOUT_SETTING}.",
             code=ErrorCode.MCP_REQUEST_TIMEOUT,
         ) from exc
     except McpClientError as exc:
@@ -194,9 +194,9 @@ _OUTPUT_ASK = OutputSpec(
     help_spec=HelpSpec(
         summary="Ask the Deephaven documentation assistant a question.",
         description=(
-            "Sends a one-shot question to the docs MCP server configured as "
-            "'docs.url' in cli.json (default: the Deephaven-hosted production "
-            "docs server). The assistant is LLM-backed, so responses "
+            "Sends a one-shot question to the docs MCP server named by the "
+            "configured cli.docs.url (default: the Deephaven-hosted "
+            "production docs server). The assistant is LLM-backed, so responses "
             "typically take several seconds; raise --timeout for complex "
             "questions. Multi-turn follow-ups stay one-shot: pass the prior "
             "exchange via --history. The local daemon is not involved."
@@ -322,15 +322,15 @@ _OUTPUT_STATUS = OutputSpec(
     help_spec=HelpSpec(
         summary="Check that the configured docs MCP server is reachable.",
         description=(
-            "Connects to the docs MCP server configured as 'docs.url' in "
-            "cli.json, initializes an MCP session, and lists its tools. Use "
-            "this to distinguish an unreachable or misconfigured docs server "
-            "from a slow assistant answer when 'docs ask' fails. Exits 2 "
-            "with mcp_request_failed when the server cannot be reached, or "
-            "with mcp_request_timeout when the whole probe does not "
-            "complete within the request timeout (--timeout or "
-            "docs.timeouts.request_seconds in cli.json). The local daemon "
-            "is not involved."
+            "Connects to the docs MCP server named by the configured "
+            "cli.docs.url, initializes an MCP session, and lists its tools. "
+            "Use this to distinguish an unreachable or misconfigured docs "
+            "server from a slow assistant answer when 'docs ask' fails. "
+            "Exits 2 with mcp_request_failed when the server cannot be "
+            "reached, or with mcp_request_timeout when the whole probe does "
+            "not complete within the request timeout (--timeout or "
+            "cli.docs.timeouts.request_seconds). The local daemon is not "
+            "involved."
         ),
         output=_OUTPUT_STATUS,
         examples=(
@@ -363,7 +363,7 @@ async def docs_status(runtime: Runtime) -> None:
         raise CliError(
             f"docs status probe of {url} timed out after {timeout_seconds} "
             f"seconds. To allow more time, pass --timeout or raise "
-            f"{_DOCS_TIMEOUT_SETTING} in cli.json.",
+            f"{_DOCS_TIMEOUT_SETTING}.",
             code=ErrorCode.MCP_REQUEST_TIMEOUT,
         ) from exc
     except McpClientError as exc:

--- a/src/deephaven_mcp/cli/_commands/pq.py
+++ b/src/deephaven_mcp/cli/_commands/pq.py
@@ -70,8 +70,9 @@ _BATCH_NOTE = (
 
 _MAX_CONCURRENT_HELP = (
     "Cap on how many ids are operated on in parallel; must be greater than "
-    "0. Omitted: the operator-configured default — pq_tools.default_max_concurrent "
-    "in enterprise/settings.json, itself 20 unless set."
+    "0. Omitted: the operator-configured default — "
+    "enterprise.settings.pq_tools.default_max_concurrent, itself 20 unless "
+    "set."
 )
 """Shared help for the batch verbs' concurrency cap, whose default is server-side."""
 
@@ -1160,10 +1161,10 @@ async def pq_delete(
 
 _WAIT_HELP = (
     "Wait for the state change before returning (default), for the "
-    "operator-configured duration — timeouts.client."
-    "pq_state_change_timeout_seconds in enterprise/settings.json, itself 120 "
-    "seconds unless set. --no-wait submits the request and returns "
-    "immediately, leaving the PQ mid-transition."
+    "operator-configured duration — enterprise.settings.timeouts.client."
+    "pq_state_change_timeout_seconds, itself 120 seconds unless set. "
+    "--no-wait submits the request and returns immediately, leaving the PQ "
+    "mid-transition."
 )
 """Shared help for the lifecycle wait flag, whose duration is server-side."""
 

--- a/src/deephaven_mcp/cli/_commands/session.py
+++ b/src/deephaven_mcp/cli/_commands/session.py
@@ -1234,8 +1234,9 @@ _OUTPUT_OPEN = OutputSpec(
             "default browser, which keeps the auth token out of stdout. Same "
             "Community-only scope and security gate as 'session credentials'. "
             "If the browser cannot be launched, exits 2 "
-            "(browser_launch_failed) with the authenticated URL in the message "
-            "so you can open it manually."
+            "(browser_launch_failed) with a URL to open manually -- the "
+            "token-free one unless --reveal-secrets was passed, so a failure "
+            "does not disclose the credential either."
         ),
         arguments=(
             HelpEntry(
@@ -1249,7 +1250,8 @@ _OUTPUT_OPEN = OutputSpec(
         examples=(
             "$ dhcli session open community:community:my-session",
             "$ dhcli session open community:community:my-session --print",
-            "$ dhcli session open my-session --print --reveal-secrets | jq -r .opened",
+            "$ dhcli session open community:community:my-session --print "
+            "--reveal-secrets | jq -r .opened",
         ),
         see_also=(
             "dhcli session url ID",
@@ -1286,9 +1288,30 @@ async def session_open(
     id = require_context_value(runtime, ContextKey.SESSION, id)
     payload = await _fetch_credentials(runtime, id, retry_command="dhcli session open")
     url = _authenticated_url(payload)
-    launched = False if print_only else launch_browser(url)
     # Disclosure is orthogonal to launching: --print says "do not open a
     # browser", not "put the token on stdout". Only --reveal-secrets does
     # that, the same flag 'config get' uses.
     opened = url if reveal_secrets else payload.get("connection_url") or url
+    launched = (
+        False
+        if print_only
+        # The browser still receives the authenticated URL -- it has to,
+        # or the page cannot log in. Only the *error message* falls back
+        # to the token-free URL, so a launch failure does not write the
+        # credential to stderr behind the opt-in's back.
+        else launch_browser(
+            url,
+            manual_url=opened,
+            # Earn the hint: an anonymous session (and any payload with
+            # no separate authenticated URL) makes `opened` identical to
+            # what we opened, so there is no withheld token to explain
+            # and no better URL for 'session url' to hand back.
+            hint=(
+                "That URL omits the auth token; run 'dhcli session url' "
+                "to get one you can log in with."
+                if opened != url
+                else None
+            ),
+        )
+    )
     echo_payload(runtime, {"opened": opened, "launched": launched})

--- a/src/deephaven_mcp/cli/_commands/session.py
+++ b/src/deephaven_mcp/cli/_commands/session.py
@@ -30,6 +30,7 @@ from deephaven_mcp.cli._commands._wrapping import (
     call_for_payload,
     parse_key_value,
     read_local_script,
+    reveal_secrets_option,
     wrapper_error_codes,
     yes_option,
 )
@@ -1103,8 +1104,10 @@ _CREDENTIALS_DESCRIPTION = (
     "Wraps the session_community_credentials MCP tool (Community sessions "
     "only; a clear error is returned for an Enterprise id). The output "
     "contains a PLAINTEXT auth token by design so you can open the session "
-    "in a browser. Retrieval is gated by security.credential_retrieval_mode "
-    "in community/settings.json (default 'none'); when disabled, or the "
+    "in a browser. Retrieval is gated by the configured "
+    "community.settings.security.credential_retrieval_mode (default "
+    "'dynamic_only', which permits sessions created by 'session create' but "
+    "withholds statically configured credentials); when refused, or the "
     "session is missing or not a Community session, the command exits 3."
 )
 
@@ -1209,7 +1212,12 @@ async def session_url(runtime: Runtime, id: str | None) -> None:
 _OUTPUT_OPEN = OutputSpec(
     "object",
     (
-        OutputField("opened", "string", "The URL that was launched (or would be)."),
+        OutputField(
+            "opened",
+            "string",
+            "The session URL, without the auth token unless "
+            "--reveal-secrets is passed.",
+        ),
         OutputField("launched", "boolean", "True if a browser was launched."),
     ),
 )
@@ -1218,16 +1226,16 @@ _OUTPUT_OPEN = OutputSpec(
 @session.command(
     "open",
     wraps_tool=_CREDENTIALS_TOOL,
-    client_only_params=frozenset({"print_only"}),
+    client_only_params=frozenset({"print_only", "reveal_secrets"}),
     help_spec=HelpSpec(
         summary="Open a Community session in the default web browser.",
         description=(
-            "Fetches the authenticated URL and launches your default browser. "
-            "Pass --print to print the URL instead of launching (use this in "
-            "headless / CI environments). Same Community-only scope and "
-            "security gate as 'session credentials'. If the browser cannot be "
-            "launched, exits 2 (browser_launch_failed) with the URL in the "
-            "message so you can open it manually."
+            "Fetches the session's authenticated URL and hands it to your "
+            "default browser, which keeps the auth token out of stdout. Same "
+            "Community-only scope and security gate as 'session credentials'. "
+            "If the browser cannot be launched, exits 2 "
+            "(browser_launch_failed) with the authenticated URL in the message "
+            "so you can open it manually."
         ),
         arguments=(
             HelpEntry(
@@ -1241,7 +1249,7 @@ _OUTPUT_OPEN = OutputSpec(
         examples=(
             "$ dhcli session open community:community:my-session",
             "$ dhcli session open community:community:my-session --print",
-            "$ dhcli session open community:community:my-session --print | jq -r .opened",
+            "$ dhcli session open my-session --print --reveal-secrets | jq -r .opened",
         ),
         see_also=(
             "dhcli session url ID",
@@ -1262,14 +1270,25 @@ _OUTPUT_OPEN = OutputSpec(
     "print_only",
     is_flag=True,
     default=False,
-    help="Print the URL instead of launching a browser (headless-safe).",
+    help=(
+        "Do not launch a browser; only report the URL (headless-safe). Add "
+        "--reveal-secrets to get one you can actually log in with, or use "
+        "'dhcli session url'."
+    ),
 )
+@reveal_secrets_option
 @click.pass_obj
 @run_async
-async def session_open(runtime: Runtime, id: str | None, print_only: bool) -> None:
+async def session_open(
+    runtime: Runtime, id: str | None, print_only: bool, reveal_secrets: bool
+) -> None:
     """Open a Community session in the default web browser."""
     id = require_context_value(runtime, ContextKey.SESSION, id)
     payload = await _fetch_credentials(runtime, id, retry_command="dhcli session open")
     url = _authenticated_url(payload)
     launched = False if print_only else launch_browser(url)
-    echo_payload(runtime, {"opened": url, "launched": launched})
+    # Disclosure is orthogonal to launching: --print says "do not open a
+    # browser", not "put the token on stdout". Only --reveal-secrets does
+    # that, the same flag 'config get' uses.
+    opened = url if reveal_secrets else payload.get("connection_url") or url
+    echo_payload(runtime, {"opened": opened, "launched": launched})

--- a/src/deephaven_mcp/cli/_context.py
+++ b/src/deephaven_mcp/cli/_context.py
@@ -568,8 +568,8 @@ def _resolve_required(
             if enabled
             else (
                 "Pass it explicitly. The sticky context cannot supply it: the "
-                "fallback is disabled by --no-context or cli.json's "
-                "context.enabled=false."
+                "fallback is disabled by --no-context or the configured "
+                "cli.context.enabled=false."
             )
         )
         raise CliError(

--- a/src/deephaven_mcp/cli/_daemon/_lifecycle.py
+++ b/src/deephaven_mcp/cli/_daemon/_lifecycle.py
@@ -202,7 +202,7 @@ def _decide_for_live_entry(
             raise DaemonReuseRefusedError(
                 f"The running daemon (pid {entry.pid}) is a different build than "
                 f"this CLI: {detail}. Run 'dhcli daemon restart' to replace it, "
-                f"or adjust the daemon.reuse policy in cli.json.",
+                f"or adjust the configured cli.daemon.reuse policy.",
                 differing=decision.differing,
             )
         case DaemonReuseAction.RESTART:
@@ -385,8 +385,8 @@ async def get_or_start_daemon(
         if not auto_start:
             raise DaemonClientError(
                 "No daemon is running and auto-start is disabled. "
-                "Run `dhcli daemon start` or set "
-                "`daemon.auto_start: true` in cli.json."
+                "Run `dhcli daemon start` or "
+                "`dhcli config set cli.daemon.auto_start=true`."
             )
         spawned = _spawn_or_defer(
             reg, ctx, startup_deadline_seconds=startup_deadline_seconds

--- a/src/deephaven_mcp/cli/_errors.py
+++ b/src/deephaven_mcp/cli/_errors.py
@@ -184,7 +184,10 @@ class ErrorCode(StrEnum):
         "browser_launch_failed",
         (
             "The default web browser could not be launched; the URL is included "
-            "in the error message so it can be opened manually."
+            "in the error message so it can be opened manually. For 'session "
+            "open' that URL omits the auth token unless --reveal-secrets was "
+            "passed, so opening it will prompt for credentials; 'dhcli session "
+            "url' returns one that logs in."
         ),
     )
     SYSTEM_NOT_FOUND = (

--- a/src/deephaven_mcp/cli/_errors.py
+++ b/src/deephaven_mcp/cli/_errors.py
@@ -117,7 +117,8 @@ class ErrorCode(StrEnum):
             "The running daemon is a different build than this CLI (its "
             "version, virtualenv, or source fingerprint differs) and the "
             "daemon.reuse policy resolved to 'refuse'. Run 'dhcli daemon "
-            "restart' to replace it, or adjust daemon.reuse in cli.json."
+            "restart' to replace it, or adjust the configured "
+            "cli.daemon.reuse."
         ),
     )
     MCP_REQUEST_FAILED = (
@@ -130,8 +131,8 @@ class ErrorCode(StrEnum):
             "The MCP request timed out. The server may still finish "
             "processing the request — if the operation changes state, verify "
             "the result before retrying. Allow more time with --timeout, or "
-            "raise the timeout in cli.json: request.timeouts.default_seconds "
-            "(docs.timeouts.request_seconds for the 'docs' commands)."
+            "raise the configured cli.request.timeouts.default_seconds "
+            "(cli.docs.timeouts.request_seconds for the 'docs' commands)."
         ),
     )
     TOOL_NOT_FOUND = (
@@ -197,7 +198,7 @@ class ErrorCode(StrEnum):
             "one: pass it explicitly, run 'dhcli context set <key> <value>' to "
             "establish a default, or check 'dhcli context show' if one was "
             "expected. Context fallback is skipped entirely when --no-context "
-            "was given or cli.json's context.enabled is false."
+            "was given or the configured cli.context.enabled is false."
         ),
     )
     CONFIG_INVALID = (

--- a/src/deephaven_mcp/cli/_main.py
+++ b/src/deephaven_mcp/cli/_main.py
@@ -228,7 +228,7 @@ def _quiet_dependency_loggers(verbose: int) -> None:
     is_eager=True,
     help=(
         "Output format. Takes precedence over the DHCLI_OUTPUT "
-        "environment variable and the 'output.format' setting in cli.json."
+        "environment variable and the configured cli.output.format."
     ),
 )
 @click.option(
@@ -236,9 +236,9 @@ def _quiet_dependency_loggers(verbose: int) -> None:
     type=int,
     default=None,
     help=(
-        "Per-request timeout in seconds. Overrides the "
-        "'request.timeouts.default_seconds' setting in cli.json (and "
-        "'docs.timeouts.request_seconds' for the 'docs' commands)."
+        "Per-request timeout in seconds. Overrides the configured "
+        "cli.request.timeouts.default_seconds (and "
+        "cli.docs.timeouts.request_seconds for the 'docs' commands)."
     ),
 )
 @click.option(
@@ -273,10 +273,10 @@ def _quiet_dependency_loggers(verbose: int) -> None:
     help=(
         "Disable the sticky context for this invocation: when a session, "
         "system, or PQ id is omitted, the command fails with "
-        "context_not_set instead of falling back to context.json. "
-        "Overrides cli.json's context.enabled. This governs only the "
-        "read: 'session create' and 'pq create' still record the new id "
-        "unless --no-set-context is given."
+        "context_not_set instead of falling back to the stored context. "
+        "Overrides the configured cli.context.enabled. This governs only "
+        "the read: 'session create' and 'pq create' still record the new "
+        "id unless --no-set-context is given."
     ),
 )
 @click.option(

--- a/src/deephaven_mcp/cli/_manifest.py
+++ b/src/deephaven_mcp/cli/_manifest.py
@@ -673,7 +673,7 @@ AGENT_CONVENTIONS: tuple[str, ...] = (
     "message. A command node names the codes it can emit; 'dhcli agents "
     "errors' is where their meanings and recovery steps live.",
     "A session, system, or PQ id omitted from a verb falls back to the "
-    "sticky context in context.json, which the command line does not show "
+    "sticky context, which the command line does not show "
     "— an omitted id means 'whatever the context holds', not 'no target'. "
     "Run 'dhcli context show' before any consequential verb whose id you "
     "intend to omit, or pass the id explicitly.",

--- a/src/deephaven_mcp/cli/_mcp_client.py
+++ b/src/deephaven_mcp/cli/_mcp_client.py
@@ -82,7 +82,7 @@ class McpClient:
         *,
         headers: dict[str, str] | None = None,
         request_timeout_seconds: int = 60,
-        timeout_setting: str = "request.timeouts.default_seconds",
+        timeout_setting: str = "cli.request.timeouts.default_seconds",
     ) -> None:
         """Capture the connection parameters; no I/O yet.
 
@@ -95,9 +95,9 @@ class McpClient:
             request_timeout_seconds (int): Default per-call timeout
                 applied to ``call_tool`` when no override is
                 supplied. Defaults to ``60``.
-            timeout_setting (str): Dotted ``cli.json`` key named in the
+            timeout_setting (str): Logical config path named in the
                 timeout error's recovery hint. Defaults to the daemon
-                request timeout key.
+                request timeout path.
         """
         self._url = url
         self._headers = dict(headers) if headers else {}
@@ -302,8 +302,7 @@ class McpClient:
                     f"{timeout.total_seconds():g} seconds. The server may still "
                     f"finish processing the request — if the operation changes "
                     f"state, verify the result before retrying. To allow more "
-                    f"time, pass --timeout or raise {self._timeout_setting} "
-                    f"in cli.json."
+                    f"time, pass --timeout or raise {self._timeout_setting}."
                 ) from exc
             raise McpClientError(
                 f"call_tool({name!r}) failed: {describe_exception(exc)}"

--- a/src/deephaven_mcp/config/_redact_raw.py
+++ b/src/deephaven_mcp/config/_redact_raw.py
@@ -48,7 +48,10 @@ from deephaven_mcp._redaction import REDACTED
 from deephaven_mcp.config._field_path import FieldPath
 from deephaven_mcp.config._file_kinds import ConfigFileKind
 from deephaven_mcp.config._settable_fields import settable_fields
-from deephaven_mcp.config._templating import is_single_placeholder
+from deephaven_mcp.config._templating import (
+    is_single_placeholder,
+    replace_placeholder_default,
+)
 
 _DISCRIMINATOR = "type"
 """Key tagging which member of a discriminated union applies. It names
@@ -155,9 +158,14 @@ def _scrub(value: Any) -> RawRedaction:
     """
     if isinstance(value, str):
         # A lone ``${...}`` reference points at the secret rather than
-        # being it, so it survives.
+        # being it, so it survives -- except for a ``:-`` fallback, which
+        # carries a literal inside the placeholder. Masking just the
+        # fallback keeps the variable name legible.
         if is_single_placeholder(value):
-            return RawRedaction(value, 0)
+            masked = replace_placeholder_default(value, replacement=REDACTED)
+            if masked is None:
+                return RawRedaction(value, 0)
+            return RawRedaction(masked, 1)
         return RawRedaction(REDACTED, 1)
     if isinstance(value, dict):
         scrubbed: dict[str, Any] = {}

--- a/src/deephaven_mcp/config/_redact_raw.py
+++ b/src/deephaven_mcp/config/_redact_raw.py
@@ -1,0 +1,207 @@
+"""Schema-guided redaction of raw, not-yet-validated configuration data.
+
+``dhcli config get`` prints what is actually on disk, and must keep
+working on a tree too broken to load — so it cannot use
+:func:`~deephaven_mcp._pydantic.dump_redacted`, which needs a validated
+model instance. :func:`redact_raw` fills that gap using the field
+inventory that
+:func:`~deephaven_mcp.config._settable_fields.settable_fields` already
+derives from the same schemas, so ``dhcli config keys`` and ``dhcli
+config get`` agree on which fields are secret.
+
+Three rules define what it redacts:
+
+- **Redaction starts at the deepest secret field.**
+  :attr:`~deephaven_mcp.config._settable_fields.SettableField.secret`
+  is annotation-wide, so an enclosing block is flagged alongside the
+  field that makes it secret; starting at the deepest flagged path
+  keeps the surrounding structure visible.
+- **Within that field, each value is replaced but every key survives,
+  as does the ``type`` discriminator.** Which *kind* of credential is
+  configured is a diagnostic, not a secret, so an ``auth`` block
+  renders as ``{"credentials": {"type": "psk", "token":
+  "[REDACTED]"}}``. An anonymous block carries no secret at all and so
+  passes through untouched and uncounted.
+- **A bare templating reference is left verbatim.** ``"${env:DH_PSK}"``
+  names an environment variable and discloses nothing, so redacting it
+  would cost the diagnostic that matters most (is this field wired to
+  the variable I think it is?) and buy no secrecy. A literal in the
+  same field *is* the secret and is replaced.
+
+A key the schema does not declare is left verbatim: it cannot be a
+schema secret, and it is exactly what an operator runs ``config get``
+to find.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "RawRedaction",
+    "redact_raw",
+]
+
+from dataclasses import dataclass
+from functools import cache
+from typing import Any
+
+from deephaven_mcp._redaction import REDACTED
+from deephaven_mcp.config._field_path import FieldPath
+from deephaven_mcp.config._file_kinds import ConfigFileKind
+from deephaven_mcp.config._settable_fields import settable_fields
+from deephaven_mcp.config._templating import is_single_placeholder
+
+_DISCRIMINATOR = "type"
+"""Key tagging which member of a discriminated union applies. It names
+the *kind* of credential, never the credential, so it survives
+redaction — without it an auth block reduces to an opaque blob."""
+
+
+@dataclass(frozen=True, slots=True)
+class RawRedaction:
+    """Outcome of one :func:`redact_raw` call."""
+
+    value: Any
+    """The input value with every secret-bearing field replaced by
+    :data:`~deephaven_mcp._redaction.REDACTED`. Shares unmodified
+    sub-objects with the input; the input itself is never mutated."""
+
+    count: int
+    """How many values were replaced. ``0`` means nothing was redacted,
+    so revealing the value would disclose nothing."""
+
+
+@cache
+def _redaction_points(kind: ConfigFileKind) -> frozenset[FieldPath]:
+    """Return the deepest secret field paths of one file kind's schema.
+
+    Cached because the result depends only on the schema, which is
+    fixed at import time.
+
+    Args:
+        kind (ConfigFileKind): The file kind whose schema to inspect.
+
+    Returns:
+        frozenset[FieldPath]: Every path flagged secret that has no
+            secret descendant, in wire format relative to the file.
+    """
+    secret = {field.path for field in settable_fields(kind) if field.secret}
+    return frozenset(
+        path
+        for path in secret
+        if not any(other != path and other.has_prefix(path) for other in secret)
+    )
+
+
+def redact_raw(
+    kind: ConfigFileKind,
+    value: Any,
+    *,
+    at: FieldPath = FieldPath.ROOT,
+) -> RawRedaction:
+    """Redact the secret-bearing fields of a raw configuration value.
+
+    Args:
+        kind (ConfigFileKind): The file kind ``value`` came from. Used
+            for its schema-derived field inventory only; nothing is
+            validated, so ``value`` need not be valid.
+        value (Any): The raw JSON-parsed value: a whole file's mapping,
+            a subtree, or a single scalar.
+        at (FieldPath): Where ``value`` sits within the file, in wire
+            format. :attr:`~deephaven_mcp.config._field_path.FieldPath.ROOT`
+            (the default) means ``value`` is the whole file.
+
+    Returns:
+        RawRedaction: The redacted value and the number of values
+            replaced.
+    """
+    return _redact(_redaction_points(kind), at, value)
+
+
+def _redact(points: frozenset[FieldPath], path: FieldPath, value: Any) -> RawRedaction:
+    """Redact ``value``, sitting at ``path``, against the redaction points.
+
+    Args:
+        points (frozenset[FieldPath]): The deepest secret field paths.
+        path (FieldPath): Where ``value`` sits within its file.
+        value (Any): The raw value to redact.
+
+    Returns:
+        RawRedaction: The redacted value and the replacement count.
+    """
+    # ``has_prefix`` is true for the point itself and for anything under
+    # it, so addressing a field *inside* a secret block (``config get
+    # ...auth.credentials.token``) cannot slip past the check.
+    if any(path.has_prefix(point) for point in points):
+        return _scrub(value)
+    if isinstance(value, dict):
+        return _redact_mapping(points, path, value)
+    # A list is opaque to the field inventory: any secret inside one is
+    # flagged at the list's own path, handled above. Reaching here means
+    # nothing within can be a schema secret.
+    return RawRedaction(value, 0)
+
+
+def _scrub(value: Any) -> RawRedaction:
+    """Replace the disclosing material inside one secret field's value.
+
+    Args:
+        value (Any): The raw value sitting at a redaction point.
+
+    Returns:
+        RawRedaction: The scrubbed value and the replacement count.
+            ``0`` means the field held nothing disclosing — an
+            anonymous credentials block, or a value that only
+            references a secret stored elsewhere.
+    """
+    if isinstance(value, str):
+        # A lone ``${...}`` reference points at the secret rather than
+        # being it, so it survives.
+        if is_single_placeholder(value):
+            return RawRedaction(value, 0)
+        return RawRedaction(REDACTED, 1)
+    if isinstance(value, dict):
+        scrubbed: dict[str, Any] = {}
+        count = 0
+        for key, item in value.items():
+            if key == _DISCRIMINATOR:
+                # Which kind of credential this is, never the credential
+                # itself. Keeping it is the difference between a useful
+                # and a useless view of an auth block.
+                scrubbed[key] = item
+                continue
+            outcome = _scrub(item)
+            scrubbed[key] = outcome.value
+            count += outcome.count
+        return RawRedaction(scrubbed, count)
+    if isinstance(value, list):
+        results = [_scrub(item) for item in value]
+        return RawRedaction(
+            [result.value for result in results],
+            sum(result.count for result in results),
+        )
+    # A non-string scalar at a secret field is invalid data that would
+    # still disclose whatever it holds, so it fails closed.
+    return RawRedaction(REDACTED, 1)
+
+
+def _redact_mapping(
+    points: frozenset[FieldPath], path: FieldPath, data: dict[str, Any]
+) -> RawRedaction:
+    """Redact each key of a raw mapping.
+
+    Args:
+        points (frozenset[FieldPath]): The deepest secret field paths.
+        path (FieldPath): Where ``data`` sits within its file.
+        data (dict[str, Any]): The raw mapping.
+
+    Returns:
+        RawRedaction: A new mapping with the same key order, and the
+            replacement count.
+    """
+    redacted: dict[str, Any] = {}
+    count = 0
+    for key, item in data.items():
+        outcome = _redact(points, path + key, item)
+        redacted[key] = outcome.value
+        count += outcome.count
+    return RawRedaction(redacted, count)

--- a/src/deephaven_mcp/config/_redact_raw.py
+++ b/src/deephaven_mcp/config/_redact_raw.py
@@ -21,7 +21,12 @@ Three rules define what it redacts:
   configured is a diagnostic, not a secret, so an ``auth`` block
   renders as ``{"credentials": {"type": "psk", "token":
   "[REDACTED]"}}``. An anonymous block carries no secret at all and so
-  passes through untouched and uncounted.
+  passes through untouched and uncounted. The exemption is confined to
+  the flagged field's own mapping, and applies equally whether the
+  discriminator is reached through the block or addressed directly.
+  Deeper in, a key named ``type`` is scrubbed like any other: this runs
+  on unvalidated data, so such a key need not be a discriminator at
+  all.
 - **A bare templating reference is left verbatim.** ``"${env:DH_PSK}"``
   names an environment variable and discloses nothing, so redacting it
   would cost the diagnostic that matters most (is this field wired to
@@ -131,6 +136,14 @@ def _redact(points: frozenset[FieldPath], path: FieldPath, value: Any) -> RawRed
     Returns:
         RawRedaction: The redacted value and the replacement count.
     """
+    # Addressing the discriminator directly must agree with how the
+    # enclosing block renders it. Without this, ``config get
+    # ...credentials`` shows ``"type": "psk"`` while ``config get
+    # ...credentials.type`` shows ``[REDACTED]`` and warns of a
+    # disclosure -- contradicting the rule that the discriminator names
+    # the kind of credential, never the credential.
+    if any(path == point + _DISCRIMINATOR for point in points):
+        return RawRedaction(value, 0)
     # ``has_prefix`` is true for the point itself and for anything under
     # it, so addressing a field *inside* a secret block (``config get
     # ...auth.credentials.token``) cannot slip past the check.
@@ -144,11 +157,18 @@ def _redact(points: frozenset[FieldPath], path: FieldPath, value: Any) -> RawRed
     return RawRedaction(value, 0)
 
 
-def _scrub(value: Any) -> RawRedaction:
+def _scrub(value: Any, *, at_point: bool = True) -> RawRedaction:
     """Replace the disclosing material inside one secret field's value.
 
     Args:
         value (Any): The raw value sitting at a redaction point.
+        at_point (bool): Whether ``value`` is the redaction point's own
+            value, or an element of a list at it -- the only positions
+            where a ``type`` key is the union discriminator. Nested
+            mappings recurse with ``False``: this runs on unvalidated
+            data, where a deeper key happens to be named ``type``
+            without being a discriminator, and exempting it would print
+            a secret verbatim.
 
     Returns:
         RawRedaction: The scrubbed value and the replacement count.
@@ -171,18 +191,20 @@ def _scrub(value: Any) -> RawRedaction:
         scrubbed: dict[str, Any] = {}
         count = 0
         for key, item in value.items():
-            if key == _DISCRIMINATOR:
+            if at_point and key == _DISCRIMINATOR:
                 # Which kind of credential this is, never the credential
                 # itself. Keeping it is the difference between a useful
                 # and a useless view of an auth block.
                 scrubbed[key] = item
                 continue
-            outcome = _scrub(item)
+            outcome = _scrub(item, at_point=False)
             scrubbed[key] = outcome.value
             count += outcome.count
         return RawRedaction(scrubbed, count)
     if isinstance(value, list):
-        results = [_scrub(item) for item in value]
+        # A list at the point holds the point's own values (e.g. a list
+        # of credential blocks), so the exemption carries across it.
+        results = [_scrub(item, at_point=at_point) for item in value]
         return RawRedaction(
             [result.value for result in results],
             sum(result.count for result in results),

--- a/src/deephaven_mcp/config/_templating.py
+++ b/src/deephaven_mcp/config/_templating.py
@@ -78,6 +78,7 @@ __all__ = [
     "expand_tree",
     "expand_tree_lenient",
     "is_single_placeholder",
+    "replace_placeholder_default",
 ]
 
 import os
@@ -241,15 +242,22 @@ def is_single_placeholder(value: str) -> bool:
     """Whether ``value`` is exactly one ``${...}`` placeholder and nothing else.
 
     Distinguishes a value that merely *points* at a secret from one that
-    *is* a secret. ``"${env:DH_PSK}"`` names an environment variable and
-    discloses nothing; ``"s3cret"`` in the same field is the secret
-    itself. Callers that redact secret-bearing fields use this to leave
-    the pointer legible, which is what makes a redacted view still
-    useful for diagnosing configuration.
+    *is* a secret. ``"${env:DH_PSK}"`` names an environment variable;
+    ``"s3cret"`` in the same field is the secret itself. Callers that
+    redact secret-bearing fields use this to leave the pointer legible,
+    which is what makes a redacted view still useful for diagnosing
+    configuration.
 
     A string with a placeholder *plus* literal text (``"tok-${env:X}"``)
     is deliberately **not** a single placeholder: its literal part may
     itself be sensitive, so it is reported as a value, not a reference.
+
+    Note:
+        A single placeholder is *not* automatically safe to display: a
+        ``:-`` fallback embeds a literal in the placeholder itself
+        (``"${env:DH_PSK:-s3cret}"``). This predicate answers only the
+        structural question; a caller displaying the value must pass it
+        through :func:`replace_placeholder_default` first.
 
     Args:
         value (str): The raw string value as written in the file.
@@ -262,6 +270,54 @@ def is_single_placeholder(value: str) -> bool:
             load time, with a proper error).
     """
     return _PLACEHOLDER_RE.fullmatch(value) is not None
+
+
+def replace_placeholder_default(value: str, *, replacement: str) -> str | None:
+    """Substitute the ``:-`` fallback inside a lone ``${...}`` placeholder.
+
+    A purely syntactic rewrite over the placeholder grammar this module
+    owns: ``"${env:DH_PSK:-s3cret}"`` becomes
+    ``"${env:DH_PSK:-<replacement>}"``, leaving the kind and argument
+    untouched. It lives beside that grammar rather than with its caller
+    because ``_PLACEHOLDER_RE`` and the ``:-`` rule are defined here and
+    enforced by :func:`_validate_placeholder_syntax`; a second parser
+    elsewhere would drift from them.
+
+    The motivating caller is configuration redaction
+    (:mod:`deephaven_mcp.config._redact_raw`), where a fallback is a
+    literal secret embedded in an otherwise-safe reference: replacing
+    only the fallback withholds it while keeping the variable name
+    legible. *What* to substitute, and whether the substitution counts
+    as a disclosure, are that caller's policy — this function only
+    rewrites.
+
+    Deliberately kind-agnostic: it rewrites the fallback for any
+    placeholder body containing ``:-``, not just ``env``. Only ``env``
+    accepts the syntax (``file`` rejects it in
+    :func:`_validate_placeholder_syntax`), but callers run this against
+    *raw, not-yet-validated* file content, where an unknown or
+    malformed kind may still carry a literal.
+
+    Args:
+        value (str): A string for which :func:`is_single_placeholder`
+            returns ``True``. Any other input yields ``None``.
+        replacement (str): Text substituted for the fallback literal,
+            e.g. ``"[REDACTED]"``.
+
+    Returns:
+        str | None: The placeholder with its fallback replaced, or
+            ``None`` when there is nothing to replace — ``value`` is not
+            a lone placeholder, carries no ``:-``, or its fallback is
+            empty (``"${env:X:-}"`` defaults to the empty string, which
+            discloses nothing).
+    """
+    match = _PLACEHOLDER_RE.fullmatch(value)
+    if match is None:
+        return None
+    head, separator, fallback = match.group(1).partition(":-")
+    if not separator or not fallback:
+        return None
+    return f"${{{head}:-{replacement}}}"
 
 
 def expand_string(

--- a/src/deephaven_mcp/config/_templating.py
+++ b/src/deephaven_mcp/config/_templating.py
@@ -77,6 +77,7 @@ __all__ = [
     "expand_string",
     "expand_tree",
     "expand_tree_lenient",
+    "is_single_placeholder",
 ]
 
 import os
@@ -234,6 +235,33 @@ def _validate_placeholder_syntax(
             f"In {source} at {path}: unknown placeholder kind {kind!r} in "
             f"{match.group(0)!r}; expected 'env' or 'file'"
         )
+
+
+def is_single_placeholder(value: str) -> bool:
+    """Whether ``value`` is exactly one ``${...}`` placeholder and nothing else.
+
+    Distinguishes a value that merely *points* at a secret from one that
+    *is* a secret. ``"${env:DH_PSK}"`` names an environment variable and
+    discloses nothing; ``"s3cret"`` in the same field is the secret
+    itself. Callers that redact secret-bearing fields use this to leave
+    the pointer legible, which is what makes a redacted view still
+    useful for diagnosing configuration.
+
+    A string with a placeholder *plus* literal text (``"tok-${env:X}"``)
+    is deliberately **not** a single placeholder: its literal part may
+    itself be sensitive, so it is reported as a value, not a reference.
+
+    Args:
+        value (str): The raw string value as written in the file.
+
+    Returns:
+        bool: ``True`` when ``value`` consists of one placeholder and
+            no surrounding text. Syntactic only — no attempt is made
+            to resolve the placeholder or to validate its kind, so a
+            malformed ``${bogus:x}`` still counts (it fails later, at
+            load time, with a proper error).
+    """
+    return _PLACEHOLDER_RE.fullmatch(value) is not None
 
 
 def expand_string(

--- a/src/deephaven_mcp/config/schema/_community.py
+++ b/src/deephaven_mcp/config/schema/_community.py
@@ -89,17 +89,18 @@ class CommunitySecurity(StrictSchema):
     """``security`` sub-block of ``community/settings.json``."""
 
     credential_retrieval_mode: Literal["none", "dynamic_only", "static_only", "all"] = (
-        "none"
+        "dynamic_only"
     )
     """Policy controlling whether the systems server exposes its
     community session credentials to MCP clients through the
     credential-retrieval tool. ``"none"`` disables retrieval;
     ``"dynamic_only"`` permits retrieval for runtime-launched
-    sessions; ``"static_only"`` permits retrieval for sessions defined
-    in ``community/sessions/``; ``"all"`` permits both. The whole
-    ``security:`` block can still be omitted;
-    :attr:`CommunitySettings.security` carries ``None`` as a default
-    to encode absence."""
+    sessions; ``"static_only"`` permits retrieval for sessions
+    configured under ``community.sessions``; ``"all"`` permits both.
+
+    Defaults to ``"dynamic_only"``: a dynamic worker's token was minted
+    for a session the caller just created, while operator-authored
+    static credentials stay withheld until an operator opts in."""
 
 
 class DockerImages(StrictSchema):
@@ -259,10 +260,9 @@ class CommunitySettings(StrictSchema):
     the effective value without further default resolution.
     """
 
-    security: CommunitySecurity | None = None
-    """Optional community-wide security policy. ``None`` means
-    credential retrieval is disabled (the same as
-    ``credential_retrieval_mode: "none"``)."""
+    security: CommunitySecurity = Field(default_factory=CommunitySecurity)
+    """Community-wide security policy. Omitting the block is the same as
+    writing it empty: each field takes its own default."""
 
     session_creation: CommunitySessionCreation | None = None
     """Optional defaults for dynamically-created community sessions.

--- a/src/deephaven_mcp/config/schema/_community.py
+++ b/src/deephaven_mcp/config/schema/_community.py
@@ -99,8 +99,13 @@ class CommunitySecurity(StrictSchema):
     configured under ``community.sessions``; ``"all"`` permits both.
 
     Defaults to ``"dynamic_only"``: a dynamic worker's token was minted
-    for a session the caller just created, while operator-authored
-    static credentials stay withheld until an operator opts in."""
+    by this server at runtime, while operator-authored static
+    credentials stay withheld until an operator opts in.
+
+    The gate keys on a session's *origin*, not on who created it. Every
+    dynamically launched session is in scope — whichever client created
+    it, and including one created with an explicit ``auth_token`` rather
+    than a server-generated one."""
 
 
 class DockerImages(StrictSchema):

--- a/src/deephaven_mcp/mcp_systems_server/_http.py
+++ b/src/deephaven_mcp/mcp_systems_server/_http.py
@@ -97,7 +97,7 @@ def _resolve_psk_or_exit(
     cli_psk: str | None,
     server_cfg: ServerConfig,
     config_dir: Path,
-) -> str:
+) -> SecretStr:
     """Resolve the HTTP-transport PSK with CLI > JSON precedence.
 
     Args:
@@ -110,7 +110,7 @@ def _resolve_psk_or_exit(
             used only for the error message when no PSK is available.
 
     Returns:
-        str: The non-empty PSK string from the highest-precedence
+        SecretStr: The non-empty PSK from the highest-precedence
             source.
 
     Raises:
@@ -122,13 +122,13 @@ def _resolve_psk_or_exit(
             "[mcp_systems_server._http:_resolve_psk_or_exit] "
             "Using PSK from --psk CLI flag"
         )
-        return cli_psk
+        return SecretStr(cli_psk)
     if server_cfg.psk is not None and server_cfg.psk.get_secret_value():
         _LOGGER.debug(
             "[mcp_systems_server._http:_resolve_psk_or_exit] "
             "Using PSK from server.json"
         )
-        return server_cfg.psk.get_secret_value()
+        return server_cfg.psk
     _LOGGER.error(
         "[mcp_systems_server._http:_resolve_psk_or_exit] HTTP transport requires a PSK. "
         f"Set --psk or configure 'psk' in {config_dir}/server.json. "
@@ -137,13 +137,16 @@ def _resolve_psk_or_exit(
     sys.exit(1)
 
 
-def _generate_daemon_psk() -> str:
+def _generate_daemon_psk() -> SecretStr:
     """Return a fresh random PSK for the daemon HTTP transport.
 
     Uses :func:`secrets.token_urlsafe` with 32 bytes of entropy (a
     ~43-character URL-safe string).
+
+    Returns:
+        SecretStr: The freshly generated PSK.
     """
-    return secrets.token_urlsafe(32)
+    return SecretStr(secrets.token_urlsafe(32))
 
 
 def _acquire_loopback_socket() -> socket.socket:
@@ -169,7 +172,7 @@ def _acquire_loopback_socket() -> socket.socket:
 def _build_http_app(
     server: FastMCP[LifespanContext],
     *,
-    psk: str,
+    psk: SecretStr,
     activity_timer: IdleTimer | None,
 ) -> Starlette:
     """Assemble the streamable-HTTP ASGI app with the PSK gate (and optional activity bump).
@@ -182,8 +185,8 @@ def _build_http_app(
 
     Args:
         server (FastMCP[LifespanContext]): The FastMCP instance to host.
-        psk (str): The non-empty PSK that :class:`PSKMiddleware` requires on
-            every request.
+        psk (SecretStr): The non-empty PSK that :class:`PSKMiddleware` requires
+            on every request. Unwrapped here, at the middleware boundary.
         activity_timer (IdleTimer | None): When supplied, an
             :class:`ActivityMiddleware` bumps this timer on every successful
             response.
@@ -197,7 +200,7 @@ def _build_http_app(
         0,
         Middleware(
             PSKMiddleware,
-            expected_psk=psk,
+            expected_psk=psk.get_secret_value(),
             bypass_paths=(HEALTH_PATH,),
         ),
     )
@@ -360,8 +363,10 @@ class _HttpRun:
     """FastMCP server name advertised in MCP handshakes. Sourced from
     ``ServerConfig.server_name``."""
 
-    psk: str
-    """Non-empty PSK installed on the :class:`PSKMiddleware`."""
+    psk: SecretStr
+    """Non-empty PSK installed on the :class:`PSKMiddleware`. Held as a
+    :class:`~pydantic.SecretStr` so this plan's ``repr`` — which reaches
+    logs and tracebacks — cannot disclose a live key."""
 
     bind: _BindSpec
     """Resolved uvicorn bind (direct or handoff)."""
@@ -485,7 +490,7 @@ def _plan_daemon(
         f"at {handle.path} (runtime_dir={runtime_dir})"
     )
     if cli_psk:
-        psk = cli_psk
+        psk = SecretStr(cli_psk)
         _LOGGER.debug(
             "[mcp_systems_server._http:_plan_daemon] Using PSK from --psk "
             "override (debug)"
@@ -550,7 +555,7 @@ def _publish_daemon_registry(
         process_name=daemon.process_name,
         host="127.0.0.1",
         port=plan.bind.port,
-        psk=SecretStr(plan.psk),
+        psk=plan.psk,
         started_at=datetime.now(UTC),
         config_dir=plan.multi_config.config_dir,
         server_name=plan.server_name,

--- a/src/deephaven_mcp/mcp_systems_server/_tools/session.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/session.py
@@ -483,7 +483,6 @@ async def session_details(
                 - deephaven_enterprise_version (str, optional): Version of Deephaven Enterprise/Core+/CorePlus (e.g., "0.24.0")
                   if the session is an enterprise installation
                 - connection_url (str, optional): Base connection URL for dynamically created sessions (e.g., "http://localhost:45123")
-                - connection_url_with_auth (str, optional): Connection URL with auth token for dynamically created sessions
                 - auth_type (str, optional): Authentication type for dynamically created sessions ("PSK" or "Anonymous")
                 - launch_method (str, optional): Launch method for dynamically created sessions ("docker" or "python")
                 - port (int, optional): Port number for dynamically created sessions
@@ -496,6 +495,10 @@ async def session_details(
         deephaven_enterprise_version) will only be present if the session is available and
         the information could be retrieved successfully. Fields with null values are excluded
         from the response.
+
+    Security Note:
+        Returns no credentials; use ``session_community_credentials`` when a
+        token or authenticated URL is needed.
     """
     _LOGGER.info(f"[mcp_systems_server:session_details] Invoked for id: {id}")
     try:

--- a/src/deephaven_mcp/mcp_systems_server/_tools/session_community.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/session_community.py
@@ -815,7 +815,17 @@ def _log_auto_generated_credentials(
     connection_url: str,
     auth_token: str,
 ) -> None:
-    """Log auto-generated credentials prominently for user access."""
+    """Log auto-generated credentials prominently for user access.
+
+    Writes the token in plaintext: it was minted for a session the caller
+    just created and is surfaced nowhere else.
+
+    Args:
+        session_name (str): Display name of the new session.
+        port (int): Port the worker is listening on.
+        connection_url (str): Base URL without authentication.
+        auth_token (str): The auto-generated PSK, logged verbatim.
+    """
     _LOGGER.warning("=" * 70)
     _LOGGER.warning(
         f"🔑 Session '{session_name}' Created - Browser Access Information:"
@@ -826,10 +836,7 @@ def _log_auto_generated_credentials(
     _LOGGER.warning(f"   Browser URL: {connection_url}/?psk={auth_token}")
     _LOGGER.warning("")
     _LOGGER.warning(
-        "   To retrieve credentials via MCP tool, enable credential_retrieval_enabled"
-    )
-    _LOGGER.warning(
-        "   in your community/settings.json in your configuration directory."
+        "   Also available from the session_community_credentials MCP tool."
     )
     _LOGGER.warning("=" * 70)
 
@@ -981,9 +988,11 @@ async def session_community_create(
 
         Security Note:
             - auth_token and connection_url_with_auth are NOT included for security
-            - Auto-generated tokens are logged to console (similar to Jupyter)
-            - Use session_community_credentials tool to retrieve credentials programmatically
-              (requires credential_retrieval_enabled=true in configuration)
+            - An auto-generated token is written in plaintext to the server log,
+              so treat that log as secret-bearing
+            - Use session_community_credentials to retrieve credentials
+              programmatically; the default mode permits it for sessions
+              created this way
 
         Example Success Response (docker):
         {
@@ -1022,7 +1031,7 @@ async def session_community_create(
         - Rejects duplicate display names (case-sensitive)
         - Auto-generates secure auth tokens if not provided
         - Waits for session to be ready before returning
-        - Logs auth token with WARNING level for user visibility
+        - Logs an auto-generated auth token in plaintext at WARNING level
         - Registers session in registry for lifecycle management
 
     Common Error Scenarios:
@@ -1042,8 +1051,9 @@ async def session_community_create(
     Note:
         - Created sessions are automatically cleaned up on MCP server shutdown
         - Sessions consume system resources - delete when no longer needed
-        - Auto-generated auth tokens are logged to console at WARNING level
-        - For browser access, copy the URL from console logs or use session_community_credentials tool
+        - Auto-generated auth tokens are logged in plaintext at WARNING level
+        - For browser access, copy the URL from the server log or use the
+          session_community_credentials tool
     """
     _LOGGER.info(
         f"[mcp_systems_server:session_community_create] Invoked: session_name={session_name!r}"
@@ -1634,12 +1644,10 @@ async def session_community_credentials(
 
     try:
         # Read security settings from the lifespan-loaded community config.
+        # ``security`` is schema-defaulted, so the field default is the
+        # only source of truth for the effective mode.
         settings = get_community_settings(context)
-        credential_retrieval_mode = (
-            settings.security.credential_retrieval_mode
-            if settings.security is not None
-            else "none"
-        )
+        credential_retrieval_mode = settings.security.credential_retrieval_mode
 
         # Validate id format - must be a community session
         if not id.startswith("community:"):
@@ -1656,8 +1664,8 @@ async def session_community_credentials(
             return error_response(
                 "Credential retrieval is disabled (mode='none'). To enable, set security.credential_retrieval_mode in community/settings.json (in your configuration directory):\n\n"
                 "Available modes:\n"
-                '  - "none": Disable all credential retrieval (secure default)\n'
-                '  - "dynamic_only": Allow only auto-generated session credentials\n'
+                '  - "none": Disable all credential retrieval\n'
+                '  - "dynamic_only": Allow only auto-generated session credentials (default)\n'
                 '  - "static_only": Allow only pre-configured session credentials\n'
                 '  - "all": Allow all credential retrieval\n\n'
                 "Configuration example:\n"

--- a/src/deephaven_mcp/mcp_systems_server/_tools/session_community.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/session_community.py
@@ -818,7 +818,10 @@ def _log_auto_generated_credentials(
     """Log auto-generated credentials prominently for user access.
 
     Writes the token in plaintext: it was minted for a session the caller
-    just created and is surfaced nowhere else.
+    just created. Under the default ``dynamic_only`` retrieval mode the
+    same token is also reachable through
+    :func:`session_community_credentials`, so this log is a convenience,
+    not the sole copy -- treat ``daemon.log`` accordingly.
 
     Args:
         session_name (str): Display name of the new session.
@@ -1526,18 +1529,24 @@ async def session_community_credentials(
     via web browser. This tool exposes sensitive credentials and should only be called
     when the user explicitly needs browser access.
 
-    IMPORTANT: This tool is DISABLED by default for security. To enable, add to your
+    IMPORTANT: By default (``dynamic_only``) this tool returns credentials for
+    sessions this server launched at runtime, and withholds operator-authored
+    static ones. To change that, set ``credential_retrieval_mode`` in your
     ``community/settings.json`` (in your configuration directory):
 
     {
       "security": {
-        "credential_retrieval_mode": "dynamic_only"  // or "all", "static_only"
+        "credential_retrieval_mode": "none"  // or "static_only", "all"
       }
     }
 
     Valid credential_retrieval_mode values:
-    - "none": Disabled (secure default)
-    - "dynamic_only": Only auto-generated tokens (dynamic sessions)
+    - "none": Disabled entirely
+    - "dynamic_only": Sessions this server launched at runtime (the default).
+      Scope is the session's origin, not its creator: it covers every
+      dynamically launched session regardless of which client created it,
+      and includes a token passed explicitly to session_community_create
+      rather than only server-minted ones.
     - "static_only": Only pre-configured tokens (static sessions)
     - "all": Both dynamic and static session credentials
 
@@ -1560,16 +1569,17 @@ async def session_community_credentials(
     - **Session Types**: Works for both static (config-based) and dynamic (on-demand) sessions,
       but access is controlled by credential_retrieval_mode setting.
     - **Mode Selection Guidance**:
-        * "dynamic_only": Recommended for development - allows retrieving auto-generated tokens
+        * "dynamic_only": The default - credentials for runtime-launched sessions
         * "static_only": For controlled environments with pre-configured credentials
         * "all": Maximum flexibility but requires careful security consideration
-        * "none": Default - no credential retrieval allowed (most secure)
+        * "none": No credential retrieval allowed (most restrictive)
 
     Security Note:
     - Credentials are returned in plain text
     - All calls are logged for security audit
     - Only use for legitimate browser access needs
-    - Disabled by default - must be explicitly enabled in configuration
+    - Operator-authored static credentials are withheld by default; reaching
+      them requires explicitly setting "static_only" or "all"
 
     Args:
         context (Context): MCP context provided by the MCP framework
@@ -1665,7 +1675,7 @@ async def session_community_credentials(
                 "Credential retrieval is disabled (mode='none'). To enable, set security.credential_retrieval_mode in community/settings.json (in your configuration directory):\n\n"
                 "Available modes:\n"
                 '  - "none": Disable all credential retrieval\n'
-                '  - "dynamic_only": Allow only auto-generated session credentials (default)\n'
+                '  - "dynamic_only": Allow credentials for sessions this server launched (default)\n'
                 '  - "static_only": Allow only pre-configured session credentials\n'
                 '  - "all": Allow all credential retrieval\n\n'
                 "Configuration example:\n"

--- a/tests/cli/_commands/test_config.py
+++ b/tests/cli/_commands/test_config.py
@@ -283,7 +283,7 @@ def test_config_get_hits_assert_never(
     monkeypatch.setattr(config_mod, "resolve_path", lambda path: object())
     assert config_mod.config_get.callback is not None
     with _ctx(tmp_path).scope(), pytest.raises(AssertionError):
-        config_mod.config_get.callback(None)
+        config_mod.config_get.callback(None, False)
 
 
 def test_config_keys_hits_assert_never(
@@ -372,6 +372,108 @@ def test_get_refs_stay_unexpanded(tmp_path: Path) -> None:
     )
     result = _run(tmp_path, "get", "community.sessions.s1.auth.credentials.token")
     assert json.loads(result.stdout) == "${env:DOES_NOT_EXIST_XYZ}"
+
+
+# ---------------------------------------------------------------------------
+# get: secret redaction and the --reveal-secrets opt-out
+# ---------------------------------------------------------------------------
+
+_TOKEN_PATH = "community.sessions.psk1.auth.credentials.token"
+
+
+def _add_psk_session(tmp_path: Path, token: str, name: str = "psk1") -> None:
+    """Add a Community session whose PSK credential is ``token``."""
+    _run(
+        tmp_path,
+        "session",
+        "add",
+        name,
+        "--host",
+        "localhost",
+        "--auth",
+        "psk",
+        "--token",
+        token,
+        "--no-input",
+    )
+
+
+def test_get_redacts_a_literal_secret_by_default(tmp_path: Path) -> None:
+    """A literal secret must not reach stdout without an explicit opt-in."""
+    _add_psk_session(tmp_path, "literal-s3cret")
+    result = _run(tmp_path, "get", _TOKEN_PATH)
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == "[REDACTED]"
+    assert "literal-s3cret" not in result.output
+
+
+def test_get_redacts_a_secret_nested_in_a_subtree(tmp_path: Path) -> None:
+    """Redaction replaces the leaf, not the block containing it."""
+    _add_psk_session(tmp_path, "literal-s3cret")
+    payload = json.loads(_run(tmp_path, "get", "community.sessions.psk1").stdout)
+    assert payload["auth"]["credentials"]["token"] == "[REDACTED]"
+    assert payload["auth"]["credentials"]["type"] == "psk"
+    assert payload["host"] == "localhost"
+
+
+def test_get_redacts_a_secret_in_the_whole_tree(tmp_path: Path) -> None:
+    """The no-PATH aggregate view is redacted too."""
+    _add_psk_session(tmp_path, "literal-s3cret")
+    result = _run(tmp_path, "get")
+    assert "literal-s3cret" not in result.output
+
+
+def test_get_reveal_secrets_prints_the_plaintext(tmp_path: Path) -> None:
+    _add_psk_session(tmp_path, "literal-s3cret")
+    result = _run(tmp_path, "get", _TOKEN_PATH, "--reveal-secrets")
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == "literal-s3cret"
+
+
+def test_get_reveal_secrets_warns_on_stderr_with_a_count(tmp_path: Path) -> None:
+    """The warning must not pollute stdout, which stays parseable JSON."""
+    _add_psk_session(tmp_path, "literal-s3cret")
+    result = _run(tmp_path, "get", _TOKEN_PATH, "--reveal-secrets")
+    assert "--reveal-secrets wrote 1 plaintext secret value" in result.stderr
+    assert json.loads(result.stdout) == "literal-s3cret"
+
+
+def test_get_reveal_secrets_warning_is_plural_for_several(tmp_path: Path) -> None:
+    _add_psk_session(tmp_path, "one-secret", name="psk1")
+    _add_psk_session(tmp_path, "two-secret", name="psk2")
+    result = _run(tmp_path, "get", "community", "--reveal-secrets")
+    assert "wrote 2 plaintext secret values" in result.stderr
+
+
+def test_get_reveal_secrets_is_silent_when_nothing_was_disclosed(
+    tmp_path: Path,
+) -> None:
+    """No warning when the flag revealed nothing; it would cry wolf."""
+    _add_session(tmp_path)
+    result = _run(tmp_path, "get", "community.sessions.local", "--reveal-secrets")
+    assert result.exit_code == 0, result.output
+    assert "--reveal-secrets" not in result.stderr
+
+
+def test_get_does_not_redact_a_bare_templating_ref(tmp_path: Path) -> None:
+    """A ref names the secret rather than being it, so it stays legible
+    and does not trip the disclosure warning."""
+    _add_psk_session(tmp_path, "${env:DH_PSK_XYZ}")
+    result = _run(tmp_path, "get", _TOKEN_PATH)
+    assert json.loads(result.stdout) == "${env:DH_PSK_XYZ}"
+    revealed = _run(tmp_path, "get", _TOKEN_PATH, "--reveal-secrets")
+    assert json.loads(revealed.stdout) == "${env:DH_PSK_XYZ}"
+    assert "--reveal-secrets" not in revealed.stderr
+
+
+def test_get_leaves_non_secret_fields_alone(tmp_path: Path) -> None:
+    """Redaction is schema-guided, not name-guessing: a non-secret field
+    is never touched even when it sits beside a secret."""
+    _add_psk_session(tmp_path, "literal-s3cret")
+    payload = json.loads(_run(tmp_path, "get", "community.sessions.psk1").stdout)
+    assert "[REDACTED]" not in json.dumps(
+        {k: v for k, v in payload.items() if k != "auth"}
+    )
 
 
 def test_get_missing_file_not_found(tmp_path: Path) -> None:

--- a/tests/cli/_commands/test_docs.py
+++ b/tests/cli/_commands/test_docs.py
@@ -336,4 +336,6 @@ def test_docs_client_reads_url_and_timeout_from_config(tmp_path: Path) -> None:
     assert client._url == _DOCS_URL  # noqa: SLF001
     assert client._timeout.total_seconds() == 120  # noqa: SLF001
     assert client._headers == {}  # noqa: SLF001
-    assert client._timeout_setting == "docs.timeouts.request_seconds"  # noqa: SLF001
+    assert (  # noqa: SLF001
+        client._timeout_setting == "cli.docs.timeouts.request_seconds"
+    )

--- a/tests/cli/_commands/test_session.py
+++ b/tests/cli/_commands/test_session.py
@@ -917,12 +917,20 @@ def test_open_no_browser_found_exits_2(tmp_path: Path) -> None:
     with (
         acquire_p,
         call_p,
-        patch.object(browser_mod.webbrowser, "open", return_value=False),
+        patch.object(browser_mod.webbrowser, "open", return_value=False) as wb,
     ):
         result = _invoke(["session", "open", _SID], rt, standalone_mode=False)
     assert _error_code(result) == "browser_launch_failed"
     assert result.exception.exit_code == 2
     assert "manually" in str(result.exception)
+    # The browser still got a URL that can actually log in...
+    wb.assert_called_once_with(_CREDS["connection_url_with_auth"])
+    # ...but the failure message did not: an error path must not walk
+    # around --reveal-secrets and put the credential on stderr.
+    message = str(result.exception)
+    assert _CREDS["auth_token"] not in message
+    assert _CREDS["connection_url"] in message
+    assert "dhcli session url" in message
 
 
 def test_open_browser_error_exits_2(tmp_path: Path) -> None:
@@ -939,6 +947,70 @@ def test_open_browser_error_exits_2(tmp_path: Path) -> None:
     assert _error_code(result) == "browser_launch_failed"
     assert result.exception.exit_code == 2
     assert "Could not launch" in str(result.exception)
+    assert _CREDS["auth_token"] not in str(result.exception)
+
+
+def test_open_browser_failure_on_anonymous_session_omits_the_hint(
+    tmp_path: Path,
+) -> None:
+    """An anonymous session has no token, so its authenticated URL *is*
+    its base URL. Nothing was withheld, and 'session url' would return
+    the very same string -- promising a better one would be a lie."""
+    creds = {
+        "success": True,
+        "id": _SID,
+        "auth_type": "ANONYMOUS",
+        "auth_token": "",
+        "connection_url": "http://h:1",
+        "connection_url_with_auth": "http://h:1",
+    }
+    rt = make_runtime(tmp_path)
+    acquire_p, call_p = _patch(_result(creds))
+    with (
+        acquire_p,
+        call_p,
+        patch.object(browser_mod.webbrowser, "open", return_value=False),
+    ):
+        result = _invoke(["session", "open", _SID], rt, standalone_mode=False)
+    assert _error_code(result) == "browser_launch_failed"
+    message = str(result.exception)
+    assert "http://h:1" in message
+    assert "omits the auth token" not in message
+    assert "dhcli session url" not in message
+
+
+def test_open_browser_failure_message_ends_with_the_url(tmp_path: Path) -> None:
+    """Trailing prose after a URL gets swallowed by terminal and chat
+    autolinkers, so the URL must be the last thing in the message."""
+    rt = make_runtime(tmp_path)
+    acquire_p, call_p = _patch(_result(_CREDS))
+    with (
+        acquire_p,
+        call_p,
+        patch.object(browser_mod.webbrowser, "open", return_value=False),
+    ):
+        result = _invoke(["session", "open", _SID], rt, standalone_mode=False)
+    assert str(result.exception).endswith(_CREDS["connection_url"])
+
+
+def test_open_browser_failure_reveals_the_token_when_asked(tmp_path: Path) -> None:
+    """--reveal-secrets governs the failure path too, so the operator who
+    opted in gets a URL they can paste straight into a browser."""
+    rt = make_runtime(tmp_path)
+    acquire_p, call_p = _patch(_result(_CREDS))
+    with (
+        acquire_p,
+        call_p,
+        patch.object(browser_mod.webbrowser, "open", return_value=False),
+    ):
+        result = _invoke(
+            ["session", "open", _SID, "--reveal-secrets"], rt, standalone_mode=False
+        )
+    assert _error_code(result) == "browser_launch_failed"
+    message = str(result.exception)
+    assert _CREDS["connection_url_with_auth"] in message
+    # The redirect to 'session url' would be noise: they already have it.
+    assert "dhcli session url" not in message
 
 
 def test_open_no_url_exits_2(tmp_path: Path) -> None:

--- a/tests/cli/_commands/test_session.py
+++ b/tests/cli/_commands/test_session.py
@@ -843,9 +843,13 @@ def test_open_launches_browser(tmp_path: Path) -> None:
     ):
         result = _invoke(["-o", "json", "session", "open", _SID], rt)
     assert result.exit_code == 0
+    # The browser gets the authenticated URL...
     wb.assert_called_once_with(_CREDS["connection_url_with_auth"])
     payload = json.loads(result.output)
-    assert payload == {"opened": _CREDS["connection_url_with_auth"], "launched": True}
+    # ...but stdout does not: it already holds the credential, so echoing
+    # the token would only spread it to logs and shell history.
+    assert payload == {"opened": _CREDS["connection_url"], "launched": True}
+    assert _CREDS["auth_token"] not in result.output
 
 
 def test_open_print_only_does_not_launch(tmp_path: Path) -> None:
@@ -856,9 +860,55 @@ def test_open_print_only_does_not_launch(tmp_path: Path) -> None:
         call_p,
         patch.object(browser_mod.webbrowser, "open", return_value=True) as wb,
     ):
-        result = _invoke(["session", "open", _SID, "--print"], rt)
+        result = _invoke(["-o", "json", "session", "open", _SID, "--print"], rt)
     assert result.exit_code == 0
     wb.assert_not_called()
+    # --print controls launching only: it is not a disclosure opt-in, so the
+    # token stays out of the output until --reveal-secrets asks for it.
+    payload = json.loads(result.output)
+    assert payload == {"opened": _CREDS["connection_url"], "launched": False}
+    assert _CREDS["auth_token"] not in result.output
+
+
+def test_open_reveal_secrets_includes_the_token(tmp_path: Path) -> None:
+    rt = make_runtime(tmp_path)
+    acquire_p, call_p = _patch(_result(_CREDS))
+    with (
+        acquire_p,
+        call_p,
+        patch.object(browser_mod.webbrowser, "open", return_value=True) as wb,
+    ):
+        result = _invoke(
+            ["-o", "json", "session", "open", _SID, "--print", "--reveal-secrets"], rt
+        )
+    assert result.exit_code == 0
+    wb.assert_not_called()
+    payload = json.loads(result.output)
+    assert payload == {
+        "opened": _CREDS["connection_url_with_auth"],
+        "launched": False,
+    }
+
+
+def test_open_reveal_secrets_is_independent_of_print(tmp_path: Path) -> None:
+    """--reveal-secrets discloses the token even when a browser was launched."""
+    rt = make_runtime(tmp_path)
+    acquire_p, call_p = _patch(_result(_CREDS))
+    with (
+        acquire_p,
+        call_p,
+        patch.object(browser_mod.webbrowser, "open", return_value=True) as wb,
+    ):
+        result = _invoke(
+            ["-o", "json", "session", "open", _SID, "--reveal-secrets"], rt
+        )
+    assert result.exit_code == 0
+    wb.assert_called_once_with(_CREDS["connection_url_with_auth"])
+    payload = json.loads(result.output)
+    assert payload == {
+        "opened": _CREDS["connection_url_with_auth"],
+        "launched": True,
+    }
 
 
 def test_open_no_browser_found_exits_2(tmp_path: Path) -> None:

--- a/tests/cli/test__browser.py
+++ b/tests/cli/test__browser.py
@@ -11,6 +11,8 @@ from deephaven_mcp.cli._browser import launch_browser
 from deephaven_mcp.cli._errors import CliError, ErrorCode
 
 _URL = "http://localhost:10000/ide/?psk=secret"
+_SAFE_URL = "http://localhost:10000"
+_HINT = "Run 'dhcli session url' for one you can log in with."
 
 
 def test_launch_browser_returns_true_when_a_browser_opens() -> None:
@@ -53,3 +55,89 @@ def test_launch_browser_chains_the_original_error() -> None:
     ):
         launch_browser(_URL)
     assert exc_info.value.__cause__ is original
+
+
+# ---------------------------------------------------------------------------
+# manual_url / hint
+# ---------------------------------------------------------------------------
+
+
+def test_manual_url_replaces_the_url_in_the_message_only() -> None:
+    """The browser needs the real URL to log in; the error message does
+    not, and must not carry a credential the caller chose to withhold."""
+    with (
+        patch("webbrowser.open", return_value=False) as opener,
+        pytest.raises(CliError) as exc_info,
+    ):
+        launch_browser(_URL, manual_url=_SAFE_URL)
+    opener.assert_called_once_with(_URL)
+    message = str(exc_info.value)
+    assert _SAFE_URL in message
+    assert "psk=secret" not in message
+
+
+def test_manual_url_also_applies_to_the_webbrowser_error_branch() -> None:
+    """Both failure branches build their own message; a substitution
+    that covered only one would leak on the other."""
+    with (
+        patch("webbrowser.open", side_effect=webbrowser.Error("no display")),
+        pytest.raises(CliError) as exc_info,
+    ):
+        launch_browser(_URL, manual_url=_SAFE_URL)
+    assert "psk=secret" not in str(exc_info.value)
+
+
+def test_manual_url_defaults_to_the_opened_url() -> None:
+    """Omitting it leaves the pre-existing behavior untouched, which is
+    what keeps 'system open' (no credential involved) unchanged."""
+    with (
+        patch("webbrowser.open", return_value=False),
+        pytest.raises(CliError) as exc_info,
+    ):
+        launch_browser(_URL)
+    assert _URL in str(exc_info.value)
+
+
+def test_hint_precedes_the_url() -> None:
+    """Trailing prose after a URL gets swept into the link by terminal
+    and chat autolinkers, so the URL has to come last."""
+    with (
+        patch("webbrowser.open", return_value=False),
+        pytest.raises(CliError) as exc_info,
+    ):
+        launch_browser(_URL, manual_url=_SAFE_URL, hint=_HINT)
+    message = str(exc_info.value)
+    assert _HINT in message
+    assert message.index(_HINT) < message.index(_SAFE_URL)
+    assert message.endswith(_SAFE_URL)
+
+
+def test_hint_precedes_the_url_on_the_webbrowser_error_branch() -> None:
+    with (
+        patch("webbrowser.open", side_effect=webbrowser.Error("no display")),
+        pytest.raises(CliError) as exc_info,
+    ):
+        launch_browser(_URL, manual_url=_SAFE_URL, hint=_HINT)
+    message = str(exc_info.value)
+    assert message.index(_HINT) < message.index(_SAFE_URL)
+    assert message.endswith(_SAFE_URL)
+
+
+def test_omitted_hint_adds_no_stray_whitespace() -> None:
+    """A caller with nothing to explain must not pay a double space."""
+    with (
+        patch("webbrowser.open", return_value=False),
+        pytest.raises(CliError) as exc_info,
+    ):
+        launch_browser(_URL)
+    message = str(exc_info.value)
+    assert "  " not in message
+    assert message == f"No usable browser was found. Open this URL manually: {_URL}"
+
+
+def test_hint_is_ignored_for_a_successful_launch() -> None:
+    """The parameters shape a failure message only; a launch that works
+    raises nothing and still reports success."""
+    with patch("webbrowser.open", return_value=True) as opener:
+        assert launch_browser(_URL, manual_url=_SAFE_URL, hint=_HINT) is True
+    opener.assert_called_once_with(_URL)

--- a/tests/cli/test__daemon_integration.py
+++ b/tests/cli/test__daemon_integration.py
@@ -148,9 +148,10 @@ def _seed_config_dir(
 def _write_community_settings(cfg_dir: Path, *, credential_retrieval_mode: str) -> None:
     """Write ``community/settings.json`` enabling credential retrieval.
 
-    The default config gates credential retrieval off (``mode='none'``),
-    so the e2e test that exercises ``session credentials`` / ``url`` /
-    ``open`` against the static session must turn it on here.
+    The default mode (``dynamic_only``) covers only sessions the server
+    created itself, so the e2e test that exercises ``session
+    credentials`` / ``url`` / ``open`` against a *static* session must
+    widen the mode here.
     """
     settings = {"security": {"credential_retrieval_mode": credential_retrieval_mode}}
     community_dir = cfg_dir / "community"
@@ -866,12 +867,20 @@ async def test_session_wrapper_verbs_e2e(
         assert result.returncode == 0, result.stderr
         assert community_worker in result.stdout
 
-        # session open --print → prints the URL without launching a browser.
+        # session open --print → reports the URL without launching a browser,
+        # and without the token: --print is not a disclosure opt-in.
         result = run(["session", "open", _DEMO_ID, "--print"])
         assert result.returncode == 0, result.stderr
         opened = json.loads(result.stdout)
         assert opened["launched"] is False
-        assert community_worker in opened["opened"]
+        assert community_worker not in opened["opened"]
+
+        # ...which --reveal-secrets asks for explicitly.
+        result = run(["session", "open", _DEMO_ID, "--print", "--reveal-secrets"])
+        assert result.returncode == 0, result.stderr
+        revealed = json.loads(result.stdout)
+        assert revealed["launched"] is False
+        assert community_worker in revealed["opened"]
     finally:
         run(["daemon", "stop"])
 

--- a/tests/cli/test__manifest.py
+++ b/tests/cli/test__manifest.py
@@ -822,7 +822,7 @@ def test_manifest_emits_router_and_client_params_for_session() -> None:
 
     open_ = manifest["commands"]["session"]["subcommands"]["open"]["wraps"]
     assert open_["tools"] == ["session_community_credentials"]
-    assert open_["client_only_params"] == ["print_only"]
+    assert open_["client_only_params"] == ["print_only", "reveal_secrets"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/config/schema/test__community.py
+++ b/tests/config/schema/test__community.py
@@ -49,7 +49,9 @@ def test_defaults_non_dict_input_passes_through_to_pydantic():
 
 def test_settings_empty_dict_is_valid():
     cfg = CommunitySettings.model_validate({})
-    assert cfg.security is None
+    # ``security`` is schema-defaulted rather than optional, so callers
+    # read the effective policy without a second default to resolve.
+    assert cfg.security.credential_retrieval_mode == "dynamic_only"
     assert cfg.session_creation is None
     # Timer fields carry schema defaults when JSON omits them.
     assert cfg.timeouts.eviction.session_idle_timeout_seconds == 3600.0
@@ -200,18 +202,24 @@ def test_security_accepts_valid_mode():
     cfg = CommunitySettings.model_validate(
         {"security": {"credential_retrieval_mode": "all"}}
     )
-    assert cfg.security is not None
     assert cfg.security.credential_retrieval_mode == "all"
 
 
-def test_security_mode_defaults_to_none_string():
-    """``credential_retrieval_mode`` defaults to ``"none"`` when the
-    ``security`` block is empty; the whole block can also be omitted,
-    in which case ``security`` itself is ``None``.
+def test_security_mode_defaults_to_dynamic_only():
+    """An omitted or empty ``security`` block yields the same effective
+    mode: the field default is the single source of truth, so there is
+    no second place for the two to diverge.
     """
-    cfg = CommunitySettings.model_validate({"security": {}})
-    assert cfg.security is not None
-    assert cfg.security.credential_retrieval_mode == "none"
+    assert (
+        CommunitySettings.model_validate(
+            {"security": {}}
+        ).security.credential_retrieval_mode
+        == "dynamic_only"
+    )
+    assert (
+        CommunitySettings.model_validate({}).security.credential_retrieval_mode
+        == "dynamic_only"
+    )
 
 
 def test_security_mode_rejects_null():
@@ -223,6 +231,15 @@ def test_security_mode_rejects_null():
         CommunitySettings.model_validate(
             {"security": {"credential_retrieval_mode": None}}
         )
+
+
+def test_security_block_rejects_null():
+    """The block itself is no longer nullable: an explicit ``null`` was
+    previously a silent way to disable retrieval, which is now spelled
+    ``credential_retrieval_mode: "none"``.
+    """
+    with pytest.raises(ValidationError):
+        CommunitySettings.model_validate({"security": None})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/config/test__redact_raw.py
+++ b/tests/config/test__redact_raw.py
@@ -188,6 +188,37 @@ def test_ref_embedded_in_a_larger_string_is_redacted() -> None:
     assert outcome.count == 1
 
 
+def test_defaulted_ref_has_its_fallback_redacted() -> None:
+    """A ``:-`` fallback is a literal secret living inside an otherwise
+    safe reference. The variable name stays legible; the literal does
+    not, and it counts so --reveal-secrets reports it."""
+    outcome = redact_raw(ConfigFileKind.SERVER, {"psk": "${env:DH_PSK:-hunter2}"})
+    assert outcome.value == {"psk": "${env:DH_PSK:-[REDACTED]}"}
+    assert outcome.count == 1
+    assert "hunter2" not in str(outcome.value)
+
+
+def test_defaulted_ref_with_an_empty_fallback_survives() -> None:
+    """An empty fallback resolves to the empty string, so there is no
+    literal to hide and nothing to count."""
+    outcome = redact_raw(ConfigFileKind.SERVER, {"psk": "${env:DH_PSK:-}"})
+    assert outcome.value == {"psk": "${env:DH_PSK:-}"}
+    assert outcome.count == 0
+
+
+def test_defaulted_ref_inside_a_secret_block_is_redacted() -> None:
+    """The fallback rule applies inside a credentials block too."""
+    outcome = redact_raw(
+        ConfigFileKind.COMMUNITY_SESSION,
+        {"auth": {"credentials": {"type": "psk", "token": "${env:T:-s3cret}"}}},
+    )
+    assert outcome.value["auth"]["credentials"] == {
+        "type": "psk",
+        "token": "${env:T:-[REDACTED]}",
+    }
+    assert outcome.count == 1
+
+
 def test_ref_inside_a_secret_block_survives() -> None:
     """The placeholder rule applies inside a block too, so a properly
     externalized credential stays fully readable."""

--- a/tests/config/test__redact_raw.py
+++ b/tests/config/test__redact_raw.py
@@ -1,0 +1,358 @@
+"""Tests for schema-guided redaction of raw configuration data.
+
+The redaction points come from the same schema walk that powers
+``dhcli config keys``, so these tests exercise the real schemas rather
+than synthetic models: a drift between the two surfaces should fail
+here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, get_args
+
+import pytest
+
+from deephaven_mcp.auth.credentials import CredentialsUnion
+from deephaven_mcp.config._field_path import FieldPath
+from deephaven_mcp.config._file_kinds import ConfigFileKind
+from deephaven_mcp.config._redact_raw import (
+    _DISCRIMINATOR,
+    _redaction_points,
+    redact_raw,
+)
+
+_CREDENTIALS = FieldPath(("auth", "credentials"))
+_PRIVATE_KEY = FieldPath(("tls", "client_certificate", "private_key"))
+
+
+def _session_file() -> dict[str, Any]:
+    """Return a static community session file with both secret shapes."""
+    return {
+        "host": "dh.example.com",
+        "port": 10000,
+        "tls": {
+            "root_certs": "${file:/etc/ssl/ca.pem}",
+            "client_certificate": {
+                "cert_chain": "-----BEGIN CERTIFICATE-----",
+                "private_key": "-----BEGIN PRIVATE KEY-----",
+            },
+        },
+        "auth": {"credentials": {"type": "psk", "token": "literal-token"}},
+    }
+
+
+# ---------------------------------------------------------------------------
+# redaction points
+# ---------------------------------------------------------------------------
+
+
+def test_points_are_the_deepest_secret_fields() -> None:
+    """``auth`` and ``tls`` are flagged secret because they *contain* a
+    secret; redacting there would hide non-secret structure, so only the
+    deepest flagged paths are redaction points."""
+    points = _redaction_points(ConfigFileKind.COMMUNITY_SESSION)
+    assert points == {_CREDENTIALS, _PRIVATE_KEY}
+    assert FieldPath(("auth",)) not in points
+    assert FieldPath(("tls",)) not in points
+    assert FieldPath(("tls", "client_certificate")) not in points
+
+
+def test_server_psk_is_a_point() -> None:
+    assert FieldPath(("psk",)) in _redaction_points(ConfigFileKind.SERVER)
+
+
+def test_points_exclude_non_secret_fields() -> None:
+    points = _redaction_points(ConfigFileKind.COMMUNITY_SESSION)
+    assert FieldPath(("host",)) not in points
+    assert FieldPath(("port",)) not in points
+    assert FieldPath(("tls", "client_certificate", "cert_chain")) not in points
+
+
+_EXPECTED_POINTS: dict[ConfigFileKind, set[FieldPath]] = {
+    ConfigFileKind.CLI: set(),
+    ConfigFileKind.SERVER: {FieldPath(("psk",))},
+    ConfigFileKind.COMMUNITY_SETTINGS: {
+        FieldPath(("session_creation", "defaults", "auth", "credentials"))
+    },
+    ConfigFileKind.COMMUNITY_SESSION: {_CREDENTIALS, _PRIVATE_KEY},
+    ConfigFileKind.ENTERPRISE_SETTINGS: set(),
+    ConfigFileKind.ENTERPRISE_SYSTEM: {_CREDENTIALS},
+}
+
+
+@pytest.mark.parametrize("kind", list(ConfigFileKind), ids=lambda k: k.value)
+def test_points_are_pinned_for_every_file_kind(kind: ConfigFileKind) -> None:
+    """``config get`` with no PATH spans all six kinds, so each one's
+    redaction points are pinned exactly. A schema change that adds or
+    moves a secret anywhere fails here instead of silently leaking."""
+    assert _redaction_points(kind) == _EXPECTED_POINTS[kind]
+
+
+def test_every_file_kind_is_pinned() -> None:
+    """Guards the table above against a newly added file kind slipping in
+    unpinned, which parametrization alone would not catch."""
+    assert set(_EXPECTED_POINTS) == set(ConfigFileKind)
+
+
+def test_discriminator_matches_the_schema_declaration() -> None:
+    """``_DISCRIMINATOR`` duplicates the ``Field(discriminator=...)`` on
+    the credentials union. Renaming the tag there without updating the
+    constant would make ``config get`` start redacting it -- a silent
+    loss of diagnostic value, with nothing else failing.
+
+    ``CredentialsUnion`` is an ``Annotated[...]`` alias, so ``get_args``
+    yields the union first and its metadata after; the discriminator
+    lives on the ``FieldInfo`` in that metadata.
+    """
+    declared = [
+        getattr(meta, "discriminator", None) for meta in get_args(CredentialsUnion)[1:]
+    ]
+    assert _DISCRIMINATOR in declared, (
+        f"credentials union declares {declared}, but _redact_raw preserves "
+        f"{_DISCRIMINATOR!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# whole-file redaction
+# ---------------------------------------------------------------------------
+
+
+def test_secret_block_keeps_its_keys_and_discriminator() -> None:
+    """The credential value is replaced, but the block's shape and the
+    ``type`` tag — which names the auth kind, not the secret — survive."""
+    outcome = redact_raw(ConfigFileKind.COMMUNITY_SESSION, _session_file())
+    assert outcome.value["auth"] == {
+        "credentials": {"type": "psk", "token": "[REDACTED]"}
+    }
+    assert outcome.value["host"] == "dh.example.com"
+    assert outcome.value["port"] == 10000
+    assert (
+        outcome.value["tls"]["client_certificate"]["cert_chain"]
+        == "-----BEGIN CERTIFICATE-----"
+    )
+
+
+def test_count_totals_every_redacted_value() -> None:
+    """Both the credentials block and the literal private key count."""
+    outcome = redact_raw(ConfigFileKind.COMMUNITY_SESSION, _session_file())
+    assert outcome.count == 2
+
+
+def test_scalar_secret_is_redacted() -> None:
+    outcome = redact_raw(ConfigFileKind.COMMUNITY_SESSION, _session_file())
+    assert outcome.value["tls"]["client_certificate"]["private_key"] == "[REDACTED]"
+
+
+def test_input_is_not_mutated() -> None:
+    data = _session_file()
+    redact_raw(ConfigFileKind.COMMUNITY_SESSION, data)
+    assert data["auth"]["credentials"]["token"] == "literal-token"
+    assert (
+        data["tls"]["client_certificate"]["private_key"]
+        == "-----BEGIN PRIVATE KEY-----"
+    )
+
+
+def test_key_order_is_preserved() -> None:
+    outcome = redact_raw(ConfigFileKind.COMMUNITY_SESSION, _session_file())
+    assert list(outcome.value) == ["host", "port", "tls", "auth"]
+
+
+# ---------------------------------------------------------------------------
+# templating references
+# ---------------------------------------------------------------------------
+
+
+def test_templating_ref_at_a_scalar_secret_survives() -> None:
+    """``${env:VAR}`` names the secret rather than being it, so it is
+    shown as written and not counted."""
+    outcome = redact_raw(
+        ConfigFileKind.SERVER, {"psk": "${env:DH_PSK}"}, at=FieldPath.ROOT
+    )
+    assert outcome.value == {"psk": "${env:DH_PSK}"}
+    assert outcome.count == 0
+
+
+def test_literal_at_a_scalar_secret_is_redacted() -> None:
+    outcome = redact_raw(ConfigFileKind.SERVER, {"psk": "hunter2"})
+    assert outcome.value == {"psk": "[REDACTED]"}
+    assert outcome.count == 1
+
+
+def test_ref_embedded_in_a_larger_string_is_redacted() -> None:
+    """Only a *lone* placeholder discloses nothing; concatenated text
+    may carry literal secret material alongside it."""
+    outcome = redact_raw(ConfigFileKind.SERVER, {"psk": "prefix-${env:DH_PSK}"})
+    assert outcome.value == {"psk": "[REDACTED]"}
+    assert outcome.count == 1
+
+
+def test_ref_inside_a_secret_block_survives() -> None:
+    """The placeholder rule applies inside a block too, so a properly
+    externalized credential stays fully readable."""
+    outcome = redact_raw(
+        ConfigFileKind.COMMUNITY_SESSION,
+        {"auth": {"credentials": {"type": "psk", "token": "${env:DH_PSK}"}}},
+    )
+    assert outcome.value["auth"]["credentials"] == {
+        "type": "psk",
+        "token": "${env:DH_PSK}",
+    }
+    assert outcome.count == 0
+
+
+def test_anonymous_block_is_untouched_and_uncounted() -> None:
+    """An anonymous credentials block holds no secret, so redacting it
+    would hide a diagnostic and make --reveal-secrets cry wolf."""
+    outcome = redact_raw(
+        ConfigFileKind.COMMUNITY_SESSION,
+        {"auth": {"credentials": {"type": "anonymous"}}},
+    )
+    assert outcome.value["auth"]["credentials"] == {"type": "anonymous"}
+    assert outcome.count == 0
+
+
+def test_username_beside_a_password_is_redacted() -> None:
+    """Only ``type`` is exempt; every other value in the block goes."""
+    outcome = redact_raw(
+        ConfigFileKind.COMMUNITY_SESSION,
+        {
+            "auth": {
+                "credentials": {
+                    "type": "basic",
+                    "username": "admin",
+                    "password": "hunter2",
+                }
+            }
+        },
+    )
+    assert outcome.value["auth"]["credentials"] == {
+        "type": "basic",
+        "username": "[REDACTED]",
+        "password": "[REDACTED]",
+    }
+    assert outcome.count == 2
+
+
+# ---------------------------------------------------------------------------
+# subtree addressing
+# ---------------------------------------------------------------------------
+
+
+def test_subtree_redaction_uses_the_at_path() -> None:
+    """``config get community.sessions.x.auth`` hands the redactor a
+    subtree, which only resolves correctly with ``at`` applied."""
+    outcome = redact_raw(
+        ConfigFileKind.COMMUNITY_SESSION,
+        {"credentials": {"type": "psk", "token": "literal"}},
+        at=FieldPath(("auth",)),
+    )
+    assert outcome.value == {"credentials": {"type": "psk", "token": "[REDACTED]"}}
+    assert outcome.count == 1
+
+
+def test_at_the_secret_itself_scrubs_its_values() -> None:
+    outcome = redact_raw(
+        ConfigFileKind.COMMUNITY_SESSION,
+        {"type": "psk", "token": "literal"},
+        at=_CREDENTIALS,
+    )
+    assert outcome.value == {"type": "psk", "token": "[REDACTED]"}
+    assert outcome.count == 1
+
+
+def test_list_inside_a_secret_field_is_scrubbed_elementwise() -> None:
+    outcome = redact_raw(
+        ConfigFileKind.COMMUNITY_SESSION,
+        {"type": "custom", "tokens": ["a", "${env:B}"]},
+        at=_CREDENTIALS,
+    )
+    assert outcome.value == {"type": "custom", "tokens": ["[REDACTED]", "${env:B}"]}
+    assert outcome.count == 1
+
+
+def test_at_a_path_below_a_secret_point_is_still_redacted() -> None:
+    """``config get ...auth.credentials.token`` addresses *inside* a
+    secret block; it must not escape redaction by being deeper than the
+    point.
+    """
+    outcome = redact_raw(
+        ConfigFileKind.COMMUNITY_SESSION, "literal", at=_CREDENTIALS + "token"
+    )
+    assert outcome.value == "[REDACTED]"
+    assert outcome.count == 1
+
+
+def test_at_a_path_below_a_secret_point_keeps_a_ref_legible() -> None:
+    outcome = redact_raw(
+        ConfigFileKind.COMMUNITY_SESSION, "${env:DH_PSK}", at=_CREDENTIALS + "token"
+    )
+    assert outcome.value == "${env:DH_PSK}"
+    assert outcome.count == 0
+
+
+def test_at_a_scalar_secret_redacts_the_bare_value() -> None:
+    outcome = redact_raw(
+        ConfigFileKind.COMMUNITY_SESSION, "-----BEGIN PRIVATE KEY-----", at=_PRIVATE_KEY
+    )
+    assert outcome.value == "[REDACTED]"
+    assert outcome.count == 1
+
+
+def test_at_a_non_secret_path_changes_nothing() -> None:
+    outcome = redact_raw(
+        ConfigFileKind.COMMUNITY_SESSION, "dh.example.com", at=FieldPath(("host",))
+    )
+    assert outcome.value == "dh.example.com"
+    assert outcome.count == 0
+
+
+# ---------------------------------------------------------------------------
+# values the schema does not describe
+# ---------------------------------------------------------------------------
+
+
+def test_undeclared_keys_are_left_verbatim() -> None:
+    """An unknown key cannot be a schema secret, and surfacing it is
+    exactly why someone runs ``config get`` on a broken tree."""
+    outcome = redact_raw(
+        ConfigFileKind.COMMUNITY_SESSION, {"typo_host": "x", "nested": {"deep": 1}}
+    )
+    assert outcome.value == {"typo_host": "x", "nested": {"deep": 1}}
+    assert outcome.count == 0
+
+
+def test_non_string_at_a_secret_point_is_redacted() -> None:
+    """Invalid data still discloses whatever it holds."""
+    outcome = redact_raw(ConfigFileKind.SERVER, {"psk": 12345})
+    assert outcome.value == {"psk": "[REDACTED]"}
+    assert outcome.count == 1
+
+
+def test_null_at_a_secret_point_is_redacted() -> None:
+    outcome = redact_raw(ConfigFileKind.SERVER, {"psk": None})
+    assert outcome.value == {"psk": "[REDACTED]"}
+    assert outcome.count == 1
+
+
+def test_list_values_pass_through() -> None:
+    """A list is opaque to the field inventory, so any secret inside one
+    is flagged at the list's own path rather than within it."""
+    outcome = redact_raw(
+        ConfigFileKind.SERVER, {"server_name": "s", "unknown_list": [{"a": 1}, "b"]}
+    )
+    assert outcome.value == {"server_name": "s", "unknown_list": [{"a": 1}, "b"]}
+    assert outcome.count == 0
+
+
+def test_scalar_root_passes_through() -> None:
+    outcome = redact_raw(ConfigFileKind.SERVER, "not-a-mapping")
+    assert outcome.value == "not-a-mapping"
+    assert outcome.count == 0
+
+
+def test_empty_mapping_passes_through() -> None:
+    outcome = redact_raw(ConfigFileKind.SERVER, {})
+    assert outcome.value == {}
+    assert outcome.count == 0

--- a/tests/config/test__redact_raw.py
+++ b/tests/config/test__redact_raw.py
@@ -340,6 +340,83 @@ def test_at_a_non_secret_path_changes_nothing() -> None:
 
 
 # ---------------------------------------------------------------------------
+# scope of the discriminator exemption
+# ---------------------------------------------------------------------------
+
+
+def test_nested_type_key_inside_a_secret_block_is_scrubbed() -> None:
+    """The exemption covers the flagged field's own mapping, not every
+    mapping beneath it. This runs on unvalidated data, where a deeper
+    key named ``type`` need not be a discriminator -- exempting it
+    everywhere printed a literal secret verbatim.
+    """
+    outcome = redact_raw(
+        ConfigFileKind.ENTERPRISE_SYSTEM,
+        {
+            "auth": {
+                "credentials": {
+                    "type": "custom",
+                    "extra": {"type": "literal-secret"},
+                }
+            }
+        },
+    )
+    credentials = outcome.value["auth"]["credentials"]
+    assert credentials["type"] == "custom"
+    assert credentials["extra"] == {"type": "[REDACTED]"}
+    assert outcome.count == 1
+
+
+def test_nested_type_key_is_scrubbed_inside_a_list() -> None:
+    """A list at the point carries the point's own values, so its
+    elements keep the exemption while their nested mappings do not."""
+    outcome = redact_raw(
+        ConfigFileKind.ENTERPRISE_SYSTEM,
+        {"auth": {"credentials": [{"type": "psk", "inner": {"type": "s3cret"}}]}},
+    )
+    entry = outcome.value["auth"]["credentials"][0]
+    assert entry["type"] == "psk"
+    assert entry["inner"] == {"type": "[REDACTED]"}
+    assert outcome.count == 1
+
+
+def test_directly_addressed_discriminator_is_not_redacted() -> None:
+    """``config get ...credentials.type`` must agree with the value the
+    whole-block view shows, and must not warn of a disclosure."""
+    outcome = redact_raw(
+        ConfigFileKind.ENTERPRISE_SYSTEM,
+        "psk",
+        at=_CREDENTIALS + _DISCRIMINATOR,
+    )
+    assert outcome.value == "psk"
+    assert outcome.count == 0
+
+
+def test_directly_addressed_discriminator_agrees_with_the_block_view() -> None:
+    """The two routes to the same field are the contract; pin them
+    together so neither can drift."""
+    block = redact_raw(
+        ConfigFileKind.ENTERPRISE_SYSTEM,
+        {"type": "psk", "token": "literal"},
+        at=_CREDENTIALS,
+    )
+    direct = redact_raw(
+        ConfigFileKind.ENTERPRISE_SYSTEM, "psk", at=_CREDENTIALS + _DISCRIMINATOR
+    )
+    assert direct.value == block.value["type"]
+
+
+def test_a_sibling_of_the_discriminator_is_still_redacted() -> None:
+    """The exemption is keyed to the discriminator name, not to being
+    addressed directly -- a real secret leaf stays covered."""
+    outcome = redact_raw(
+        ConfigFileKind.ENTERPRISE_SYSTEM, "literal", at=_CREDENTIALS + "token"
+    )
+    assert outcome.value == "[REDACTED]"
+    assert outcome.count == 1
+
+
+# ---------------------------------------------------------------------------
 # values the schema does not describe
 # ---------------------------------------------------------------------------
 

--- a/tests/config/test__templating.py
+++ b/tests/config/test__templating.py
@@ -14,6 +14,7 @@ from deephaven_mcp.config._templating import (
     expand_tree,
     expand_tree_lenient,
     is_single_placeholder,
+    replace_placeholder_default,
 )
 
 # ---------------------------------------------------------------------------
@@ -26,6 +27,10 @@ from deephaven_mcp.config._templating import (
     [
         ("${env:DH_PSK}", True),
         ("${file:/etc/ssl/key.pem}", True),
+        # Structurally a lone placeholder even though it embeds a literal
+        # fallback; masking that literal is replace_placeholder_default's
+        # job, not this predicate's.
+        ("${env:DH_PSK:-s3cret}", True),
         # A literal prefix may itself be sensitive, so the string is a
         # value, not a bare reference.
         ("tok-${env:DH_PSK}", False),
@@ -45,6 +50,57 @@ def test_is_single_placeholder(value: str, expected: bool) -> None:
     """Distinguishes a value that *points* at a secret from one that *is*
     a secret. Redaction leans on this to keep a bare reference legible."""
     assert is_single_placeholder(value) is expected
+
+
+# ---------------------------------------------------------------------------
+# replace_placeholder_default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # The leak this function exists to close: the fallback is a
+        # literal secret sitting inside an otherwise-safe reference.
+        ("${env:DH_PSK:-s3cret}", "${env:DH_PSK:-[REDACTED]}"),
+        # Split on the *first* ``:-`` only; a fallback may contain colons.
+        ("${env:X:-a:b:c}", "${env:X:-[REDACTED]}"),
+        # Kind-agnostic: raw file content may carry an unvalidated kind.
+        ("${bogus:x:-sneaky}", "${bogus:x:-[REDACTED]}"),
+        # Nothing to mask.
+        ("${env:DH_PSK}", None),
+        ("${file:/etc/ssl/key.pem}", None),
+        # An empty fallback resolves to the empty string, disclosing
+        # nothing, so it is left legible rather than implying a secret.
+        ("${env:X:-}", None),
+        # Not a lone placeholder, so out of contract; the caller redacts
+        # the whole value instead.
+        ("tok-${env:X:-s3cret}", None),
+        ("plain-secret", None),
+        ("", None),
+    ],
+)
+def test_replace_placeholder_default(value: str, expected: str | None) -> None:
+    """Masks a ``:-`` fallback literal while leaving the variable name
+    legible, so a redacted view stays useful for diagnosing config."""
+    assert replace_placeholder_default(value, replacement="[REDACTED]") == expected
+
+
+def test_replace_placeholder_default_honors_replacement() -> None:
+    """The replacement text is caller-chosen, not hardcoded."""
+    assert (
+        replace_placeholder_default("${env:X:-s3cret}", replacement="***")
+        == "${env:X:-***}"
+    )
+
+
+def test_replace_placeholder_default_never_leaks_the_literal() -> None:
+    """The whole point: the fallback must not survive into the output."""
+    masked = replace_placeholder_default(
+        "${env:DH_PSK:-hunter2}", replacement="[REDACTED]"
+    )
+    assert masked is not None
+    assert "hunter2" not in masked
 
 
 # ---------------------------------------------------------------------------

--- a/tests/config/test__templating.py
+++ b/tests/config/test__templating.py
@@ -13,7 +13,39 @@ from deephaven_mcp.config._templating import (
     expand_string,
     expand_tree,
     expand_tree_lenient,
+    is_single_placeholder,
 )
+
+# ---------------------------------------------------------------------------
+# is_single_placeholder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("${env:DH_PSK}", True),
+        ("${file:/etc/ssl/key.pem}", True),
+        # A literal prefix may itself be sensitive, so the string is a
+        # value, not a bare reference.
+        ("tok-${env:DH_PSK}", False),
+        ("${env:DH_PSK}-suffix", False),
+        # Two adjacent placeholders are a concatenation, not one
+        # reference: ``[^}]+`` cannot span the intervening ``}``.
+        ("${env:A}${env:B}", False),
+        # Syntactically malformed forms are values here; they fail later,
+        # at load time, with a proper error.
+        ("${}", False),
+        ("${env:A", False),
+        ("", False),
+        ("plain-secret", False),
+    ],
+)
+def test_is_single_placeholder(value: str, expected: bool) -> None:
+    """Distinguishes a value that *points* at a secret from one that *is*
+    a secret. Redaction leans on this to keep a bare reference legible."""
+    assert is_single_placeholder(value) is expected
+
 
 # ---------------------------------------------------------------------------
 # JsonLoc

--- a/tests/mcp_systems_server/_tools/test_session_community.py
+++ b/tests/mcp_systems_server/_tools/test_session_community.py
@@ -1651,12 +1651,17 @@ def test_session_creation_defaults_rejects_invalid_programming_language():
 
 
 @pytest.mark.asyncio
-async def test_session_community_credentials_disabled_by_default():
-    """Test that credential retrieval is disabled by default (mode='none')."""
+async def test_session_community_credentials_dynamic_allowed_by_default():
+    """An absent ``security`` block permits dynamic retrieval.
+
+    The default is ``dynamic_only``, so the mode gate must not be what
+    stops this call; without it the verbs that open a dynamic session
+    cannot work out of the box.
+    """
     mock_config_manager = MagicMock()
     mock_session_registry = MagicMock(spec=CommunitySessionRegistry)
 
-    # Config without security section (defaults to mode='none')
+    # Config without a security section: the schema default applies.
     config = {
         "session_creation": {
             "max_concurrent_sessions": 5,
@@ -1678,13 +1683,7 @@ async def test_session_community_credentials_disabled_by_default():
 
     result = await session_community_credentials(context, id="community:community:1")
 
-    assert result["success"] is False
-    assert result["isError"] is True
-    assert "Credential retrieval is disabled" in result["error"]
-    assert "mode='none'" in result["error"]
-    assert "security" in result["error"]
-    assert "credential_retrieval_mode" in result["error"]
-    assert "community/settings.json" in result["error"]
+    assert "Credential retrieval is disabled" not in result["error"]
 
 
 @pytest.mark.asyncio
@@ -1714,6 +1713,10 @@ async def test_session_community_credentials_explicit_none():
     assert result["isError"] is True
     assert "Credential retrieval is disabled" in result["error"]
     assert "mode='none'" in result["error"]
+    # The remediation must name the knob and the file that holds it.
+    assert "security" in result["error"]
+    assert "credential_retrieval_mode" in result["error"]
+    assert "community/settings.json" in result["error"]
 
 
 @pytest.mark.asyncio
@@ -1822,11 +1825,11 @@ async def test_session_community_credentials_anonymous_auth():
 
 @pytest.mark.asyncio
 async def test_session_community_credentials_no_config():
-    """Test when community config is empty."""
+    """An entirely empty community config still permits dynamic retrieval."""
     mock_config_manager = MagicMock()
     mock_session_registry = MagicMock(spec=CommunitySessionRegistry)
 
-    # Empty config - should default to disabled
+    # Empty config - every field falls back to its schema default.
     config = {}
     mock_config_manager.get_config = AsyncMock(return_value=config)
     # Stash for _helpers' lifespan adapter (security tests use ``config``
@@ -1842,10 +1845,7 @@ async def test_session_community_credentials_no_config():
 
     result = await session_community_credentials(context, id="community:community:1")
 
-    assert result["success"] is False
-    assert result["isError"] is True
-    assert "Credential retrieval is disabled" in result["error"]
-    assert "mode='none'" in result["error"]
+    assert "Credential retrieval is disabled" not in result["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/mcp_systems_server/test__http.py
+++ b/tests/mcp_systems_server/test__http.py
@@ -463,7 +463,10 @@ def test_plan_daemon_ignores_server_json_psk(tmp_path):
     )
     try:
         assert plan.psk
-        assert plan.psk != "from-server-json"
+        # Unwrap: ``plan.psk`` is a SecretStr, and ``SecretStr(x) != x``
+        # is true for every x, so comparing the wrapper to a plain str
+        # would pass even if the configured PSK were reused verbatim.
+        assert plan.psk.get_secret_value() != "from-server-json"
     finally:
         plan.bind.close_unhanded()
 

--- a/tests/mcp_systems_server/test__http.py
+++ b/tests/mcp_systems_server/test__http.py
@@ -139,12 +139,14 @@ def test_is_loopback_host_unparseable_resolved_addr_is_false():
 def test_resolve_psk_or_exit_cli_flag_wins(tmp_path):
     """CLI ``--psk`` takes precedence over ``server.json``'s ``psk`` field."""
     server_cfg = ServerConfig.model_validate({"psk": "from-server-json"})
-    assert _resolve_psk_or_exit("from-cli", server_cfg, tmp_path) == "from-cli"
+    resolved = _resolve_psk_or_exit("from-cli", server_cfg, tmp_path)
+    assert resolved.get_secret_value() == "from-cli"
 
 
 def test_resolve_psk_or_exit_uses_server_json_psk(tmp_path):
     server_cfg = ServerConfig.model_validate({"psk": "hunter2"})
-    assert _resolve_psk_or_exit(None, server_cfg, tmp_path) == "hunter2"
+    resolved = _resolve_psk_or_exit(None, server_cfg, tmp_path)
+    assert resolved.get_secret_value() == "hunter2"
 
 
 def test_resolve_psk_or_exit_missing_psk_exits(tmp_path):
@@ -192,7 +194,8 @@ def test_resolve_psk_or_exit_treats_empty_cli_psk_as_missing_with_server_json(
     Empty CLI PSK is missing; server.json's PSK fills in.
     """
     server_cfg = ServerConfig.model_validate({"psk": "from-json"})
-    assert _resolve_psk_or_exit("", server_cfg, tmp_path) == "from-json"
+    resolved = _resolve_psk_or_exit("", server_cfg, tmp_path)
+    assert resolved.get_secret_value() == "from-json"
 
 
 # ---------------------------------------------------------------------------
@@ -290,7 +293,7 @@ def test_http_run_daemon_bundles_handle_and_process_name():
         multi_config=MagicMock(),
         runtime_dir=Path("/tmp/runtime"),
         server_name="srv",
-        psk="x" * 32,
+        psk=SecretStr("x" * 32),
         bind=bind,
         idle_seconds=0,
         daemon=http_module._DaemonPublish(
@@ -309,7 +312,7 @@ def test_http_run_default_has_no_daemon():
         multi_config=MagicMock(),
         runtime_dir=Path("/tmp/runtime"),
         server_name="srv",
-        psk="x" * 32,
+        psk=SecretStr("x" * 32),
         bind=bind,
         idle_seconds=0,
         daemon=None,
@@ -344,7 +347,7 @@ def test_plan_default_resolves_cli_overrides(tmp_path):
     assert plan.bind.host == "127.0.0.1"
     assert plan.bind.port == 8765
     assert plan.bind.sock is None
-    assert plan.psk == "from-cli"
+    assert plan.psk.get_secret_value() == "from-cli"
     assert plan.idle_seconds == 0
     assert plan.daemon is None
     assert plan.server_name == server_cfg.server_name
@@ -368,7 +371,7 @@ def test_plan_default_falls_back_to_server_cfg(tmp_path):
     )
     assert plan.bind.host == "127.0.0.1"
     assert plan.bind.port == 9000
-    assert plan.psk == "from-json"
+    assert plan.psk.get_secret_value() == "from-json"
 
 
 def test_plan_default_exits_on_non_loopback(tmp_path):
@@ -440,7 +443,7 @@ def test_plan_daemon_uses_cli_psk_override(tmp_path):
         cli_psk="operator-explicit-secret",
     )
     try:
-        assert plan.psk == "operator-explicit-secret"
+        assert plan.psk.get_secret_value() == "operator-explicit-secret"
     finally:
         plan.bind.close_unhanded()
 
@@ -543,7 +546,7 @@ def _operator_plan(*, psk: str = "secret", port: int = 9999) -> "http_module._Ht
         multi_config=MagicMock(),
         runtime_dir=Path("/tmp/runtime"),
         server_name="srv",
-        psk=psk,
+        psk=SecretStr(psk),
         bind=http_module._BindSpec(host="127.0.0.1", port=port, sock=None),
         idle_seconds=0,
         daemon=None,
@@ -956,7 +959,9 @@ def test_build_http_app_psk_gate_enforced_end_to_end() -> None:
     fake_server = MagicMock()
     fake_server.streamable_http_app = MagicMock(return_value=real_app)
 
-    app = http_module._build_http_app(fake_server, psk=psk, activity_timer=None)
+    app = http_module._build_http_app(
+        fake_server, psk=SecretStr(psk), activity_timer=None
+    )
     client = TestClient(app)
 
     # No PSK header -> gate rejects with 401 before reaching the route.
@@ -1041,7 +1046,7 @@ def _operator_run(*, psk: str = "secret") -> "http_module._HttpRun":
         multi_config=MagicMock(config_dir=Path("/tmp/cfg")),
         runtime_dir=Path("/tmp/runtime"),
         server_name="srv",
-        psk=psk,
+        psk=SecretStr(psk),
         bind=http_module._BindSpec(host="127.0.0.1", port=8000, sock=None),
         idle_seconds=0,
         daemon=None,
@@ -1170,7 +1175,7 @@ def _daemon_publish_plan(handle: DaemonDirectory) -> "http_module._HttpRun":
         multi_config=type("M", (), {"config_dir": Path("/tmp/cfg")})(),
         runtime_dir=Path("/tmp/runtime"),
         server_name="srv",
-        psk="secret",
+        psk=SecretStr("secret"),
         bind=http_module._BindSpec(host="127.0.0.1", port=22000, sock=None),
         idle_seconds=0,
         daemon=http_module._DaemonPublish(handle=handle, process_name="python"),

--- a/tests/mcp_systems_server/test_server.py
+++ b/tests/mcp_systems_server/test_server.py
@@ -261,7 +261,7 @@ def test_main_http_path_uses_server_json_values(_mute_logging_setup):
         main([])
     mock_http.assert_called_once()
     plan = mock_http.call_args.args[0]
-    assert plan.psk == "json-psk"
+    assert plan.psk.get_secret_value() == "json-psk"
     assert plan.bind.host == "::1"
     assert plan.bind.port == 9000
 

--- a/tests/scripts/test_convert_config_v1_to_v2.py
+++ b/tests/scripts/test_convert_config_v1_to_v2.py
@@ -408,9 +408,16 @@ def test_convert_names_with_dash_underscore_accepted():
     assert "community/sessions/my-session_2.json" in result.files
 
 
-def test_convert_credential_mode_none_omits_security_block():
+def test_convert_credential_mode_none_is_preserved():
+    """An explicit 'none' must survive conversion.
+
+    Omitting it would inherit the v2 schema default ('dynamic_only') and
+    silently widen the posture the v1 file asked for.
+    """
     v1 = {"security": {"community": {"credential_retrieval_mode": "none"}}}
-    assert conv.convert(v1).files == {}
+    assert conv.convert(v1).files == {
+        "community/settings.json": {"security": {"credential_retrieval_mode": "none"}}
+    }
 
 
 def test_convert_docker_image_maps_to_configured_language():


### PR DESCRIPTION
This pull request updates documentation and configuration to clarify and improve credential handling, output settings, and configuration key usage for the Deephaven CLI and Community server. The main themes are improved security documentation, more precise configuration paths, and clearer descriptions of how secrets and output modes are handled.

**Security and credential handling:**
* Updated the description of credential-disclosure behavior in `SECURITY.md` to clarify the default and opt-in behavior for session tokens, and that these are deliberate, documented choices, not defects.
* Changed the default `credential_retrieval_mode` in `config-samples/ai/config/community/settings.json` from `"none"` to `"dynamic_only"`, enabling session token retrieval for dynamically created sessions by default.
* Expanded documentation in `docs/CLI.md` to clarify which commands print or handle session tokens, how `--reveal-secrets` works, and when secrets are redacted or disclosed. [[1]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L404-R410) [[2]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L501-R509) [[3]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L517-R523) [[4]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L850-R856)

**Configuration and CLI documentation:**
* Updated all references to configuration keys in `docs/CLI.md` to use the new `cli.*` path (e.g., `cli.output.format`, `cli.context.enabled`, `cli.daemon.reuse`) instead of the old `cli.json`-based paths, for consistency and clarity. [[1]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L720-R726) [[2]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L737-R743) [[3]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L757-R764) [[4]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L798-R804) [[5]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L874-R881) [[6]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L889-R895) [[7]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L1022-R1033) [[8]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L1047-R1057) [[9]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L1124-R1131) [[10]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L1137-R1142) [[11]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L1201-R1207)

**Behavior and usage improvements:**
* Clarified the behavior of output modes, especially how to set human-readable output, and updated examples and descriptions to use the new configuration paths.
* Added details about how secrets are handled in output and logs, including when they are redacted and how to opt in to their disclosure. [[1]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L850-R856) [[2]](diffhunk://#diff-7340b8a6d2c5b52c935f75ec72038d28b8c606323ea41bd29ced4b521eae7761L404-R410)

These updates make the documentation more accurate, user-friendly, and secure by default.…uidance

Updated `security.credential_retrieval_mode` default from `none` to `dynamic_only` in Community sample config and documentation. Clarified that `dynamic_only` permits retrieval of auto-generated session tokens (from `session create`) but withholds statically configured credentials unless explicitly widened. Updated SECURITY.md to reflect this default and explain the deliberate credential-disclosure behavior. Added secret