### PR TITLE
fix: DH-23143: subscription healing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,13 @@ markers = [
 ]
 asyncio_mode = "strict"
 filterwarnings = [
-    "ignore:The NumPy module was reloaded (imported a second time).*:UserWarning"
+    "ignore:The NumPy module was reloaded (imported a second time).*:UserWarning",
+    # FastMCP's Settings model (pydantic-settings) declares a 'lifespan' field
+    # with a forward-reference annotation it never rebuilds; the resulting
+    # warning originates in the dependency, not our code. Matched by message so
+    # the filter holds across pydantic-settings versions (the warning class is
+    # absent in older ones).
+    "ignore:Field .* has an incomplete definition:",
 ]
 asyncio_default_fixture_loop_scope = "function"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,11 @@ ignore-words-list = "unparseable"
 # Pytest configuration for testing
 [tool.pytest.ini_options]
 testpaths = ["tests"]  # Directory containing test files
-addopts = "-W error -W ignore::pytest.PytestUnraisableExceptionWarning --cov=deephaven_mcp --cov-report=term-missing --cov-report=xml -m 'not integration'"
+# The pydantic-settings 'lifespan' ignore lives here, not in filterwarnings
+# below, because command-line -W filters outrank ini filterwarnings: -W error
+# would otherwise re-promote it. FastMCP's Settings model emits it (a field with
+# an unrebuilt forward reference); matched by message to hold across versions.
+addopts = "-W error -W ignore::pytest.PytestUnraisableExceptionWarning -W \"ignore:Field 'lifespan' has an incomplete definition\" --cov=deephaven_mcp --cov-report=term-missing --cov-report=xml -m 'not integration'"
 python_files = ["test_*.py"]  # Test file naming pattern
 python_classes = ["Test"]  # Test class naming pattern
 python_functions = ["test_"]  # Test function naming pattern
@@ -170,12 +174,6 @@ markers = [
 asyncio_mode = "strict"
 filterwarnings = [
     "ignore:The NumPy module was reloaded (imported a second time).*:UserWarning",
-    # FastMCP's Settings model (pydantic-settings) declares a 'lifespan' field
-    # with a forward-reference annotation it never rebuilds; the resulting
-    # warning originates in the dependency, not our code. Matched by message so
-    # the filter holds across pydantic-settings versions (the warning class is
-    # absent in older ones).
-    "ignore:Field .* has an incomplete definition:",
 ]
 asyncio_default_fixture_loop_scope = "function"
 

--- a/src/deephaven_mcp/client/_controller_client.py
+++ b/src/deephaven_mcp/client/_controller_client.py
@@ -66,10 +66,9 @@ from ._timeouts import EnterpriseClientTimeouts
 
 _LOGGER = logging.getLogger(__name__)
 
-_POISONED_SUBSCRIPTION_MESSAGE = (
-    "Controller subscription is stuck in the SUBSCRIBING state and can never "
-    "complete; the enterprise connection is poisoned. Reconnect the enterprise "
-    "system (recreate the session factory) or restart the MCP server to recover."
+_CONTROLLER_UNAVAILABLE_MESSAGE = (
+    "Unable to connect to the Deephaven controller; the enterprise session "
+    "must be restarted to reconnect."
 )
 
 
@@ -175,22 +174,23 @@ class CorePlusControllerClient(ClientObjectWrapper[ControllerClient]):
         return self.wrapped.sub_state is SubState.SUBSCRIBING
 
     def _raise_if_poisoned(self, operation: str) -> None:
-        """Fast-fail a subscription-dependent read when the client is poisoned.
+        """Fast-fail a subscription-dependent read when the controller is unreachable.
 
-        Skips the vendor's multi-minute subscription wait when the subscription
-        can never complete.
+        Skips the vendor's multi-minute subscription wait when the controller
+        connection can no longer be established.
 
         Args:
             operation (str): Name of the calling method, for the log prefix.
 
         Raises:
-            QueryError: If the subscription is wedged at ``SUBSCRIBING``.
+            DeephavenConnectionError: If the controller connection is wedged and
+                cannot be re-established.
         """
         if self.is_poisoned:
             _LOGGER.error(
-                f"[CorePlusControllerClient:{operation}] {_POISONED_SUBSCRIPTION_MESSAGE}"
+                f"[CorePlusControllerClient:{operation}] {_CONTROLLER_UNAVAILABLE_MESSAGE}"
             )
-            raise QueryError(_POISONED_SUBSCRIPTION_MESSAGE)
+            raise DeephavenConnectionError(_CONTROLLER_UNAVAILABLE_MESSAGE)
 
     async def ping(self) -> bool:
         """Ping the controller and refresh the cookie asynchronously.
@@ -317,13 +317,14 @@ class CorePlusControllerClient(ClientObjectWrapper[ControllerClient]):
                 )
                 return
 
-            # A wedged mid-subscribe stream cannot be adopted and must not be
-            # raced with a second stream; the factory has to be recreated.
+            # Vendor is mid-subscribe. The subscription isn't ready to adopt, 
+            # and falling through would open a second competing stream. 
+            # Fail fast; the factory will be recreated to reconnect.
             if self.wrapped.sub_state is SubState.SUBSCRIBING:
                 _LOGGER.error(
-                    f"[CorePlusControllerClient:subscribe] {_POISONED_SUBSCRIPTION_MESSAGE}"
+                    f"[CorePlusControllerClient:subscribe] {_CONTROLLER_UNAVAILABLE_MESSAGE}"
                 )
-                raise DeephavenConnectionError(_POISONED_SUBSCRIPTION_MESSAGE)
+                raise DeephavenConnectionError(_CONTROLLER_UNAVAILABLE_MESSAGE)
 
             _LOGGER.debug(
                 f"[CorePlusControllerClient:subscribe] Subscribing to query state (timeout_seconds={timeout_seconds})"

--- a/src/deephaven_mcp/client/_controller_client.py
+++ b/src/deephaven_mcp/client/_controller_client.py
@@ -317,8 +317,8 @@ class CorePlusControllerClient(ClientObjectWrapper[ControllerClient]):
                 )
                 return
 
-            # Vendor is mid-subscribe. The subscription isn't ready to adopt, 
-            # and falling through would open a second competing stream. 
+            # Vendor is mid-subscribe. The subscription isn't ready to adopt,
+            # and falling through would open a second competing stream.
             # Fail fast; the factory will be recreated to reconnect.
             if self.wrapped.sub_state is SubState.SUBSCRIBING:
                 _LOGGER.error(

--- a/src/deephaven_mcp/client/_controller_client.py
+++ b/src/deephaven_mcp/client/_controller_client.py
@@ -66,6 +66,12 @@ from ._timeouts import EnterpriseClientTimeouts
 
 _LOGGER = logging.getLogger(__name__)
 
+_POISONED_SUBSCRIPTION_MESSAGE = (
+    "Controller subscription is stuck in the SUBSCRIBING state and can never "
+    "complete; the enterprise connection is poisoned. Reconnect the enterprise "
+    "system (recreate the session factory) or restart the MCP server to recover."
+)
+
 
 class CorePlusControllerClient(ClientObjectWrapper[ControllerClient]):
     """Asynchronous wrapper around the ControllerClient for managing persistent queries.
@@ -150,6 +156,41 @@ class CorePlusControllerClient(ClientObjectWrapper[ControllerClient]):
     # ===========================================================================
     # Initialization & Connection Management
     # ===========================================================================
+
+    @property
+    def is_poisoned(self) -> bool:
+        """Whether the underlying subscription is wedged and can never complete.
+
+        A poisoned client has its vendor ``sub_state`` stuck at ``SUBSCRIBING``
+        (e.g. after a subscribe timeout, or a failed background re-subscription
+        started by the vendor response thread). Every subscription-dependent
+        read (:meth:`map`, :meth:`map_and_version`, :meth:`get`,
+        :meth:`get_serial_for_name`) would otherwise block for the vendor's full
+        subscription timeout before failing. The client cannot heal itself; the
+        owning factory must be recreated to recover.
+
+        Returns:
+            bool: True if the vendor subscription is wedged at ``SUBSCRIBING``.
+        """
+        return self.wrapped.sub_state is SubState.SUBSCRIBING
+
+    def _raise_if_poisoned(self, operation: str) -> None:
+        """Fast-fail a subscription-dependent read when the client is poisoned.
+
+        Skips the vendor's multi-minute subscription wait when the subscription
+        can never complete.
+
+        Args:
+            operation (str): Name of the calling method, for the log prefix.
+
+        Raises:
+            QueryError: If the subscription is wedged at ``SUBSCRIBING``.
+        """
+        if self.is_poisoned:
+            _LOGGER.error(
+                f"[CorePlusControllerClient:{operation}] {_POISONED_SUBSCRIPTION_MESSAGE}"
+            )
+            raise QueryError(_POISONED_SUBSCRIPTION_MESSAGE)
 
     async def ping(self) -> bool:
         """Ping the controller and refresh the cookie asynchronously.
@@ -267,7 +308,7 @@ class CorePlusControllerClient(ClientObjectWrapper[ControllerClient]):
             # rather than opening a second stream — the controller server allows
             # one subscription stream per session, so a second stream starts an
             # infinite mutual kill/re-subscribe loop between response threads.
-            if self.wrapped.sub_state is not SubState.NOT_SUBSCRIBED:
+            if self.wrapped.sub_state is SubState.SUBSCRIBED:
                 self._subscribed = True
                 _LOGGER.debug(
                     "[CorePlusControllerClient:subscribe] Wrapped client already "
@@ -275,6 +316,14 @@ class CorePlusControllerClient(ClientObjectWrapper[ControllerClient]):
                     "subscription"
                 )
                 return
+
+            # A wedged mid-subscribe stream cannot be adopted and must not be
+            # raced with a second stream; the factory has to be recreated.
+            if self.wrapped.sub_state is SubState.SUBSCRIBING:
+                _LOGGER.error(
+                    f"[CorePlusControllerClient:subscribe] {_POISONED_SUBSCRIPTION_MESSAGE}"
+                )
+                raise DeephavenConnectionError(_POISONED_SUBSCRIPTION_MESSAGE)
 
             _LOGGER.debug(
                 f"[CorePlusControllerClient:subscribe] Subscribing to query state (timeout_seconds={timeout_seconds})"
@@ -356,6 +405,7 @@ class CorePlusControllerClient(ClientObjectWrapper[ControllerClient]):
                 "subscribe() must be called before map(). This indicates a programming bug - "
                 "the controller client was not properly initialized."
             )
+        self._raise_if_poisoned("map")
         _LOGGER.debug("[CorePlusControllerClient:map] Retrieving query map")
         try:
             # The map is from int to QueryInfo, but we need to cast the keys to QuerySerial
@@ -413,6 +463,7 @@ class CorePlusControllerClient(ClientObjectWrapper[ControllerClient]):
                 "subscribe() must be called before map_and_version(). This indicates a programming bug - "
                 "the controller client was not properly initialized."
             )
+        self._raise_if_poisoned("map_and_version")
         _LOGGER.debug(
             "[CorePlusControllerClient:map_and_version] Retrieving query map with version"
         )
@@ -483,6 +534,7 @@ class CorePlusControllerClient(ClientObjectWrapper[ControllerClient]):
                 "subscribe() must be called before get_serial_for_name(). This indicates a programming bug - "
                 "the controller client was not properly initialized."
             )
+        self._raise_if_poisoned("get_serial_for_name")
         _LOGGER.debug(
             f"[CorePlusControllerClient:get_serial_for_name] Looking up serial for query name='{name}'"
         )
@@ -667,6 +719,7 @@ class CorePlusControllerClient(ClientObjectWrapper[ControllerClient]):
                        the subscription state is invalid (e.g., if subscribe() was not called).
         """
         timeout_seconds = self._timeouts.no_wait_seconds
+        self._raise_if_poisoned("get")
         _LOGGER.debug(
             f"[CorePlusControllerClient:get] Retrieving query info for serial={serial}, timeout={timeout_seconds}"
         )

--- a/src/deephaven_mcp/mcp_systems_server/_tools/pq.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/pq.py
@@ -621,14 +621,14 @@ async def _setup_batch_pq_operation(
     _LOGGER.debug(
         f"[mcp_systems_server:{function_name}] Connecting to enterprise factory"
     )
-    factory = await factory_manager.get()
+    controller = await factory_manager.get_controller_client()
     _LOGGER.debug(
         f"[mcp_systems_server:{function_name}] Connected to enterprise factory"
     )
 
     return _BatchPqSetup(
         parsed_pqs=parsed_pqs,
-        controller=factory.controller_client,
+        controller=controller,
         max_concurrent=validated_max_concurrent,
         system_name=system_name,
     )
@@ -785,13 +785,10 @@ async def pq_name_to_id(
         _LOGGER.debug(
             "[mcp_systems_server:pq_name_to_id] Connecting to enterprise factory"
         )
-        factory = await factory_manager.get()
+        controller = await factory_manager.get_controller_client()
         _LOGGER.debug(
             "[mcp_systems_server:pq_name_to_id] Connected to enterprise factory"
         )
-
-        # Get controller client
-        controller = factory.controller_client
 
         # Look up serial by name
         try:
@@ -912,11 +909,8 @@ async def pq_list(
         )
         factory_manager = session_registry.factory_manager
         _LOGGER.debug("[mcp_systems_server:pq_list] Connecting to enterprise factory")
-        factory = await factory_manager.get()
+        controller = await factory_manager.get_controller_client()
         _LOGGER.debug("[mcp_systems_server:pq_list] Connected to enterprise factory")
-
-        # Get controller client
-        controller = factory.controller_client
 
         # Get all PQs from controller
         _LOGGER.debug(
@@ -1193,11 +1187,8 @@ async def pq_details(
         _LOGGER.debug(
             "[mcp_systems_server:pq_details] Connecting to enterprise factory"
         )
-        factory = await factory_manager.get()
+        controller = await factory_manager.get_controller_client()
         _LOGGER.debug("[mcp_systems_server:pq_details] Connected to enterprise factory")
-
-        # Get controller client
-        controller = factory.controller_client
 
         # Get all PQs from controller (ensures subscription is ready)
         # Then extract the specific PQ by serial
@@ -1463,11 +1454,8 @@ async def pq_create(
         )
         factory_manager = session_registry.factory_manager
         _LOGGER.debug("[mcp_systems_server:pq_create] Connecting to enterprise factory")
-        factory = await factory_manager.get()
+        controller = await factory_manager.get_controller_client()
         _LOGGER.debug("[mcp_systems_server:pq_create] Connected to enterprise factory")
-
-        # Get controller client
-        controller = factory.controller_client
 
         # Create PQ configuration (the client normalizes programming_language)
         pq_config = await controller.make_pq_config(
@@ -1918,11 +1906,8 @@ async def pq_modify(
 
         factory_manager = session_registry.factory_manager
         _LOGGER.debug("[mcp_systems_server:pq_modify] Connecting to enterprise factory")
-        factory = await factory_manager.get()
+        controller = await factory_manager.get_controller_client()
         _LOGGER.debug("[mcp_systems_server:pq_modify] Connected to enterprise factory")
-
-        # Get controller client
-        controller = factory.controller_client
 
         # Get all PQs from controller (ensures subscription is ready)
         # Then extract the specific PQ by serial

--- a/src/deephaven_mcp/mcp_systems_server/_tools/session_enterprise.py
+++ b/src/deephaven_mcp/mcp_systems_server/_tools/session_enterprise.py
@@ -1079,8 +1079,7 @@ async def session_enterprise_delete(
         # caller can retry.
         try:
             serial = CorePlusQuerySerial(int(qsid.session_id))
-            factory = await session_registry.factory_manager.get()
-            controller = factory.controller_client
+            controller = await session_registry.factory_manager.get_controller_client()
             _LOGGER.debug(
                 f"[mcp_systems_server:session_enterprise_delete] Deleting persistent query "
                 f"(serial={serial}) for session '{id}'"

--- a/src/deephaven_mcp/resource_manager/_manager.py
+++ b/src/deephaven_mcp/resource_manager/_manager.py
@@ -2945,30 +2945,31 @@ class CorePlusSessionFactoryManager(BaseItemManager[CorePlusSessionFactory]):
         self._creds = creds
         self._timeouts = timeouts
         self._controller_heal_lock = asyncio.Lock()
+        self._controller_reconnect_attempted = False
 
     async def get_controller_client(self) -> CorePlusControllerClient:
-        """Return a controller client with a live subscription, healing a poisoned one.
+        """Return the factory's controller client, reconnecting once if it is unreachable.
 
-        Obtains the cached factory's controller client and returns it directly
-        when its subscription is healthy. When the subscription is poisoned
-        (wedged at ``SUBSCRIBING`` — see
-        :attr:`CorePlusControllerClient.is_poisoned`), the client cannot recover
-        on its own, so the factory is recreated: the cached factory is closed
-        (dropping the poisoned vendor ``SessionManager``) and a fresh one is
-        built by the next :meth:`get`, which re-authenticates and re-subscribes.
+        Returns the cached factory's controller client when the controller
+        connection is healthy. When the connection has been lost (see
+        :attr:`CorePlusControllerClient.is_poisoned`), the factory is recreated
+        one time -- closing the dead factory and building a fresh one that
+        re-authenticates and reconnects. This reconnect is attempted at most once
+        for the lifetime of this manager: if it does not restore the connection,
+        the connection is treated as permanently unrecoverable and no further
+        reconnect is attempted; callers then receive a controller whose reads fail
+        fast with a clear "session must be restarted" error rather than blocking
+        on the vendor timeout.
 
-        Recreation is serialized by ``_controller_heal_lock`` so that concurrent
-        callers heal once; callers queued behind the heal re-check and return the
-        already-recovered client without recreating again.
+        Serialized by ``_controller_heal_lock`` so concurrent callers reconnect at
+        most once.
 
         Returns:
-            CorePlusControllerClient: A controller client whose subscription is
-                live, or — if recreation could not restore it — the freshly built
-                client (whose own reads then fast-fail with a clear restart
-                message rather than blocking on the vendor timeout).
+            CorePlusControllerClient: A controller client, reconnected when
+                possible; otherwise one that fails fast on use.
 
         Raises:
-            DeephavenConnectionError: If (re)creating the factory times out or the
+            DeephavenConnectionError: If recreating the factory times out or the
                 enterprise system is unreachable.
             AuthenticationError: If re-authentication fails during recreation.
             Exception: Any other error raised by factory creation.
@@ -2979,25 +2980,29 @@ class CorePlusSessionFactoryManager(BaseItemManager[CorePlusSessionFactory]):
             return controller
 
         async with self._controller_heal_lock:
-            # A concurrent caller may have already recreated the factory.
+            # Re-check under the lock: a concurrent caller may have already
+            # reconnected or used up the one-shot reconnect attempt.
             factory = await self.get()
             controller = factory.controller_client
-            if not controller.is_poisoned:
+            if not controller.is_poisoned or self._controller_reconnect_attempted:
                 return controller
 
+            # One-shot reconnect; a connection that cannot be re-established is
+            # treated as permanently unrecoverable.
+            self._controller_reconnect_attempted = True
             _LOGGER.warning(
-                f"[{self.__class__.__name__}:get_controller_client] Controller "
-                f"subscription poisoned for '{self.qualified_session_id}'; "
-                f"recreating factory to recover"
+                f"[{self.__class__.__name__}:get_controller_client] Enterprise "
+                f"controller connection lost for '{self.qualified_session_id}'; "
+                f"reconnecting"
             )
             await self.close()
             factory = await self.get()
             controller = factory.controller_client
             if controller.is_poisoned:
                 _LOGGER.error(
-                    f"[{self.__class__.__name__}:get_controller_client] Controller "
-                    f"subscription still poisoned for '{self.qualified_session_id}' "
-                    f"after recreating the factory"
+                    f"[{self.__class__.__name__}:get_controller_client] Enterprise "
+                    f"controller connection for '{self.qualified_session_id}' could "
+                    f"not be re-established; the session must be restarted"
                 )
             return controller
 
@@ -3231,6 +3236,14 @@ class CorePlusSessionFactoryManager(BaseItemManager[CorePlusSessionFactory]):
             EnterpriseSessionManager._check_liveness(): Session-level health checking counterpart
             ResourceLivenessStatus: The enum values returned by this method
         """
+        # A lost controller connection is a factory-level health failure even
+        # when the transport still pings, so surface it as its own OFFLINE reason.
+        if item.controller_client.is_poisoned:
+            return (
+                ResourceLivenessStatus.OFFLINE,
+                "controller connection unavailable",
+            )
+
         alive = await item.ping()
 
         if alive:

--- a/src/deephaven_mcp/resource_manager/_manager.py
+++ b/src/deephaven_mcp/resource_manager/_manager.py
@@ -98,6 +98,7 @@ from deephaven_mcp._taxonomy import SessionOrigin, SystemType
 from deephaven_mcp.auth.credentials import Credentials
 from deephaven_mcp.client import (
     CommunityClientTimeouts,
+    CorePlusControllerClient,
     CorePlusSession,
     CorePlusSessionFactory,
     CoreSession,
@@ -2943,6 +2944,62 @@ class CorePlusSessionFactoryManager(BaseItemManager[CorePlusSessionFactory]):
         self._system_config = system_config
         self._creds = creds
         self._timeouts = timeouts
+        self._controller_heal_lock = asyncio.Lock()
+
+    async def get_controller_client(self) -> CorePlusControllerClient:
+        """Return a controller client with a live subscription, healing a poisoned one.
+
+        Obtains the cached factory's controller client and returns it directly
+        when its subscription is healthy. When the subscription is poisoned
+        (wedged at ``SUBSCRIBING`` — see
+        :attr:`CorePlusControllerClient.is_poisoned`), the client cannot recover
+        on its own, so the factory is recreated: the cached factory is closed
+        (dropping the poisoned vendor ``SessionManager``) and a fresh one is
+        built by the next :meth:`get`, which re-authenticates and re-subscribes.
+
+        Recreation is serialized by ``_controller_heal_lock`` so that concurrent
+        callers heal once; callers queued behind the heal re-check and return the
+        already-recovered client without recreating again.
+
+        Returns:
+            CorePlusControllerClient: A controller client whose subscription is
+                live, or — if recreation could not restore it — the freshly built
+                client (whose own reads then fast-fail with a clear restart
+                message rather than blocking on the vendor timeout).
+
+        Raises:
+            DeephavenConnectionError: If (re)creating the factory times out or the
+                enterprise system is unreachable.
+            AuthenticationError: If re-authentication fails during recreation.
+            Exception: Any other error raised by factory creation.
+        """
+        factory = await self.get()
+        controller = factory.controller_client
+        if not controller.is_poisoned:
+            return controller
+
+        async with self._controller_heal_lock:
+            # A concurrent caller may have already recreated the factory.
+            factory = await self.get()
+            controller = factory.controller_client
+            if not controller.is_poisoned:
+                return controller
+
+            _LOGGER.warning(
+                f"[{self.__class__.__name__}:get_controller_client] Controller "
+                f"subscription poisoned for '{self.qualified_session_id}'; "
+                f"recreating factory to recover"
+            )
+            await self.close()
+            factory = await self.get()
+            controller = factory.controller_client
+            if controller.is_poisoned:
+                _LOGGER.error(
+                    f"[{self.__class__.__name__}:get_controller_client] Controller "
+                    f"subscription still poisoned for '{self.qualified_session_id}' "
+                    f"after recreating the factory"
+                )
+            return controller
 
     @override
     async def _create_item(self) -> CorePlusSessionFactory:

--- a/src/deephaven_mcp/resource_manager/_registry_enterprise.py
+++ b/src/deephaven_mcp/resource_manager/_registry_enterprise.py
@@ -152,9 +152,13 @@ async def _fetch_factory_pqs(
     Pure I/O function — accesses no shared registry state.
 
     Algorithm:
-        1. If no cached client, create one via ``factory_manager.get()``.
-        2. If cached client exists, ping to verify liveness; recreate if dead.
-        3. Call ``map()`` to get the current PQ list.
+        1. If the cached client is poisoned (subscription wedged), discard it.
+        2. If no live cached client, obtain one via
+           ``factory_manager.get_controller_client()`` (which recreates the
+           factory when the current controller is poisoned).
+        3. Otherwise ping the cached client to verify liveness; recreate via
+           ``get_controller_client()`` if dead.
+        4. Call ``map()`` to get the current PQ list.
 
     Args:
         snapshot (_FactorySnapshot): Factory state captured in Phase 1.
@@ -166,11 +170,17 @@ async def _fetch_factory_pqs(
     new_client: CorePlusControllerClient | None = None
 
     try:
+        if client is not None and client.is_poisoned:
+            _LOGGER.warning(
+                "[_fetch_factory_pqs] cached controller client is poisoned "
+                "(subscription wedged in SUBSCRIBING); recreating factory to recover"
+            )
+            client = None
+
         if client is None:
-            _LOGGER.debug("[_fetch_factory_pqs] no cached client, creating")
+            _LOGGER.debug("[_fetch_factory_pqs] no live cached client, creating")
             t0 = time.monotonic()
-            factory_instance = await snapshot.factory_manager.get()
-            client = factory_instance.controller_client
+            client = await snapshot.factory_manager.get_controller_client()
             new_client = client
             _LOGGER.debug(
                 f"[_fetch_factory_pqs] client created in {time.monotonic()-t0:.2f}s"
@@ -191,8 +201,7 @@ async def _fetch_factory_pqs(
                     f"({type(ping_err).__name__}: {ping_err}); discarding and recreating"
                 )
                 t0 = time.monotonic()
-                factory_instance = await snapshot.factory_manager.get()
-                client = factory_instance.controller_client
+                client = await snapshot.factory_manager.get_controller_client()
                 new_client = client
                 _LOGGER.debug(
                     f"[_fetch_factory_pqs] client recreated in {time.monotonic()-t0:.2f}s"

--- a/tests/client/test__controller_client.py
+++ b/tests/client/test__controller_client.py
@@ -1200,11 +1200,10 @@ async def test_subscribe_idempotent(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("vendor_state", ["SUBSCRIBING", "SUBSCRIBED"])
 async def test_subscribe_adopts_existing_vendor_subscription(
-    coreplus_controller_client, dummy_controller_client, vendor_state
+    coreplus_controller_client, dummy_controller_client
 ):
-    """An existing vendor-side subscription is adopted, not duplicated.
+    """A SUBSCRIBED vendor-side subscription is adopted, not duplicated.
 
     Regression test: the vendor SessionManager subscribes the controller client
     during authentication (_init_controller). Opening a second stream makes the
@@ -1214,7 +1213,7 @@ async def test_subscribe_adopts_existing_vendor_subscription(
     """
     from deephaven_enterprise.client.controller import SubState
 
-    dummy_controller_client.sub_state = SubState[vendor_state]
+    dummy_controller_client.sub_state = SubState.SUBSCRIBED
     await coreplus_controller_client.subscribe()
     dummy_controller_client.subscribe.assert_not_called()
     assert coreplus_controller_client._subscribed is True
@@ -1222,6 +1221,27 @@ async def test_subscribe_adopts_existing_vendor_subscription(
     # State-read methods are usable after adoption.
     dummy_controller_client.map.return_value = {}
     assert await coreplus_controller_client.map() == {}
+
+
+@pytest.mark.asyncio
+async def test_subscribe_poisoned_vendor_subscription_raises(
+    coreplus_controller_client, dummy_controller_client
+):
+    """A vendor client wedged at SUBSCRIBING is treated as poisoned, not adopted.
+
+    Adopting it would leave every state read blocking on the vendor's
+    subscription timeout; racing a second stream would deadlock. The wrapper
+    raises so the owning factory is recreated instead.
+    """
+    from deephaven_enterprise.client.controller import SubState
+
+    from deephaven_mcp._exceptions import DeephavenConnectionError
+
+    dummy_controller_client.sub_state = SubState.SUBSCRIBING
+    with pytest.raises(DeephavenConnectionError):
+        await coreplus_controller_client.subscribe()
+    dummy_controller_client.subscribe.assert_not_called()
+    assert coreplus_controller_client._subscribed is False
 
 
 @pytest.mark.asyncio
@@ -1260,6 +1280,55 @@ async def test_map_without_subscribe_raises_internal_error(
     with pytest.raises(InternalError) as exc_info:
         await coreplus_controller_client.map()
     assert "subscribe() must be called before map()" in str(exc_info.value)
+
+
+def test_is_poisoned_reflects_vendor_sub_state(
+    coreplus_controller_client, dummy_controller_client
+):
+    """``is_poisoned`` is True only when the vendor is wedged at SUBSCRIBING."""
+    from deephaven_enterprise.client.controller import SubState
+
+    dummy_controller_client.sub_state = SubState.SUBSCRIBING
+    assert coreplus_controller_client.is_poisoned is True
+
+    dummy_controller_client.sub_state = SubState.SUBSCRIBED
+    assert coreplus_controller_client.is_poisoned is False
+
+    dummy_controller_client.sub_state = SubState.NOT_SUBSCRIBED
+    assert coreplus_controller_client.is_poisoned is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "method, args",
+    [
+        ("map", ()),
+        ("map_and_version", ()),
+        ("get", (12345,)),
+        ("get_serial_for_name", ("some-pq",)),
+    ],
+)
+async def test_reads_fast_fail_when_poisoned(
+    coreplus_controller_client, dummy_controller_client, method, args
+):
+    """Poisoned reads raise QueryError immediately without touching the vendor.
+
+    The vendor call would otherwise block for the full subscription timeout
+    before failing; the fast-fail removes that wait and names the recovery step.
+    """
+    from deephaven_enterprise.client.controller import SubState
+
+    from deephaven_mcp._exceptions import QueryError
+
+    coreplus_controller_client._subscribed = True
+    dummy_controller_client.sub_state = SubState.SUBSCRIBING
+
+    with pytest.raises(QueryError) as exc_info:
+        await getattr(coreplus_controller_client, method)(*args)
+
+    assert "poisoned" in str(exc_info.value)
+    assert "restart" in str(exc_info.value).lower()
+    getattr(dummy_controller_client, method).assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/client/test__controller_client.py
+++ b/tests/client/test__controller_client.py
@@ -1311,23 +1311,24 @@ def test_is_poisoned_reflects_vendor_sub_state(
 async def test_reads_fast_fail_when_poisoned(
     coreplus_controller_client, dummy_controller_client, method, args
 ):
-    """Poisoned reads raise QueryError immediately without touching the vendor.
+    """Poisoned reads raise DeephavenConnectionError immediately without touching the vendor.
 
     The vendor call would otherwise block for the full subscription timeout
     before failing; the fast-fail removes that wait and names the recovery step.
     """
     from deephaven_enterprise.client.controller import SubState
 
-    from deephaven_mcp._exceptions import QueryError
+    from deephaven_mcp._exceptions import DeephavenConnectionError
 
     coreplus_controller_client._subscribed = True
     dummy_controller_client.sub_state = SubState.SUBSCRIBING
 
-    with pytest.raises(QueryError) as exc_info:
+    with pytest.raises(DeephavenConnectionError) as exc_info:
         await getattr(coreplus_controller_client, method)(*args)
 
-    assert "poisoned" in str(exc_info.value)
-    assert "restart" in str(exc_info.value).lower()
+    message = str(exc_info.value).lower()
+    assert "connect" in message
+    assert "restart" in message
     getattr(dummy_controller_client, method).assert_not_called()
 
 

--- a/tests/mcp_systems_server/_tools/test_pq.py
+++ b/tests/mcp_systems_server/_tools/test_pq.py
@@ -189,6 +189,7 @@ async def test_pq_name_to_id_success():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
     mock_controller.get_serial_for_name = AsyncMock(return_value=12345)
 
     context = MockContext(
@@ -221,6 +222,7 @@ async def test_pq_name_to_id_not_found():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
     mock_controller.get_serial_for_name = AsyncMock(
         side_effect=KeyError("PQ not found")
     )
@@ -248,6 +250,9 @@ async def test_pq_name_to_id_connection_failed():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("connection failed"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("connection failed")
+    )
 
     context = MockContext(
         {
@@ -271,6 +276,9 @@ async def test_pq_name_to_id_exception():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("Connection error"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("Connection error")
+    )
 
     context = MockContext(
         {
@@ -658,6 +666,7 @@ async def test_pq_restart_multiple():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     mock_pq_info_1 = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
     mock_pq_info_2 = create_mock_pq_info(67890, "reporting", "RUNNING", 8.0)
@@ -707,6 +716,7 @@ async def test_pq_restart_partial_failure():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     mock_pq_info_1 = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
 
@@ -758,6 +768,7 @@ async def test_pq_delete_partial_failure():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     mock_pq_info_1 = create_mock_pq_info(12345, "analytics", "STOPPED", 8.0)
     mock_pq_info_2 = create_mock_pq_info(67890, "reporting", "STOPPED", 8.0)
@@ -816,6 +827,7 @@ async def test_pq_start_partial_failure():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     async def mock_start_side_effect(serial, wait=True):
         if serial == 67890:
@@ -877,6 +889,7 @@ async def test_pq_stop_partial_failure():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     mock_pq_info = create_mock_pq_info(12345, "analytics", "STOPPED", 8.0)
 
@@ -1630,6 +1643,7 @@ async def test_pq_list_success():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Create mock PQ map
     mock_pq_map = {
@@ -1692,6 +1706,9 @@ async def test_pq_list_connection_failed():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("connection failed"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("connection failed")
+    )
 
     context = MockContext(
         {
@@ -1715,6 +1732,9 @@ async def test_pq_list_exception():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("Connection error"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("Connection error")
+    )
 
     context = MockContext(
         {
@@ -1753,6 +1773,7 @@ async def test_pq_details_success_by_name(mock_exported_enum, mock_restart_enum)
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller.map() to return PQ map (pq_details uses map() to ensure subscription is ready)
     mock_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
@@ -1869,6 +1890,7 @@ async def test_pq_details_success_by_serial():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller.map() to return PQ map (pq_details uses map() to ensure subscription is ready)
     mock_pq_info = create_mock_pq_info(12345, "analytics", "STOPPED", 8.0)
@@ -1904,6 +1926,7 @@ async def test_pq_details_not_found():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller.map() to return empty map (PQ not found)
     mock_controller.map = AsyncMock(return_value={})
@@ -1952,6 +1975,9 @@ async def test_pq_details_connection_failed():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("connection failed"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("connection failed")
+    )
 
     context = MockContext(
         {
@@ -1975,6 +2001,9 @@ async def test_pq_details_exception():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("Connection error"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("Connection error")
+    )
 
     context = MockContext(
         {
@@ -2003,6 +2032,7 @@ async def test_pq_details_not_found_by_serial():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller to return None for non-existent PQ
     mock_controller.map = AsyncMock(return_value={})
@@ -2033,6 +2063,7 @@ async def test_pq_create_success():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller methods
     mock_config = MagicMock()
@@ -2074,6 +2105,7 @@ async def test_pq_create_forwards_owner():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     mock_config = MagicMock()
     mock_config.pb = MagicMock()
@@ -2113,6 +2145,7 @@ async def test_pq_create_success_groovy():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller methods
     mock_config = MagicMock()
@@ -2155,6 +2188,7 @@ async def test_pq_create_invalid_language():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
     # pq_create now passes programming_language raw to make_pq_config, which normalizes
     # and validates it; an invalid value raises ValueError.
     mock_controller.make_pq_config = AsyncMock(
@@ -2192,6 +2226,9 @@ async def test_pq_create_connection_failed():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("connection failed"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("connection failed")
+    )
 
     context = MockContext(
         {
@@ -2217,6 +2254,9 @@ async def test_pq_create_exception():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("Connection error"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("Connection error")
+    )
 
     context = MockContext(
         {
@@ -2375,6 +2415,7 @@ async def test_pq_delete_success_by_name():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller methods
     mock_controller.delete_query = AsyncMock()
@@ -2419,6 +2460,7 @@ async def test_pq_delete_success_custom_timeout():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller methods
     mock_controller.delete_query = AsyncMock()
@@ -2473,6 +2515,9 @@ async def test_pq_delete_connection_failed():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("connection failed"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("connection failed")
+    )
 
     context = MockContext(
         {
@@ -2496,6 +2541,9 @@ async def test_pq_delete_exception():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("Connection error"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("Connection error")
+    )
 
     context = MockContext(
         {
@@ -2524,6 +2572,7 @@ async def test_pq_delete_multiple():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller methods
     mock_controller.delete_query = AsyncMock()
@@ -2664,6 +2713,7 @@ async def test_pq_modify_success():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock current PQ info - this config will be modified in-place
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
@@ -2726,6 +2776,7 @@ async def test_pq_modify_with_restart():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock current PQ info - config will be modified in-place
     current_pq_info = create_mock_pq_info(12345, "analytics", "STOPPED", 8.0)
@@ -2784,6 +2835,7 @@ async def test_pq_modify_script_body_running_no_restart_warns():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
     mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
@@ -2822,6 +2874,7 @@ async def test_pq_modify_stopped_pq_no_warning():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     current_pq_info = create_mock_pq_info(12345, "analytics", "STOPPED", 8.0)
     mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
@@ -2858,6 +2911,7 @@ async def test_pq_modify_metadata_only_no_warning():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
     mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
@@ -2894,6 +2948,7 @@ async def test_pq_modify_running_with_restart_no_warning():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
     mock_controller.map = AsyncMock(return_value={12345: current_pq_info})
@@ -2931,6 +2986,7 @@ async def test_pq_modify_script_path():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock current PQ info
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
@@ -3020,6 +3076,9 @@ async def test_pq_modify_connection_failed():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("connection failed"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("connection failed")
+    )
 
     context = MockContext(
         {
@@ -3052,6 +3111,7 @@ async def test_pq_modify_pq_not_found():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller.map() to return empty dict (PQ doesn't exist)
     mock_controller.map = AsyncMock(return_value={})
@@ -3088,6 +3148,7 @@ async def test_pq_modify_invalid_language():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock current PQ info
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
@@ -3128,6 +3189,7 @@ async def test_pq_modify_no_changes():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock current PQ info
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
@@ -3175,6 +3237,7 @@ async def test_pq_modify_all_parameters():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock current PQ info
     current_pq_info = create_mock_pq_info(12345, "old_name", "RUNNING", 8.0)
@@ -3258,6 +3321,7 @@ async def test_pq_modify_clear_auto_delete_timeout():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock current PQ info
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
@@ -3302,6 +3366,7 @@ async def test_pq_modify_set_owner():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
     current_pq_info.config.pb.owner = "authenticated-user"
@@ -3348,6 +3413,7 @@ async def test_pq_modify_invalid_restart_users_value():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock current PQ info
     current_pq_info = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
@@ -3384,6 +3450,9 @@ async def test_pq_modify_exception():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("Connection error"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("Connection error")
+    )
 
     context = MockContext(
         {
@@ -3416,6 +3485,7 @@ async def test_pq_start_success():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller methods
     mock_controller.start_and_wait = AsyncMock()
@@ -3466,6 +3536,7 @@ async def test_pq_start_already_running():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     mock_controller.start_and_wait = AsyncMock()
     mock_pq_running = create_mock_pq_info(12345, "analytics", "RUNNING", 8.0)
@@ -3519,6 +3590,9 @@ async def test_pq_start_connection_failed():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("connection failed"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("connection failed")
+    )
 
     context = MockContext(
         {
@@ -3542,6 +3616,9 @@ async def test_pq_start_exception():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("Connection error"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("Connection error")
+    )
 
     context = MockContext(
         {
@@ -3570,6 +3647,7 @@ async def test_pq_start_multiple():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller methods
     mock_controller.start_and_wait = AsyncMock()
@@ -3676,6 +3754,7 @@ async def test_pq_stop_success():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller methods - now uses stop_query
     mock_controller.stop_query = AsyncMock()
@@ -3721,6 +3800,7 @@ async def test_pq_stop_success_custom_timeout():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller methods - now uses stop_query
     mock_controller.stop_query = AsyncMock()
@@ -3804,6 +3884,9 @@ async def test_pq_stop_connection_failed():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("connection failed"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("connection failed")
+    )
 
     context = MockContext(
         {
@@ -3827,6 +3910,9 @@ async def test_pq_stop_exception():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("Connection error"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("Connection error")
+    )
 
     context = MockContext(
         {
@@ -3855,6 +3941,7 @@ async def test_pq_restart_success():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller methods (no more get_serial_for_name)
     mock_controller.restart_query = AsyncMock()
@@ -3938,6 +4025,9 @@ async def test_pq_restart_connection_failed():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("connection failed"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("connection failed")
+    )
 
     context = MockContext(
         {
@@ -3961,6 +4051,9 @@ async def test_pq_restart_exception():
 
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(side_effect=RuntimeError("Connection error"))
+    mock_factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("Connection error")
+    )
 
     context = MockContext(
         {
@@ -3989,6 +4082,7 @@ async def test_pq_stop_multiple():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller methods
     mock_controller.stop_query = AsyncMock()
@@ -4045,6 +4139,7 @@ async def test_pq_restart_multiple():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock controller methods
     mock_controller.restart_query = AsyncMock()
@@ -4214,6 +4309,7 @@ async def test_pq_delete_parallel_execution_with_semaphore():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Track execution order and timing
     execution_log = []
@@ -4288,6 +4384,7 @@ async def test_pq_delete_handles_unexpected_exception():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # First PQ succeeds, second raises unexpected exception, third succeeds
     mock_pq_info1 = create_mock_pq_info(1, "pq1", "STOPPED")
@@ -4360,6 +4457,7 @@ async def test_pq_start_parallel_execution():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Track concurrent execution
     active_operations = []
@@ -4419,6 +4517,7 @@ async def test_pq_stop_parallel_with_mixed_results():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # First and third succeed, second fails
     async def mock_stop_side_effect(serials, wait=True):
@@ -4478,6 +4577,7 @@ async def test_pq_restart_parallel_execution():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     # Mock successful restarts
     mock_controller.restart_query = AsyncMock()
@@ -4522,6 +4622,7 @@ async def test_pq_delete_exception_escapes_to_gather(monkeypatch):
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     mock_controller.delete_query = AsyncMock()
     mock_controller.get = AsyncMock(
@@ -4578,6 +4679,7 @@ async def test_pq_delete_base_exception_escapes_to_gather(monkeypatch):
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     mock_controller.delete_query = AsyncMock()
     mock_controller.get = AsyncMock(
@@ -4627,6 +4729,7 @@ async def test_pq_start_exception_escapes_to_gather(monkeypatch):
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     mock_controller.start_and_wait = AsyncMock()
     mock_controller.get = AsyncMock(
@@ -4680,6 +4783,7 @@ async def test_pq_stop_exception_escapes_to_gather(monkeypatch):
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     mock_controller.stop_query = AsyncMock()
     mock_controller.get = AsyncMock(
@@ -4733,6 +4837,7 @@ async def test_pq_restart_exception_escapes_to_gather(monkeypatch):
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     mock_controller.restart_query = AsyncMock()
     mock_controller.get = AsyncMock(
@@ -4812,6 +4917,7 @@ async def test_pq_create_auto_delete_and_schedule_mutually_exclusive():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
     mock_controller.make_pq_config = AsyncMock()
 
     context = MockContext(
@@ -4851,6 +4957,7 @@ async def test_pq_modify_auto_delete_and_schedule_mutually_exclusive():
     mock_session_registry.factory_manager = mock_factory_manager
     mock_factory_manager.get = AsyncMock(return_value=mock_factory)
     mock_factory.controller_client = mock_controller
+    mock_factory_manager.get_controller_client = AsyncMock(return_value=mock_controller)
 
     context = MockContext(
         {

--- a/tests/mcp_systems_server/_tools/test_session_enterprise.py
+++ b/tests/mcp_systems_server/_tools/test_session_enterprise.py
@@ -363,6 +363,9 @@ async def test_session_enterprise_delete_removal_missing_in_registry():
     mock_controller.delete_query = AsyncMock()
     mock_factory = MagicMock(controller_client=mock_controller)
     mock_registry.factory_manager.get = AsyncMock(return_value=mock_factory)
+    mock_registry.factory_manager.get_controller_client = AsyncMock(
+        return_value=mock_controller
+    )
 
     context = MockContext(
         {
@@ -399,6 +402,9 @@ async def test_session_enterprise_delete_cleanup_created_sessions_empty():
     mock_controller.delete_query = AsyncMock()
     mock_factory = MagicMock(controller_client=mock_controller)
     mock_registry.factory_manager.get = AsyncMock(return_value=mock_factory)
+    mock_registry.factory_manager.get_controller_client = AsyncMock(
+        return_value=mock_controller
+    )
 
     context = MockContext(
         {
@@ -435,6 +441,9 @@ async def test_session_enterprise_delete_pq_deletion_failure():
     mock_controller.delete_query = AsyncMock(side_effect=Exception("controller down"))
     mock_factory = MagicMock(controller_client=mock_controller)
     mock_registry.factory_manager.get = AsyncMock(return_value=mock_factory)
+    mock_registry.factory_manager.get_controller_client = AsyncMock(
+        return_value=mock_controller
+    )
 
     context = MockContext(
         {
@@ -483,6 +492,9 @@ async def test_session_enterprise_delete_refuses_non_dynamic_session(origin):
     mock_controller.delete_query = AsyncMock()
     mock_factory = MagicMock(controller_client=mock_controller)
     mock_registry.factory_manager.get = AsyncMock(return_value=mock_factory)
+    mock_registry.factory_manager.get_controller_client = AsyncMock(
+        return_value=mock_controller
+    )
 
     context = MockContext(
         {
@@ -529,6 +541,9 @@ async def test_session_enterprise_delete_registry_pop_raises_error():
     mock_controller.delete_query = AsyncMock()
     mock_factory = MagicMock(controller_client=mock_controller)
     mock_registry.factory_manager.get = AsyncMock(return_value=mock_factory)
+    mock_registry.factory_manager.get_controller_client = AsyncMock(
+        return_value=mock_controller
+    )
 
     context = MockContext(
         {
@@ -564,6 +579,9 @@ async def test_session_enterprise_delete_outer_exception_logger_info_raises():
     mock_controller.delete_query = AsyncMock()
     mock_factory = MagicMock(controller_client=mock_controller)
     mock_registry.factory_manager.get = AsyncMock(return_value=mock_factory)
+    mock_registry.factory_manager.get_controller_client = AsyncMock(
+        return_value=mock_controller
+    )
 
     context = MockContext(
         {
@@ -1717,6 +1735,9 @@ async def test_session_enterprise_delete_success():
     mock_controller.delete_query = AsyncMock()
     mock_factory = MagicMock(controller_client=mock_controller)
     mock_registry.factory_manager.get = AsyncMock(return_value=mock_factory)
+    mock_registry.factory_manager.get_controller_client = AsyncMock(
+        return_value=mock_controller
+    )
 
     context = MockContext(
         {
@@ -1876,6 +1897,9 @@ async def test_session_enterprise_delete_close_failure_continues():
     mock_controller.delete_query = AsyncMock()
     mock_factory = MagicMock(controller_client=mock_controller)
     mock_registry.factory_manager.get = AsyncMock(return_value=mock_factory)
+    mock_registry.factory_manager.get_controller_client = AsyncMock(
+        return_value=mock_controller
+    )
 
     context = MockContext(
         {
@@ -2430,6 +2454,9 @@ async def test_session_enterprise_delete_success_v2():
     mock_controller.delete_query = AsyncMock()
     mock_factory = MagicMock(controller_client=mock_controller)
     mock_session_registry.factory_manager.get = AsyncMock(return_value=mock_factory)
+    mock_session_registry.factory_manager.get_controller_client = AsyncMock(
+        return_value=mock_controller
+    )
 
     context = MockContext(
         {

--- a/tests/resource_manager/test__manager.py
+++ b/tests/resource_manager/test__manager.py
@@ -877,6 +877,7 @@ class TestCorePlusSessionFactoryManager:
     async def test_check_liveness(self):
         """Test that _check_liveness correctly calls the item's ping method."""
         mock_factory = AsyncMock(spec=client.CorePlusSessionFactory)
+        mock_factory.controller_client.is_poisoned = False
         manager = CorePlusSessionFactoryManager(
             name="test_factory",
             system_config=_stub_enterprise_config(name="test_factory"),
@@ -900,6 +901,24 @@ class TestCorePlusSessionFactoryManager:
             "Ping returned False",
         )
         mock_factory.ping.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_check_liveness_poisoned_controller(self):
+        """A wedged controller subscription reports OFFLINE without pinging."""
+        mock_factory = AsyncMock(spec=client.CorePlusSessionFactory)
+        mock_factory.controller_client.is_poisoned = True
+        manager = CorePlusSessionFactoryManager(
+            name="test_factory",
+            system_config=_stub_enterprise_config(name="test_factory"),
+            creds=self._make_creds(),
+            timeouts=EnterpriseClientTimeouts(),
+        )
+
+        status, detail = await manager._check_liveness(mock_factory)
+
+        assert status == ResourceLivenessStatus.OFFLINE
+        assert detail is not None and "connection" in detail
+        mock_factory.ping.assert_not_awaited()
 
     @staticmethod
     def _make_factory_with_controller(poisoned: bool):
@@ -985,6 +1004,24 @@ class TestCorePlusSessionFactoryManager:
         assert result is poisoned_controller
         manager.close.assert_awaited_once()
         assert manager.get.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_get_controller_client_reconnects_at_most_once(self):
+        """A second unrecoverable call does not recreate the factory again."""
+        manager = self._make_factory_manager()
+        poisoned_factory, poisoned_controller = self._make_factory_with_controller(
+            poisoned=True
+        )
+        manager.get = AsyncMock(return_value=poisoned_factory)
+        manager.close = AsyncMock()
+
+        first = await manager.get_controller_client()
+        second = await manager.get_controller_client()
+
+        assert first is poisoned_controller
+        assert second is poisoned_controller
+        # Only the first call attempts a reconnect; the second gives up.
+        manager.close.assert_awaited_once()
 
     """Tests for DynamicCommunitySessionManager class."""
 

--- a/tests/resource_manager/test__manager.py
+++ b/tests/resource_manager/test__manager.py
@@ -901,8 +901,91 @@ class TestCorePlusSessionFactoryManager:
         )
         mock_factory.ping.assert_awaited_once()
 
+    @staticmethod
+    def _make_factory_with_controller(poisoned: bool):
+        """Return a mock factory whose controller_client.is_poisoned == poisoned."""
+        controller = MagicMock()
+        controller.is_poisoned = poisoned
+        factory = MagicMock()
+        factory.controller_client = controller
+        return factory, controller
 
-class TestDynamicCommunitySessionManager:
+    def _make_factory_manager(self):
+        return CorePlusSessionFactoryManager(
+            name="test_factory",
+            system_config=_stub_enterprise_config(name="test_factory"),
+            creds=self._make_creds(),
+            timeouts=EnterpriseClientTimeouts(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_controller_client_healthy(self):
+        """A healthy controller is returned without recreating the factory."""
+        manager = self._make_factory_manager()
+        factory, controller = self._make_factory_with_controller(poisoned=False)
+        manager.get = AsyncMock(return_value=factory)
+        manager.close = AsyncMock()
+
+        result = await manager.get_controller_client()
+
+        assert result is controller
+        manager.get.assert_awaited_once()
+        manager.close.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_controller_client_heals_poisoned(self):
+        """A poisoned controller triggers factory recreation and returns the fresh one."""
+        manager = self._make_factory_manager()
+        poisoned_factory, _ = self._make_factory_with_controller(poisoned=True)
+        healthy_factory, healthy_controller = self._make_factory_with_controller(
+            poisoned=False
+        )
+        # First two gets see the poisoned factory; after close(), a fresh one.
+        manager.get = AsyncMock(
+            side_effect=[poisoned_factory, poisoned_factory, healthy_factory]
+        )
+        manager.close = AsyncMock()
+
+        result = await manager.get_controller_client()
+
+        assert result is healthy_controller
+        manager.close.assert_awaited_once()
+        assert manager.get.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_get_controller_client_recheck_finds_healed(self):
+        """A concurrent heal is observed on re-check; no second recreation occurs."""
+        manager = self._make_factory_manager()
+        poisoned_factory, _ = self._make_factory_with_controller(poisoned=True)
+        healthy_factory, healthy_controller = self._make_factory_with_controller(
+            poisoned=False
+        )
+        # Poisoned on first read, healed by the time the heal lock is held.
+        manager.get = AsyncMock(side_effect=[poisoned_factory, healthy_factory])
+        manager.close = AsyncMock()
+
+        result = await manager.get_controller_client()
+
+        assert result is healthy_controller
+        manager.close.assert_not_called()
+        assert manager.get.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_controller_client_still_poisoned_after_recreate(self):
+        """If recreation cannot recover, the poisoned controller is returned as-is."""
+        manager = self._make_factory_manager()
+        poisoned_factory, poisoned_controller = self._make_factory_with_controller(
+            poisoned=True
+        )
+        manager.get = AsyncMock(return_value=poisoned_factory)
+        manager.close = AsyncMock()
+
+        result = await manager.get_controller_client()
+
+        assert result is poisoned_controller
+        manager.close.assert_awaited_once()
+        assert manager.get.await_count == 3
+
     """Tests for DynamicCommunitySessionManager class."""
 
     def test_init_stores_launched_session(self):

--- a/tests/resource_manager/test__registry_enterprise.py
+++ b/tests/resource_manager/test__registry_enterprise.py
@@ -160,7 +160,7 @@ def _make_pq_info(pq_name: str) -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_fetch_factory_pqs_no_cached_client_success():
-    """No cached client → creates new client via factory_manager.get(), calls map()."""
+    """No cached client → creates client via get_controller_client(), calls map()."""
     snapshot = _make_factory_snapshot(client=None)
 
     mock_client = AsyncMock()
@@ -170,9 +170,7 @@ async def test_fetch_factory_pqs_no_cached_client_success():
             "q2": _make_pq_info("pq2"),
         }
     )
-    mock_factory_instance = MagicMock()
-    mock_factory_instance.controller_client = mock_client
-    snapshot.factory_manager.get = AsyncMock(return_value=mock_factory_instance)
+    snapshot.factory_manager.get_controller_client = AsyncMock(return_value=mock_client)
 
     result = await _fetch_factory_pqs(snapshot)
 
@@ -182,9 +180,35 @@ async def test_fetch_factory_pqs_no_cached_client_success():
 
 
 @pytest.mark.asyncio
+async def test_fetch_factory_pqs_poisoned_cached_client_recreates():
+    """Poisoned cached client → discarded and recreated via get_controller_client()."""
+    mock_old_client = AsyncMock()
+    mock_old_client.is_poisoned = True
+
+    mock_new_client = AsyncMock()
+    mock_new_client.is_poisoned = False
+    mock_new_client.map = AsyncMock(return_value={"q1": _make_pq_info("healed-pq")})
+
+    snapshot = _make_factory_snapshot(client=mock_old_client)
+    snapshot.factory_manager.get_controller_client = AsyncMock(
+        return_value=mock_new_client
+    )
+
+    result = await _fetch_factory_pqs(snapshot)
+
+    assert isinstance(result, _FactoryQueryResult)
+    assert result.new_client is mock_new_client
+    assert result.query_map == {"q1": "healed-pq"}
+    # Poisoned client is discarded without pinging.
+    mock_old_client.ping.assert_not_called()
+    snapshot.factory_manager.get_controller_client.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_fetch_factory_pqs_cached_client_ping_ok():
     """Cached client with good ping → reuses client, new_client is NOT set (stays None in result's new_client)."""
     mock_client = AsyncMock()
+    mock_client.is_poisoned = False
     mock_client.ping = AsyncMock(return_value=True)
     mock_client.map = AsyncMock(
         return_value={
@@ -200,14 +224,15 @@ async def test_fetch_factory_pqs_cached_client_ping_ok():
     # When ping ok, we reuse the cached client and return it as new_client
     assert result.new_client is mock_client
     assert result.query_map == {"q1": "mypq"}
-    # factory_manager.get should NOT have been called
-    snapshot.factory_manager.get.assert_not_called()
+    # get_controller_client should NOT have been called
+    snapshot.factory_manager.get_controller_client.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_fetch_factory_pqs_cached_client_ping_returns_false():
-    """Ping returns False → recreates client via factory_manager.get()."""
+    """Ping returns False → recreates client via get_controller_client()."""
     mock_old_client = AsyncMock()
+    mock_old_client.is_poisoned = False
     mock_old_client.ping = AsyncMock(return_value=False)
 
     mock_new_client = AsyncMock()
@@ -216,24 +241,25 @@ async def test_fetch_factory_pqs_cached_client_ping_returns_false():
             "q1": _make_pq_info("fresh-pq"),
         }
     )
-    mock_factory_instance = MagicMock()
-    mock_factory_instance.controller_client = mock_new_client
 
     snapshot = _make_factory_snapshot(client=mock_old_client)
-    snapshot.factory_manager.get = AsyncMock(return_value=mock_factory_instance)
+    snapshot.factory_manager.get_controller_client = AsyncMock(
+        return_value=mock_new_client
+    )
 
     result = await _fetch_factory_pqs(snapshot)
 
     assert isinstance(result, _FactoryQueryResult)
     assert result.new_client is mock_new_client
     assert result.query_map == {"q1": "fresh-pq"}
-    snapshot.factory_manager.get.assert_awaited_once()
+    snapshot.factory_manager.get_controller_client.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_fetch_factory_pqs_cached_client_ping_raises():
     """Ping raises Exception → recreates client."""
     mock_old_client = AsyncMock()
+    mock_old_client.is_poisoned = False
     mock_old_client.ping = AsyncMock(side_effect=ConnectionError("timeout"))
 
     mock_new_client = AsyncMock()
@@ -242,11 +268,11 @@ async def test_fetch_factory_pqs_cached_client_ping_raises():
             "q1": _make_pq_info("recovered-pq"),
         }
     )
-    mock_factory_instance = MagicMock()
-    mock_factory_instance.controller_client = mock_new_client
 
     snapshot = _make_factory_snapshot(client=mock_old_client)
-    snapshot.factory_manager.get = AsyncMock(return_value=mock_factory_instance)
+    snapshot.factory_manager.get_controller_client = AsyncMock(
+        return_value=mock_new_client
+    )
 
     result = await _fetch_factory_pqs(snapshot)
 
@@ -257,9 +283,11 @@ async def test_fetch_factory_pqs_cached_client_ping_raises():
 
 @pytest.mark.asyncio
 async def test_fetch_factory_pqs_no_cached_client_factory_get_raises():
-    """No cached client, factory.get() raises → returns _FactoryQueryError with new_client=None."""
+    """No cached client, get_controller_client() raises → _FactoryQueryError(new_client=None)."""
     snapshot = _make_factory_snapshot(client=None)
-    snapshot.factory_manager.get = AsyncMock(side_effect=RuntimeError("factory down"))
+    snapshot.factory_manager.get_controller_client = AsyncMock(
+        side_effect=RuntimeError("factory down")
+    )
 
     result = await _fetch_factory_pqs(snapshot)
 
@@ -271,34 +299,34 @@ async def test_fetch_factory_pqs_no_cached_client_factory_get_raises():
 
 @pytest.mark.asyncio
 async def test_fetch_factory_pqs_cached_client_ping_fails_recreate_fails():
-    """Ping raises AND factory.get() also raises → _FactoryQueryError(new_client=None)."""
+    """Ping raises AND get_controller_client() also raises → _FactoryQueryError(new_client=None)."""
     mock_old_client = AsyncMock()
+    mock_old_client.is_poisoned = False
     mock_old_client.ping = AsyncMock(side_effect=ConnectionError("dead"))
 
     snapshot = _make_factory_snapshot(client=mock_old_client)
-    snapshot.factory_manager.get = AsyncMock(
+    snapshot.factory_manager.get_controller_client = AsyncMock(
         side_effect=RuntimeError("factory unreachable")
     )
 
     result = await _fetch_factory_pqs(snapshot)
 
     assert isinstance(result, _FactoryQueryError)
-    # new_client is None because factory.get() failed before assignment
+    # new_client is None because get_controller_client() failed before assignment
     assert result.new_client is None
     assert "RuntimeError" in result.error
 
 
 @pytest.mark.asyncio
 async def test_fetch_factory_pqs_map_raises_new_client_created():
-    """No cached client, factory.get() succeeds, but client.map() raises → _FactoryQueryError(new_client=<new>, ...)."""
+    """No cached client, get_controller_client() succeeds, but client.map() raises → _FactoryQueryError(new_client=<new>, ...)."""
     mock_new_client = AsyncMock()
     mock_new_client.map = AsyncMock(side_effect=IOError("map failed"))
 
-    mock_factory_instance = MagicMock()
-    mock_factory_instance.controller_client = mock_new_client
-
     snapshot = _make_factory_snapshot(client=None)
-    snapshot.factory_manager.get = AsyncMock(return_value=mock_factory_instance)
+    snapshot.factory_manager.get_controller_client = AsyncMock(
+        return_value=mock_new_client
+    )
 
     result = await _fetch_factory_pqs(snapshot)
 
@@ -315,6 +343,7 @@ async def test_fetch_factory_pqs_map_raises_using_cached_client():
     new_client stays None because we reused the cached client (no new creation).
     """
     mock_client = AsyncMock()
+    mock_client.is_poisoned = False
     mock_client.ping = AsyncMock(return_value=True)
     mock_client.map = AsyncMock(side_effect=ValueError("bad map"))
 


### PR DESCRIPTION
Adds connection logic so that if the controller is wedged in a `SUBSCRIBING` state, the reconnect fails fast instead of waiting for the timeout every tool call.